### PR TITLE
feat(leads): base top-up disbursement charges on take-home

### DIFF
--- a/app/(application)/leads/new/components/loan-terms-form.tsx
+++ b/app/(application)/leads/new/components/loan-terms-form.tsx
@@ -36,6 +36,11 @@ import { CheckCircle2, AlertCircle } from "lucide-react";
 import { Calendar } from "@/components/ui/calender";
 import { cn } from "@/lib/utils";
 import { useFeatureFlags } from "@/hooks/use-feature-flags";
+import {
+  recomputeTopupAwareDisbursementChargeAmounts,
+  roundMoney,
+  type EditableLoanChargeRow,
+} from "@/lib/topup-charge-base";
 
 // Helper function to format repayment strategy name
 // Replaces "Penalties" with "Interest on Unpaid Balance" for display
@@ -1860,6 +1865,80 @@ export function LoanTermsForm({
     watchedValues.interestCalculationPeriod,
   ]);
 
+  const watchedPrincipal = watchedValues.principal;
+
+  const topupTakeHomePreview = useMemo(() => {
+    if (!isTopup || !loanIdToClose.trim() || !loanTemplate?.clientActiveLoanOptions?.length) {
+      return null;
+    }
+    const match = loanTemplate.clientActiveLoanOptions.find(
+      (l) => String(l.id) === loanIdToClose.trim()
+    );
+    if (!match) return null;
+    const decimals =
+      (loanTemplate as { currency?: { decimalPlaces?: number } } | null)?.currency
+        ?.decimalPlaces ?? 2;
+    const p = Number(watchedPrincipal);
+    if (!Number.isFinite(p) || p <= 0) return null;
+    const takeHome = Math.max(0, p - Number(match.loanBalance));
+    return {
+      takeHome: roundMoney(takeHome, decimals),
+      loanBalance: Number(match.loanBalance),
+    };
+  }, [
+    isTopup,
+    loanIdToClose,
+    watchedPrincipal,
+    loanTemplate?.clientActiveLoanOptions,
+    (loanTemplate as { currency?: { decimalPlaces?: number } } | null)?.currency
+      ?.decimalPlaces,
+  ]);
+
+  // Top-up: disbursement percentage fees use take-home (principal − loan to close), not gross principal.
+  useEffect(() => {
+    if (isInvoiceDiscountingLead) return;
+
+    setEditableCharges((prev) => {
+      if (prev.length === 0) return prev;
+
+      const templatePrincipal =
+        loanTemplate?.principal != null ? Number(loanTemplate.principal) : null;
+      const decimalsRaw = (loanTemplate as { currency?: { decimalPlaces?: number } } | null)
+        ?.currency?.decimalPlaces;
+
+      const next = recomputeTopupAwareDisbursementChargeAmounts(
+        prev as EditableLoanChargeRow[],
+        {
+          principal: watchedPrincipal,
+          isTopup,
+          loanIdToClose,
+          activeLoanOptions: loanTemplate?.clientActiveLoanOptions,
+          templateDefaultPrincipal: templatePrincipal,
+          currencyDecimalPlaces: decimalsRaw ?? 2,
+        }
+      );
+
+      const unchanged =
+        next.length === prev.length &&
+        next.every(
+          (c, i) =>
+            c.amount === prev[i].amount &&
+            c.chargeId === prev[i].chargeId &&
+            c.name === prev[i].name
+        );
+      return unchanged ? prev : (next as typeof prev);
+    });
+  }, [
+    isInvoiceDiscountingLead,
+    watchedPrincipal,
+    isTopup,
+    loanIdToClose,
+    loanTemplate?.principal,
+    loanTemplate?.clientActiveLoanOptions,
+    (loanTemplate as { currency?: { decimalPlaces?: number } } | null)?.currency
+      ?.decimalPlaces,
+  ]);
+
   // Helper function to get section status
   const getSectionStatus = (
     sectionName: keyof typeof sectionCompletion
@@ -3296,6 +3375,26 @@ export function LoanTermsForm({
                       ? "Edit charge amounts only. Adding or removing charges and due dates is fixed for this product."
                       : "Manage loan charges and fees. Add, remove, or edit charges and their due dates."}
                   </CardDescription>
+                  {!isInvoiceDiscountingLead && topupTakeHomePreview && (
+                    <p className="text-sm text-muted-foreground mt-2 rounded-md border border-blue-200 bg-blue-50/80 px-3 py-2 dark:border-blue-900 dark:bg-blue-950/40">
+                      Top-up: percentage disbursement fees use your estimated take-home (
+                      {(loanTemplate as { currency?: { displaySymbol?: string; code?: string } })
+                        ?.currency?.displaySymbol ||
+                        (loanTemplate as { currency?: { code?: string } })?.currency?.code ||
+                        ""}
+                      {topupTakeHomePreview.takeHome.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                      ), not the full new principal. Take-home is new principal minus the selected
+                      loan's balance (
+                      {topupTakeHomePreview.loanBalance.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                      ).
+                    </p>
+                  )}
                 </div>
                 {loanTemplate?.chargeOptions &&
                   canEditLoan &&
@@ -3475,7 +3574,9 @@ export function LoanTermsForm({
                                 calcHighlight.kind === "flat"
                                   ? "Flat fee: amount is a fixed currency value"
                                   : calcHighlight.kind === "percent"
-                                    ? "Percentage: amount is a percent of principal or another base"
+                                    ? topupTakeHomePreview
+                                      ? "Percentage: amount is applied to take-home (net after closing the selected loan)"
+                                      : "Percentage: amount is a percent of principal or another base"
                                     : undefined
                               }
                             >
@@ -3514,7 +3615,9 @@ export function LoanTermsForm({
                               {calcHighlight.kind === "flat" &&
                                 "(fixed currency amount)"}
                               {calcHighlight.kind === "percent" &&
-                                "(% of principal or defined base)"}
+                                (topupTakeHomePreview
+                                  ? "(% of take-home)"
+                                  : "(% of principal or defined base)")}
                               {calcHighlight.kind === "other" && ""}
                             </span>
                           </Label>

--- a/app/(application)/leads/new/components/repayment-schedule-form.tsx
+++ b/app/(application)/leads/new/components/repayment-schedule-form.tsx
@@ -21,6 +21,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { format } from "date-fns";
+import {
+  recomputeTopupAwareDisbursementChargeAmounts,
+  type EditableLoanChargeRow,
+} from "@/lib/topup-charge-base";
 import { Calendar, FileText, Loader2, Plus, Trash2, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -112,15 +116,7 @@ export function RepaymentScheduleForm({
   const [loanTerms, setLoanTerms] = useState<any>(null);
   const [loanDetails, setLoanDetails] = useState<any>(null);
   const [loanTemplate, setLoanTemplate] = useState<any>(null);
-  const [editableCharges, setEditableCharges] = useState<
-    Array<{
-      chargeId: number;
-      name: string;
-      amount: number;
-      dueDate: string;
-      originalCharge?: any;
-    }>
-  >([]);
+  const [editableCharges, setEditableCharges] = useState<EditableLoanChargeRow[]>([]);
   const [showAddCharge, setShowAddCharge] = useState(false);
   const [selectedChargeOption, setSelectedChargeOption] = useState<string>("");
   const [newChargeAmount, setNewChargeAmount] = useState<string>("");
@@ -189,9 +185,20 @@ export function RepaymentScheduleForm({
                   name: charge.name || "Unknown Charge",
                   amount: charge.amount || 0,
                   dueDate: charge.dueDate || disbursementDate,
+                  originalCharge: charge.originalCharge,
                 }),
               );
-              setEditableCharges(savedCharges);
+              setEditableCharges(
+                recomputeTopupAwareDisbursementChargeAmounts(savedCharges, {
+                  principal: termsResult.data.principal,
+                  isTopup: Boolean(termsResult.data.isTopup),
+                  loanIdToClose: termsResult.data.loanIdToClose || "",
+                  activeLoanOptions: templateData?.clientActiveLoanOptions,
+                  templateDefaultPrincipal: templateData?.principal,
+                  currencyDecimalPlaces:
+                    templateData?.currency?.decimalPlaces ?? 2,
+                })
+              );
             } else if (
               templateData?.charges &&
               templateData.charges.length > 0
@@ -206,7 +213,17 @@ export function RepaymentScheduleForm({
                   originalCharge: charge,
                 }),
               );
-              setEditableCharges(initialCharges);
+              setEditableCharges(
+                recomputeTopupAwareDisbursementChargeAmounts(initialCharges, {
+                  principal: termsResult.data.principal,
+                  isTopup: Boolean(termsResult.data.isTopup),
+                  loanIdToClose: termsResult.data.loanIdToClose || "",
+                  activeLoanOptions: templateData?.clientActiveLoanOptions,
+                  templateDefaultPrincipal: templateData?.principal,
+                  currencyDecimalPlaces:
+                    templateData?.currency?.decimalPlaces ?? 2,
+                })
+              );
             }
           }
         }
@@ -272,8 +289,23 @@ export function RepaymentScheduleForm({
           )
         : format(new Date(), "dd MMMM yyyy");
 
-      // Build charges array from editable charges
-      const charges = editableCharges.map((charge) => ({
+      const decimalPlaces =
+        (loanTemplate as { currency?: { decimalPlaces?: number } })?.currency
+          ?.decimalPlaces ?? 2;
+
+      const chargesForSchedule = recomputeTopupAwareDisbursementChargeAmounts(
+        editableCharges,
+        {
+          principal: loanTerms.principal || 0,
+          isTopup: Boolean(loanTerms.isTopup),
+          loanIdToClose: loanTerms.loanIdToClose || "",
+          activeLoanOptions: loanTemplate?.clientActiveLoanOptions,
+          templateDefaultPrincipal: loanTemplate?.principal,
+          currencyDecimalPlaces: decimalPlaces,
+        }
+      );
+
+      const charges = chargesForSchedule.map((charge) => ({
         chargeId: charge.chargeId,
         amount: charge.amount,
         dueDate: charge.dueDate,

--- a/lib/topup-charge-base.ts
+++ b/lib/topup-charge-base.ts
@@ -1,0 +1,161 @@
+/**
+ * Top-up "take home" = new principal minus outstanding on the loan being closed
+ * (net cash to the client). Disbursement % fees should apply to this base, not gross principal.
+ */
+
+type ChargeCalcTypeRef = { id?: number; code?: string; value?: string };
+type ChargeTimeTypeRef = { id?: number; code?: string; value?: string };
+
+export type ActiveLoanOption = { id: number; loanBalance: number };
+
+export type EditableLoanChargeRow = {
+  chargeId: number;
+  name: string;
+  amount: number;
+  dueDate: Date | string;
+  originalCharge?: {
+    chargeTimeType?: ChargeTimeTypeRef;
+    chargeCalculationType?: ChargeCalcTypeRef;
+    percentage?: unknown;
+    amount?: unknown;
+    penalty?: boolean;
+  };
+};
+
+function toNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof (value as { toString?: () => string })?.toString === "function") {
+    const parsed = Number((value as { toString: () => string }).toString());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function roundMoney(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function isLoanDisbursementChargeTime(timeType?: ChargeTimeTypeRef): boolean {
+  const code = (timeType?.code || "").toLowerCase();
+  const value = (timeType?.value || "").trim();
+  if (code.includes("tranche")) return false;
+  return (
+    timeType?.id === 1 ||
+    code === "disbursement" ||
+    code.endsWith(".disbursement") ||
+    /\bdisbursement\b/i.test(value)
+  );
+}
+
+export function isSimplePrincipalPercentCalculation(calc?: ChargeCalcTypeRef): boolean {
+  const code = (calc?.code || "").toLowerCase();
+  if (!code.includes("percent")) return false;
+  if (code.includes("percent.of.amount.and.interest")) return false;
+  if (code.includes("percent.of.interest")) return false;
+  return true;
+}
+
+export function shouldRebaseTopupDisbursementCharge(
+  originalCharge: EditableLoanChargeRow["originalCharge"]
+): boolean {
+  if (!originalCharge) return false;
+  if (originalCharge.penalty) return false;
+  if (!isLoanDisbursementChargeTime(originalCharge.chargeTimeType)) return false;
+  return isSimplePrincipalPercentCalculation(originalCharge.chargeCalculationType);
+}
+
+/**
+ * Take-home principal for disbursement fee base (top-up with loan to close), else full principal.
+ */
+export function computeTopupTakeHomeChargeBase(params: {
+  principal: number;
+  isTopup: boolean;
+  loanIdToClose: string;
+  activeLoanOptions: ActiveLoanOption[] | null | undefined;
+}): number {
+  const principal = toNumber(params.principal);
+  if (principal == null || principal <= 0) return 0;
+  if (!params.isTopup) return principal;
+  const idStr = (params.loanIdToClose || "").trim();
+  if (!idStr) return principal;
+  const match = (params.activeLoanOptions || []).find(
+    (o) => String(o.id) === idStr
+  );
+  const bal = toNumber(match?.loanBalance);
+  if (bal == null || bal < 0) return principal;
+  return Math.max(0, roundMoney(principal - bal, 6));
+}
+
+function extractPercentRateFromCharge(
+  originalCharge: EditableLoanChargeRow["originalCharge"],
+  referencePrincipalForRatio: number,
+  currentAmount: number
+): number | null {
+  if (!originalCharge) return null;
+  const fromField = toNumber(originalCharge.percentage);
+  if (fromField != null && fromField > 0) {
+    return fromField;
+  }
+  if (
+    referencePrincipalForRatio > 0 &&
+    Number.isFinite(currentAmount) &&
+    currentAmount >= 0
+  ) {
+    return (currentAmount / referencePrincipalForRatio) * 100;
+  }
+  return null;
+}
+
+export function recomputeTopupAwareDisbursementChargeAmounts(
+  charges: EditableLoanChargeRow[],
+  params: {
+    principal: number;
+    isTopup: boolean;
+    loanIdToClose: string;
+    activeLoanOptions: ActiveLoanOption[] | null | undefined;
+    templateDefaultPrincipal: number | null | undefined;
+    currencyDecimalPlaces: number;
+  }
+): EditableLoanChargeRow[] {
+  const decimals =
+    toNumber(params.currencyDecimalPlaces) != null &&
+    Number.isFinite(Number(params.currencyDecimalPlaces))
+      ? Math.max(0, Math.min(8, Math.floor(Number(params.currencyDecimalPlaces))))
+      : 2;
+
+  const base = computeTopupTakeHomeChargeBase({
+    principal: params.principal,
+    isTopup: params.isTopup,
+    loanIdToClose: params.loanIdToClose,
+    activeLoanOptions: params.activeLoanOptions,
+  });
+
+  const refPrincipal =
+    toNumber(params.templateDefaultPrincipal) && Number(params.templateDefaultPrincipal) > 0
+      ? Number(params.templateDefaultPrincipal)
+      : params.principal;
+
+  return charges.map((charge) => {
+    const oc = charge.originalCharge;
+    if (!shouldRebaseTopupDisbursementCharge(oc) || !oc) {
+      return charge;
+    }
+    const rate = extractPercentRateFromCharge(oc, refPrincipal, charge.amount);
+    if (rate == null) {
+      return charge;
+    }
+    const next = roundMoney((rate / 100) * base, decimals);
+    if (next === charge.amount) {
+      return charge;
+    }
+    return { ...charge, amount: next };
+  });
+}

--- a/lib/topup-disbursement-charge-service.ts
+++ b/lib/topup-disbursement-charge-service.ts
@@ -18,10 +18,12 @@ interface ApplyTopupDisbursementChargesResult {
 interface FineractTopupDetails {
   topupAmount?: unknown;
   loanBalance?: unknown;
+  loanIdToClose?: unknown;
 }
 
 interface FineractLoanSnapshot {
   isTopup?: boolean;
+  closureLoanId?: unknown;
   topupDetails?: FineractTopupDetails;
   loanBalance?: unknown;
   principal?: unknown;
@@ -140,6 +142,48 @@ function extractChargeList(payload: unknown): FineractLoanChargeSummary[] {
   return [];
 }
 
+async function resolveOutstandingOnLoanBeingClosed(
+  loan: FineractLoanSnapshot
+): Promise<number | null> {
+  const closureLoanId =
+    toNumber((loan as { closureLoanId?: unknown }).closureLoanId) ??
+    toNumber(loan?.topupDetails?.loanIdToClose);
+
+  if (closureLoanId != null && closureLoanId > 0) {
+    try {
+      const closureLoan = (await fetchFineractAPI(
+        `/loans/${closureLoanId}?associations=summary&exclude=guarantors,futureSchedule`,
+        { method: "GET" }
+      )) as Record<string, unknown>;
+
+      const summary = closureLoan.summary as Record<string, unknown> | undefined;
+      const fromSummary = pickFirstPositive(
+        summary?.totalOutstanding,
+        summary?.principalOutstanding
+      );
+      if (fromSummary != null) {
+        return fromSummary;
+      }
+
+      const fromLoan = pickFirstPositive(closureLoan.loanBalance);
+      if (fromLoan != null) {
+        return fromLoan;
+      }
+    } catch (error) {
+      console.warn("[TopupDisbursementCharges] Failed to fetch closure loan balance", {
+        closureLoanId,
+        error,
+      });
+    }
+  }
+
+  return pickFirstPositive(
+    loan?.topupDetails?.loanBalance,
+    loan?.topupDetails?.topupAmount,
+    loan?.loanBalance
+  );
+}
+
 function hasExistingChargeForToday(
   existingCharges: FineractLoanChargeSummary[],
   chargeId: number,
@@ -193,11 +237,7 @@ export async function applyTopupDisbursementCharges(
     };
   }
 
-  const previousLoanBalance = pickFirstPositive(
-    loan?.topupDetails?.topupAmount,
-    loan?.topupDetails?.loanBalance,
-    loan?.loanBalance
-  );
+  const previousLoanBalance = await resolveOutstandingOnLoanBeingClosed(loan);
 
   const principal = pickFirstPositive(
     loan?.principal,


### PR DESCRIPTION
Recompute disbursement percentage charge amounts on new principal minus the loan being closed, on loan terms and repayment schedule flows.

Resolve closure loan outstanding from Fineract summary when applying post-disbursement top-up charges. Add shared topup-charge-base helper and brief UI copy for take-home on the terms and charges tab.