### PR TITLE
fix(ci): push prod gitops updates to prod branch and use GHCR registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
         fi
         
-        yq eval ".image.repository = \"harbor.kenac.co.zw/kenac/loan-matrix\"" -i "$VALUES_FILE"
+        yq eval ".image.repository = \"ghcr.io/kenac-innovations/loan-matrix\"" -i "$VALUES_FILE"
         yq eval ".image.tag = \"$NEW_TAG\"" -i "$VALUES_FILE"
         
         echo "Updated values file:"
@@ -177,7 +177,11 @@ jobs:
         - Branch: ${{ github.ref_name }}
         - Workflow: ${{ github.workflow }}"
         
-        git push origin master
+        if [[ "$ENV" == "prod" ]]; then
+          git push origin prod
+        else
+          git push origin master
+        fi
 
     - name: Deployment summary
       if: github.event_name == 'push'


### PR DESCRIPTION
- On prod environment, push gitops tag update to kenac-gitops prod branch
- Switch image repository yq update to ghcr.io/kenac-innovations/loan-matrix