### PR TITLE
fix(ci): use HEAD:prod refspec to push to gitops prod branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
         - Workflow: ${{ github.workflow }}"
         
         if [[ "$ENV" == "prod" ]]; then
-          git push origin prod
+          git push origin HEAD:prod
         else
           git push origin master
         fi


### PR DESCRIPTION
CI checks out gitops on master so there is no local prod branch. Using HEAD:prod pushes the committed changes to the remote prod branch.