### PR TITLE
feat: Revolving Credit Facility (RCF) end-to-end

### DIFF
--- a/app/(application)/leads/new/rcf/components/rcf-contracts.tsx
+++ b/app/(application)/leads/new/rcf/components/rcf-contracts.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { FileText, ExternalLink, Loader2, CheckCircle2 } from "lucide-react";
+import { AlertCircle, Loader2 } from "lucide-react";
 import { submitRcfApplication } from "@/app/actions/rcf-actions";
 
 interface RcfContractsProps {
@@ -19,90 +12,97 @@ interface RcfContractsProps {
 }
 
 export function RcfContracts({ leadId, onComplete, onBack }: RcfContractsProps) {
-  const [previewing, setPreviewing] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isIframeLoading, setIsIframeLoading] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const [acknowledged, setAcknowledged] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const handlePreview = async () => {
+  const contractUrl = useMemo(
+    () => (leadId ? `/api/leads/${leadId}/print-rcf-contract?action=view` : null),
+    [leadId]
+  );
+
+  useEffect(() => {
     if (!leadId) return;
-    setPreviewing(true);
-    setPreviewError(null);
-    try {
-      const res = await fetch(
-        `/api/leads/${leadId}/print-rcf-contract?action=view&validate=true`,
-        { cache: "no-store" }
-      );
-      const payload = await res.json().catch(() => null);
-      if (!res.ok || !payload?.success) {
-        setPreviewError(payload?.error || "Unable to generate the RCF agreement.");
-        return;
+    let cancelled = false;
+
+    const validate = async () => {
+      setIsValidating(true);
+      setValidationError(null);
+      try {
+        const res = await fetch(
+          `/api/leads/${leadId}/print-rcf-contract?action=view&validate=true`,
+          { cache: "no-store" }
+        );
+        const payload = await res.json().catch(() => null);
+        if (cancelled) return;
+        if (!res.ok || !payload?.success) {
+          setValidationError(payload?.error || "Unable to generate the RCF agreement.");
+          return;
+        }
+        setIsIframeLoading(true);
+      } catch {
+        if (!cancelled) setValidationError("Unable to generate the RCF agreement.");
+      } finally {
+        if (!cancelled) setIsValidating(false);
       }
-      window.open(`/api/leads/${leadId}/print-rcf-contract?action=view`, "_blank");
-      setAcknowledged(true);
-    } catch {
-      setPreviewError("Unable to open the RCF agreement. Please try again.");
-    } finally {
-      setPreviewing(false);
-    }
-  };
+    };
+
+    validate();
+    return () => { cancelled = true; };
+  }, [leadId]);
 
   if (!leadId) {
     return (
       <div className="text-center py-8">
-        <p className="text-muted-foreground mb-4">
-          Please complete client registration first.
-        </p>
+        <p className="text-muted-foreground mb-4">Please complete client registration first.</p>
         <Button onClick={onBack}>Go Back</Button>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <FileText className="h-4 w-4" />
-            Revolving Credit Facility Agreement
-          </CardTitle>
-          <CardDescription>
-            Review the facility agreement before submitting the application.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            The agreement will be generated using the facility terms you configured.
-            Open it to review, print, or download as PDF.
-          </p>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handlePreview}
-            disabled={previewing}
-            className="gap-2"
-          >
-            {previewing ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <ExternalLink className="h-4 w-4" />
-            )}
-            {previewing ? "Opening..." : "Open RCF Agreement"}
-          </Button>
-
-          {previewError && (
-            <p className="text-sm text-red-500">{previewError}</p>
-          )}
-
-          {acknowledged && (
-            <div className="flex items-center gap-2 text-sm text-green-600">
-              <CheckCircle2 className="h-4 w-4" />
-              Agreement opened — collect signatures and proceed.
+    <div className="space-y-4">
+      {/* Inline contract viewer */}
+      <div className="relative rounded-xl border bg-background shadow-sm overflow-hidden" style={{ height: "70vh" }}>
+        {(isValidating || isIframeLoading) && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/95">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+              <div>
+                <p className="font-medium">Loading agreement...</p>
+                <p className="text-sm text-muted-foreground">Preparing the latest facility data.</p>
+              </div>
             </div>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+
+        {validationError && (
+          <div className="absolute inset-0 flex items-center justify-center p-8">
+            <div className="max-w-sm text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+                <AlertCircle className="h-6 w-6 text-red-600" />
+              </div>
+              <h2 className="text-base font-semibold">Agreement unavailable</h2>
+              <p className="mt-1 text-sm text-muted-foreground">{validationError}</p>
+            </div>
+          </div>
+        )}
+
+        {!isValidating && !validationError && contractUrl && (
+          <iframe
+            src={contractUrl}
+            title="RCF Agreement"
+            className="h-full w-full border-0"
+            onLoad={() => setIsIframeLoading(false)}
+          />
+        )}
+      </div>
+
+      {submitError && (
+        <p className="text-sm text-red-500">{submitError}</p>
+      )}
 
       <div className="flex items-center justify-between pt-2 border-t">
         <Button type="button" variant="outline" onClick={onBack} disabled={submitting}>
@@ -114,16 +114,16 @@ export function RcfContracts({ leadId, onComplete, onBack }: RcfContractsProps) 
           onClick={async () => {
             if (!leadId) return;
             setSubmitting(true);
-            setPreviewError(null);
+            setSubmitError(null);
             try {
               const result = await submitRcfApplication(leadId);
               if (!result.success) {
-                setPreviewError(result.error || "Submission failed. Please try again.");
+                setSubmitError(result.error || "Submission failed. Please try again.");
                 return;
               }
               await onComplete();
             } catch {
-              setPreviewError("Submission failed. Please try again.");
+              setSubmitError("Submission failed. Please try again.");
             } finally {
               setSubmitting(false);
             }

--- a/app/(application)/leads/new/rcf/components/rcf-facility-terms-form.tsx
+++ b/app/(application)/leads/new/rcf/components/rcf-facility-terms-form.tsx
@@ -197,7 +197,6 @@ export function RcfFacilityTermsForm({
           {errors.savingsProductId && (
             <p className="text-xs text-red-500">{errors.savingsProductId.message}</p>
           )}
-          <p className="text-xs text-muted-foreground">Fineract savings product backing this facility</p>
         </div>
 
         {/* Credit Limit */}

--- a/app/api/leads/[id]/facility/repayment/route.ts
+++ b/app/api/leads/[id]/facility/repayment/route.ts
@@ -48,15 +48,6 @@ export async function POST(
       );
     }
 
-    // Guard: can't repay more than has been utilized (available = creditLimit - utilized)
-    const utilizedAmount = facility.creditLimit - facility.availableBalance;
-    if (amount > utilizedAmount) {
-      return NextResponse.json(
-        { error: `Repayment amount exceeds utilized balance of ${utilizedAmount}` },
-        { status: 400 }
-      );
-    }
-
     const dateStr = transactionDate
       ? formatFineractDate(new Date(transactionDate))
       : formatFineractDate(new Date());


### PR DESCRIPTION
## Summary

- **RCF lead wizard**: multi-step create form (Client → Affordability → Facility Terms → Contracts) with draft restore via `?id=` param
- **Facility Terms**: savings product, credit limit, interest rate, tenor, max drawdowns — activation date auto-set to today
- **Workflow integration**: submission creates Fineract savings account; approval approves + activates it (no disbursement stages)
- **Lead page**: facility type badge, Approved badge for activated RCF leads, RCF Details button, Move Stage hidden once approved
- **Savings account detail page**: inline drawdown/repayment modals, stat cards (Credit Limit, Outstanding Balance + interest accrued, Utilized, Available, Drawdowns), Mifos-style Details tab, Fineract transaction history
- **Overdraft balance model**: `available = creditLimit − (totalWithdrawals − totalDeposits)`, interest accrued shown as always-positive; repayment amount unrestricted
- **Contract tab**: RCF agreement rendered inline (iframe) in the Contracts wizard step
- **Draft routing**: RCF drafts open `/leads/new/rcf`, term loan drafts open `/leads/new/loan`; product selection page at `/leads/new` when RCF feature flag is enabled
- **DB migrations**: `RevolvingCreditFacility`, `RevolvingCreditDrawdown`, `RevolvingCreditRepayment` tables + `REVOLVING_CREDIT` enum value applied to `loan_matrix_uat`

## Test plan

- [ ] Create a new RCF lead — wizard steps complete in order, draft restores from URL
- [ ] Facility terms save correctly (product, credit limit, interest rate, tenor, max drawdowns)
- [ ] Approve RCF lead — savings account approved + activated in Fineract, `RevolvingCreditFacility` record created
- [ ] Lead page shows Approved badge and RCF Details button; Move Stage hidden
- [ ] Savings detail page: stat cards show correct values for fresh account (utilized = 0, available = credit limit)
- [ ] Record drawdown — balance updates correctly (overdraft model)
- [ ] Record repayment — any amount accepted, balance restores
- [ ] Outstanding Balance card shows principal + interest accrued (always positive)
- [ ] Contract tab renders agreement inline without navigating away
- [ ] Clicking RCF draft in leads table opens `/leads/new/rcf?id=...` and restores state

🤖 Generated with [Claude Code](https://claude.com/claude-code)