### PR TITLE
feat: source teller vault balance from Fineract GL (branch cash)

### DIFF
--- a/app/(application)/tellers/[id]/components/teller-actions.tsx
+++ b/app/(application)/tellers/[id]/components/teller-actions.tsx
@@ -18,6 +18,9 @@ interface TellerActionsProps {
     startDate: string | Date | number[];
     endDate?: string | Date | number[] | null;
     status: string;
+    glAccountId?: number | null;
+    glAccountName?: string | null;
+    glAccountCode?: string | null;
   };
 }
 

--- a/app/(application)/tellers/[id]/page.tsx
+++ b/app/(application)/tellers/[id]/page.tsx
@@ -92,6 +92,17 @@ export default async function TellerDetailPage({
                 )}
               </div>
             )}
+            {teller.vaultBalanceSource === "fineract_gl" && teller.glAccountCode && (
+              <div className="text-xs text-green-700 dark:text-green-400 mt-1">
+                Sourced from GL {teller.glAccountCode}
+                {teller.glAccountName ? ` (${teller.glAccountName})` : ""}
+              </div>
+            )}
+            {teller.vaultBalanceSource === "local_fallback" && (
+              <div className="text-xs text-amber-600 mt-1">
+                Could not reach Fineract GL — showing local ledger as fallback.
+              </div>
+            )}
           </CardContent>
         </Card>
 
@@ -174,6 +185,23 @@ export default async function TellerDetailPage({
               <div>
                 <div className="text-sm text-muted-foreground">Status</div>
                 <div>{getStatusBadge(teller.status)}</div>
+              </div>
+              <div>
+                <div className="text-sm text-muted-foreground">
+                  Branch Cash GL Account
+                </div>
+                <div className="font-medium">
+                  {teller.glAccountId && teller.glAccountCode ? (
+                    <span>
+                      {teller.glAccountCode}
+                      {teller.glAccountName ? ` — ${teller.glAccountName}` : ""}
+                    </span>
+                  ) : (
+                    <span className="text-amber-600 text-sm">
+                      Not configured — vault balance falls back to local ledger
+                    </span>
+                  )}
+                </div>
               </div>
               {teller.endDate && (
                 <div>

--- a/app/(application)/tellers/components/edit-teller-modal.tsx
+++ b/app/(application)/tellers/components/edit-teller-modal.tsx
@@ -28,12 +28,22 @@ interface EditTellerModalProps {
     startDate: string | Date | number[];
     endDate?: string | Date | number[] | null;
     status: string;
+    glAccountId?: number | null;
+    glAccountName?: string | null;
+    glAccountCode?: string | null;
   };
 }
 
 interface Office {
   id: number;
   name: string;
+}
+
+interface GLAccount {
+  id: number;
+  name: string;
+  glCode: string;
+  type: { value: string };
 }
 
 export function EditTellerModal({
@@ -45,7 +55,9 @@ export function EditTellerModal({
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [offices, setOffices] = useState<Office[]>([]);
+  const [glAccounts, setGlAccounts] = useState<GLAccount[]>([]);
   const [loadingOffices, setLoadingOffices] = useState(false);
+  const [loadingGlAccounts, setLoadingGlAccounts] = useState(false);
   const [formData, setFormData] = useState({
     name: "",
     description: "",
@@ -53,11 +65,13 @@ export function EditTellerModal({
     startDate: "",
     endDate: "",
     status: "ACTIVE",
+    glAccountId: "",
   });
 
   useEffect(() => {
     if (open) {
       fetchOffices();
+      fetchGlAccounts();
       // Parse dates from teller
       const parseDate = (date: string | Date | number[] | null | undefined): string => {
         if (!date) return "";
@@ -77,6 +91,7 @@ export function EditTellerModal({
         startDate: parseDate(teller.startDate),
         endDate: parseDate(teller.endDate),
         status: teller.status || "ACTIVE",
+        glAccountId: teller.glAccountId?.toString() || "",
       });
     }
   }, [open, teller]);
@@ -96,9 +111,30 @@ export function EditTellerModal({
     }
   };
 
+  const fetchGlAccounts = async () => {
+    setLoadingGlAccounts(true);
+    try {
+      const response = await fetch(
+        "/api/fineract/glaccounts/detail?usage=1&disabled=false&manualEntriesAllowed=true"
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setGlAccounts(data || []);
+      }
+    } catch (error) {
+      console.error("Error fetching GL accounts:", error);
+    } finally {
+      setLoadingGlAccounts(false);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+
+    const selectedGlAccount = formData.glAccountId
+      ? glAccounts.find((gl) => gl.id === parseInt(formData.glAccountId))
+      : null;
 
     try {
       const response = await fetch(`/api/tellers/${tellerId}`, {
@@ -109,6 +145,9 @@ export function EditTellerModal({
           description: formData.description,
           endDate: formData.endDate || null,
           status: formData.status,
+          glAccountId: selectedGlAccount?.id ?? null,
+          glAccountName: selectedGlAccount?.name ?? null,
+          glAccountCode: selectedGlAccount?.glCode ?? null,
         }),
       });
 
@@ -164,6 +203,34 @@ export function EditTellerModal({
                 placeholder="Teller description (optional)..."
                 rows={3}
               />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="glAccountId">Branch Cash GL Account</Label>
+              <SearchableSelect
+                options={[
+                  { value: "", label: "None" },
+                  ...glAccounts.map((gl) => ({
+                    value: gl.id.toString(),
+                    label: `${gl.glCode} - ${gl.name}`,
+                  })),
+                ]}
+                value={formData.glAccountId}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, glAccountId: value })
+                }
+                placeholder={
+                  loadingGlAccounts
+                    ? "Loading GL accounts..."
+                    : "Select GL account"
+                }
+                emptyMessage="No GL accounts found"
+                disabled={loadingGlAccounts}
+              />
+              <p className="text-xs text-muted-foreground">
+                When set, the teller&apos;s vault balance is read from this Fineract
+                GL account and allocations create journal entries.
+              </p>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">

--- a/app/(application)/tellers/new/page.tsx
+++ b/app/(application)/tellers/new/page.tsx
@@ -28,18 +28,28 @@ interface Bank {
   code: string;
 }
 
+interface GLAccount {
+  id: number;
+  name: string;
+  glCode: string;
+  type: { value: string };
+}
+
 export default function NewTellerPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [offices, setOffices] = useState<Office[]>([]);
   const [banks, setBanks] = useState<Bank[]>([]);
+  const [glAccounts, setGlAccounts] = useState<GLAccount[]>([]);
   const [loadingOffices, setLoadingOffices] = useState(true);
   const [loadingBanks, setLoadingBanks] = useState(true);
+  const [loadingGlAccounts, setLoadingGlAccounts] = useState(true);
   const [formData, setFormData] = useState({
     name: "",
     description: "",
     officeId: "",
     bankId: "",
+    glAccountId: "",
     startDate: new Date().toISOString().split("T")[0],
     endDate: "",
   });
@@ -47,6 +57,7 @@ export default function NewTellerPage() {
   useEffect(() => {
     fetchOffices();
     fetchBanks();
+    fetchGlAccounts();
   }, []);
 
   const fetchOffices = async () => {
@@ -77,9 +88,29 @@ export default function NewTellerPage() {
     }
   };
 
+  const fetchGlAccounts = async () => {
+    try {
+      const response = await fetch(
+        "/api/fineract/glaccounts/detail?usage=1&disabled=false&manualEntriesAllowed=true"
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setGlAccounts(data || []);
+      }
+    } catch (error) {
+      console.error("Error fetching GL accounts:", error);
+    } finally {
+      setLoadingGlAccounts(false);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+
+    const selectedGlAccount = formData.glAccountId
+      ? glAccounts.find((gl) => gl.id === parseInt(formData.glAccountId))
+      : null;
 
     try {
       const response = await fetch("/api/tellers", {
@@ -91,6 +122,9 @@ export default function NewTellerPage() {
           officeName: offices.find((o) => o.id === parseInt(formData.officeId))
             ?.name,
           bankId: formData.bankId || null,
+          glAccountId: selectedGlAccount?.id || null,
+          glAccountName: selectedGlAccount?.name || null,
+          glAccountCode: selectedGlAccount?.glCode || null,
         }),
       });
 
@@ -203,6 +237,34 @@ export default function NewTellerPage() {
               <p className="text-xs text-muted-foreground">
                 Link this teller to a bank to manage fund allocation hierarchy.
                 Teller allocations will be limited by the bank's available balance.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="glAccountId">
+                Branch Cash GL Account (Optional)
+              </Label>
+              <SearchableSelect
+                options={glAccounts.map((gl) => ({
+                  value: gl.id.toString(),
+                  label: `${gl.glCode} - ${gl.name}`,
+                }))}
+                value={formData.glAccountId}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, glAccountId: value })
+                }
+                placeholder={
+                  loadingGlAccounts
+                    ? "Loading GL accounts..."
+                    : "Search and select GL account"
+                }
+                emptyMessage="No GL accounts found"
+                disabled={loadingGlAccounts}
+              />
+              <p className="text-xs text-muted-foreground">
+                Link this teller to a Fineract GL account (branch cash). When set,
+                the teller&apos;s vault balance is read from this account&apos;s
+                journal entries, and allocations are posted as journal entries.
               </p>
             </div>
 

--- a/app/actions/teller-actions.ts
+++ b/app/actions/teller-actions.ts
@@ -5,6 +5,7 @@ import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 import { unstable_noStore as noStore } from "next/cache";
 
 const db = prisma as PrismaClient;
@@ -77,6 +78,16 @@ export async function getTellerFromFineract(id: string) {
     const orgCurrency = await getOrgDefaultCurrencyCode();
     let currency = orgCurrency;
     let recentSettlements: any[] = [];
+    let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
+    let glAccountInfo: {
+      glAccountId: number | null;
+      glAccountName: string | null;
+      glAccountCode: string | null;
+    } = {
+      glAccountId: null,
+      glAccountName: null,
+      glAccountCode: null,
+    };
 
     try {
       const tenant = await getTenantFromHeaders();
@@ -104,11 +115,33 @@ export async function getTellerFromFineract(id: string) {
         });
 
         if (dbTeller) {
-          vaultBalance = dbTeller.cashAllocations.reduce(
+          glAccountInfo = {
+            glAccountId: dbTeller.glAccountId,
+            glAccountName: dbTeller.glAccountName,
+            glAccountCode: dbTeller.glAccountCode,
+          };
+
+          const localVaultBalance = dbTeller.cashAllocations.reduce(
             (sum: number, alloc: { amount: number }) => sum + alloc.amount,
             0
           );
+          vaultBalance = localVaultBalance;
           currency = dbTeller.cashAllocations[0]?.currency || orgCurrency;
+
+          // Prefer Fineract GL balance when a GL account is linked.
+          if (dbTeller.glAccountId) {
+            const glResult = await getGlAccountBalance(dbTeller.glAccountId);
+            if (
+              glResult.source === "fineract_calculated" ||
+              glResult.source === "fineract_empty"
+            ) {
+              vaultBalance = glResult.balance;
+              vaultBalanceSource = "fineract_gl";
+              currency = glResult.currency || currency;
+            } else {
+              vaultBalanceSource = "local_fallback";
+            }
+          }
 
           const cashierAllocations = await db.cashAllocation.findMany({
             where: {
@@ -162,8 +195,8 @@ export async function getTellerFromFineract(id: string) {
       console.error("Error fetching local database data:", dbError);
     }
 
-    return { 
-      success: true, 
+    return {
+      success: true,
       data: {
         id: teller.id,
         name: teller.name,
@@ -176,11 +209,13 @@ export async function getTellerFromFineract(id: string) {
         cashiers: cashiers || [],
         activeCashiers: (cashiers || []).filter((c: any) => c.isFullDay || c.startTime).length,
         summary: summary,
-        // Local database balance data
+        // Balance data (GL when configured, local fallback otherwise)
         vaultBalance,
+        vaultBalanceSource,
         availableBalance,
         allocatedToCashiers,
         currency,
+        ...glAccountInfo,
         currentAllocation: {
           amount: availableBalance,
           currency,

--- a/app/api/banks/[id]/route.ts
+++ b/app/api/banks/[id]/route.ts
@@ -4,6 +4,7 @@ import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { fetchFineractAPI } from "@/lib/api";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 
 /**
  * GET /api/banks/[id]
@@ -63,29 +64,54 @@ export async function GET(
     };
 
     let allocatedToTellers = 0;
-    const tellersWithBalances = bank.tellers.map((teller) => {
-      // Total vault balance includes all allocations (for teller display)
-      const tellerVaultBalance = teller.cashAllocations.reduce(
-        (sum, alloc) => sum + alloc.amount,
-        0
-      );
+    const tellersWithBalances = await Promise.all(
+      bank.tellers.map(async (teller) => {
+        // Local vault balance from CashAllocation ledger (used as fallback)
+        const localTellerVaultBalance = teller.cashAllocations.reduce(
+          (sum, alloc) => sum + alloc.amount,
+          0
+        );
 
-      const bankAllocationsOnly = teller.cashAllocations
-        .filter(isFromBank)
-        .reduce((sum, alloc) => sum + alloc.amount, 0);
+        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
+        let tellerVaultBalance = localTellerVaultBalance;
+        let tellerVaultBalanceSource:
+          | "fineract_gl"
+          | "local"
+          | "local_fallback" = "local";
+        if (teller.glAccountId) {
+          const glResult = await getGlAccountBalance(teller.glAccountId);
+          if (
+            glResult.source === "fineract_calculated" ||
+            glResult.source === "fineract_empty"
+          ) {
+            tellerVaultBalance = glResult.balance;
+            tellerVaultBalanceSource = "fineract_gl";
+          } else {
+            tellerVaultBalanceSource = "local_fallback";
+          }
+        }
 
-      allocatedToTellers += bankAllocationsOnly;
+        const bankAllocationsOnly = teller.cashAllocations
+          .filter(isFromBank)
+          .reduce((sum, alloc) => sum + alloc.amount, 0);
 
-      return {
-        id: teller.id,
-        name: teller.name,
-        fineractTellerId: teller.fineractTellerId,
-        officeName: teller.officeName,
-        status: teller.status,
-        vaultBalance: tellerVaultBalance,
-        activeCashiers: teller.cashiers.length,
-      };
-    });
+        allocatedToTellers += bankAllocationsOnly;
+
+        return {
+          id: teller.id,
+          name: teller.name,
+          fineractTellerId: teller.fineractTellerId,
+          officeName: teller.officeName,
+          status: teller.status,
+          glAccountId: teller.glAccountId,
+          glAccountName: teller.glAccountName,
+          glAccountCode: teller.glAccountCode,
+          vaultBalance: tellerVaultBalance,
+          vaultBalanceSource: tellerVaultBalanceSource,
+          activeCashiers: teller.cashiers.length,
+        };
+      })
+    );
 
     // Get bank balance from Fineract GL account if configured, otherwise use local allocations
     let totalAllocated = 0;

--- a/app/api/banks/[id]/tellers/route.ts
+++ b/app/api/banks/[id]/tellers/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 
 /**
  * GET /api/banks/[id]/tellers
@@ -59,10 +60,28 @@ export async function GET(
     // Calculate balances for each teller
     const tellersWithBalances = await Promise.all(
       tellers.map(async (teller) => {
-        const vaultBalance = teller.cashAllocations.reduce(
+        const localVaultBalance = teller.cashAllocations.reduce(
           (sum, alloc) => sum + alloc.amount,
           0
         );
+
+        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
+        let vaultBalance = localVaultBalance;
+        let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
+        let glCurrency: string | null = null;
+        if (teller.glAccountId) {
+          const glResult = await getGlAccountBalance(teller.glAccountId);
+          if (
+            glResult.source === "fineract_calculated" ||
+            glResult.source === "fineract_empty"
+          ) {
+            vaultBalance = glResult.balance;
+            vaultBalanceSource = "fineract_gl";
+            glCurrency = glResult.currency;
+          } else {
+            vaultBalanceSource = "local_fallback";
+          }
+        }
 
         // Get allocations to cashiers
         const cashierAllocations = await prisma.cashAllocation.findMany({
@@ -82,7 +101,8 @@ export async function GET(
         );
 
         const availableBalance = vaultBalance - allocatedToCashiers;
-        const currency = teller.cashAllocations[0]?.currency || orgCurrency;
+        const currency =
+          glCurrency || teller.cashAllocations[0]?.currency || orgCurrency;
 
         return {
           id: teller.id,
@@ -94,7 +114,11 @@ export async function GET(
           status: teller.status,
           startDate: teller.startDate,
           endDate: teller.endDate,
+          glAccountId: teller.glAccountId,
+          glAccountName: teller.glAccountName,
+          glAccountCode: teller.glAccountCode,
           vaultBalance,
+          vaultBalanceSource,
           availableBalance,
           allocatedToCashiers,
           currency,

--- a/app/api/tellers/[id]/allocate/route.ts
+++ b/app/api/tellers/[id]/allocate/route.ts
@@ -170,26 +170,87 @@ export async function POST(
       }
     }
 
-    // Create allocation record in database only (no Fineract call)
-    // This is a local-only operation for teller-level tracking (vault)
-    // cashierId is null for teller vault allocations
+    // If the teller has a GL account, also post a journal entry in Fineract so the
+    // GL-sourced vault balance reflects this allocation (debit teller GL, credit bank GL).
+    // Falls back gracefully when the bank does not have a GL configured.
+    let journalTransactionId: string | null = null;
+    if (teller.glAccountId && teller.bankId && teller.bank?.glAccountId) {
+      try {
+        const today = new Date();
+        const monthNames = [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+        ];
+        const fineractDate = `${today
+          .getDate()
+          .toString()
+          .padStart(2, "0")} ${monthNames[today.getMonth()]} ${today.getFullYear()}`;
+
+        const journalResult = await fetchFineractAPI("/journalentries", {
+          method: "POST",
+          body: JSON.stringify({
+            officeId: teller.officeId,
+            transactionDate: fineractDate,
+            currencyCode: allocationCurrency,
+            debits: [
+              { glAccountId: teller.glAccountId, amount: requestedAmount },
+            ],
+            credits: [
+              { glAccountId: teller.bank.glAccountId, amount: requestedAmount },
+            ],
+            comments:
+              `Allocate to teller ${teller.name} from bank ${teller.bank.name}${
+                notes ? ` - ${notes}` : ""
+              }`.trim(),
+            referenceNumber: `TELLER-ALLOC-${teller.id}-${Date.now()}`,
+            locale: "en",
+            dateFormat: "dd MMMM yyyy",
+          }),
+        });
+        journalTransactionId =
+          journalResult?.transactionId || journalResult?.resourceId || null;
+      } catch (err) {
+        console.error(
+          "Failed to post Fineract journal entry for teller allocation; the local CashAllocation record will still be created, but GL balance will not reflect this:",
+          err
+        );
+      }
+    }
+
+    // Create allocation record in database for audit/fallback. When the teller has a
+    // GL account, the GL is the source of truth; this row stays as a local ledger trail.
     const allocation = await prisma.cashAllocation.create({
       data: {
         tenantId: tenant.id,
         tellerId: teller.id, // Use the database ID from the found teller
         cashierId: null, // null = teller vault allocation
-        fineractAllocationId: null, // No Fineract allocation for teller-level
+        fineractAllocationId: null, // No Fineract teller-allocation (we post a journal entry instead)
         amount: requestedAmount,
         currency: allocationCurrency,
         allocatedBy: session.user.id,
-        notes: teller.bankId
-          ? `${notes || ""} [From Bank: ${teller.bank?.name || teller.bankId}]`.trim()
-          : notes,
+        notes: [
+          notes,
+          teller.bankId ? `[From Bank: ${teller.bank?.name || teller.bankId}]` : null,
+          journalTransactionId ? `[GL JE: ${journalTransactionId}]` : null,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .trim(),
         status: "ACTIVE",
       },
     });
 
-    return NextResponse.json(allocation);
+    return NextResponse.json({ ...allocation, journalTransactionId });
   } catch (error) {
     console.error("Error allocating cash:", error);
     return NextResponse.json(

--- a/app/api/tellers/[id]/cashiers/[cashierId]/allocate/route.ts
+++ b/app/api/tellers/[id]/cashiers/[cashierId]/allocate/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { getOrgRawCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 
 /**
  * POST /api/tellers/[id]/cashiers/[cashierId]/allocate
@@ -189,10 +190,23 @@ export async function POST(
       },
     });
 
-    const vaultBalance = tellerVaultAllocations.reduce(
+    const localVaultBalance = tellerVaultAllocations.reduce(
       (sum, alloc) => sum + alloc.amount,
       0
     );
+
+    // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
+    // Falls back to the local CashAllocation ledger if GL is not configured or Fineract is unreachable.
+    let vaultBalance = localVaultBalance;
+    if (teller.glAccountId) {
+      const glResult = await getGlAccountBalance(teller.glAccountId);
+      if (
+        glResult.source === "fineract_calculated" ||
+        glResult.source === "fineract_empty"
+      ) {
+        vaultBalance = glResult.balance;
+      }
+    }
 
     const cashierAllocsForCheck = await prisma.cashAllocation.findMany({
       where: {

--- a/app/api/tellers/[id]/route.ts
+++ b/app/api/tellers/[id]/route.ts
@@ -3,6 +3,7 @@ import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 
 /**
  * GET /api/tellers/[id]
@@ -134,12 +135,51 @@ export async function GET(
 
     // Calculate balances - available must DECREASE when loans are disbursed, and handle deposits
     // allocatedToCashiers = cash currently in cashier tills; use netCash (current balance), not sumCashAllocation (cumulative)
-    const currency = await getOrgDefaultCurrencyCode();
-    
-    const vaultBalance = dbTeller.cashAllocations.reduce(
+    const orgCurrency = await getOrgDefaultCurrencyCode();
+
+    const localVaultBalance = dbTeller.cashAllocations.reduce(
       (sum, alloc) => sum + alloc.amount,
       0
     );
+
+    // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
+    // Falls back to the local CashAllocation ledger if GL is not configured or Fineract is unreachable.
+    let vaultBalance = localVaultBalance;
+    let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
+    let glAccountBalance: {
+      balance: number;
+      currency: string;
+      source: string;
+      entryCount?: number;
+      error?: string;
+    } | null = null;
+    let currency = orgCurrency;
+
+    if (dbTeller.glAccountId) {
+      const glResult = await getGlAccountBalance(dbTeller.glAccountId);
+      if (
+        glResult.source === "fineract_calculated" ||
+        glResult.source === "fineract_empty"
+      ) {
+        vaultBalance = glResult.balance;
+        vaultBalanceSource = "fineract_gl";
+        currency = glResult.currency || orgCurrency;
+        glAccountBalance = {
+          balance: glResult.balance,
+          currency,
+          source: glResult.source,
+          entryCount: glResult.entryCount,
+        };
+      } else {
+        vaultBalanceSource = "local_fallback";
+        glAccountBalance = {
+          balance: localVaultBalance,
+          currency,
+          source: "local_fallback",
+          error: glResult.error,
+        };
+      }
+    }
     
     // Compute allocatedToCashiers: always include local DB allocations so we never undercount
     // (Fineract may return 0 due to currency/timing; local allocations are source of truth for our allocations)
@@ -200,11 +240,16 @@ export async function GET(
       status: dbTeller.status,
       startDate: dbTeller.startDate,
       endDate: dbTeller.endDate,
+      glAccountId: dbTeller.glAccountId,
+      glAccountName: dbTeller.glAccountName,
+      glAccountCode: dbTeller.glAccountCode,
       currentAllocation: {
         amount: availableBalance, // Show available balance, not vault balance
         currency: currency,
       },
       vaultBalance: vaultBalance,
+      vaultBalanceSource,
+      glAccountBalance,
       availableBalance: availableBalance,
       allocatedToCashiers: allocatedToCashiers,
       activeCashiers: dbTeller.cashiers.length,
@@ -307,6 +352,12 @@ export async function PUT(
         endDate: body.endDate ? new Date(body.endDate) : null,
         status: body.status,
         isActive: body.isActive !== undefined ? body.isActive : true,
+        ...(body.bankId !== undefined && { bankId: body.bankId || null }),
+        ...(body.glAccountId !== undefined && {
+          glAccountId: body.glAccountId ? parseInt(body.glAccountId) : null,
+          glAccountName: body.glAccountName || null,
+          glAccountCode: body.glAccountCode || null,
+        }),
       },
     });
 

--- a/app/api/tellers/route.ts
+++ b/app/api/tellers/route.ts
@@ -3,6 +3,7 @@ import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
+import { getGlAccountBalance } from "@/lib/gl-balance";
 
 /**
  * GET /api/tellers
@@ -144,10 +145,26 @@ export async function GET(request: NextRequest) {
     // Calculate balances - use max(Fineract, local) for allocatedToCashiers so we never undercount
     const dbTellerBalances = await Promise.all(
       dbTellers.map(async (dbTeller) => {
-        const vaultBalance = dbTeller.cashAllocations.reduce(
+        const localVaultBalance = dbTeller.cashAllocations.reduce(
           (sum, alloc) => sum + alloc.amount,
           0
         );
+
+        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
+        // Falls back to the local CashAllocation ledger if GL is not configured or Fineract is unreachable.
+        let vaultBalance = localVaultBalance;
+        let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
+        let vaultCurrency: string | null = null;
+        if (dbTeller.glAccountId) {
+          const glResult = await getGlAccountBalance(dbTeller.glAccountId);
+          if (glResult.source === "fineract_calculated" || glResult.source === "fineract_empty") {
+            vaultBalance = glResult.balance;
+            vaultBalanceSource = "fineract_gl";
+            vaultCurrency = glResult.currency;
+          } else {
+            vaultBalanceSource = "local_fallback";
+          }
+        }
 
         const cashierAllocations = await prisma.cashAllocation.findMany({
           where: {
@@ -190,14 +207,18 @@ export async function GET(request: NextRequest) {
         }
 
         const availableBalance = vaultBalance - allocatedToCashiers;
-        const currency = orgCurrency;
+        const currency = vaultCurrency || orgCurrency;
 
         return {
           fineractTellerId: dbTeller.fineractTellerId,
           dbId: dbTeller.id,
           bankId: dbTeller.bankId,
           bank: dbTeller.bank,
+          glAccountId: dbTeller.glAccountId,
+          glAccountName: dbTeller.glAccountName,
+          glAccountCode: dbTeller.glAccountCode,
           vaultBalance,
+          vaultBalanceSource,
           availableBalance,
           allocatedToCashiers,
           currentAllocation: { amount: availableBalance, currency },
@@ -227,8 +248,12 @@ export async function GET(request: NextRequest) {
         ...(dbData && {
           bankId: dbData.bankId,
           bank: dbData.bank,
+          glAccountId: dbData.glAccountId,
+          glAccountName: dbData.glAccountName,
+          glAccountCode: dbData.glAccountCode,
           currentAllocation: dbData.currentAllocation,
           vaultBalance: dbData.vaultBalance,
+          vaultBalanceSource: dbData.vaultBalanceSource,
           availableBalance: dbData.availableBalance,
           allocatedToCashiers: dbData.allocatedToCashiers,
           settlementCount: dbData.settlementCount,
@@ -263,7 +288,17 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { officeId, name, description, startDate, endDate, bankId } = body;
+    const {
+      officeId,
+      name,
+      description,
+      startDate,
+      endDate,
+      bankId,
+      glAccountId,
+      glAccountName,
+      glAccountCode,
+    } = body;
 
     if (!officeId || !name || !startDate) {
       return NextResponse.json(
@@ -322,6 +357,9 @@ export async function POST(request: NextRequest) {
         endDate: endDate ? new Date(endDate) : null,
         status: "PENDING",
         bankId: bankId || null, // Link to parent bank if provided
+        glAccountId: glAccountId ? parseInt(glAccountId) : null,
+        glAccountName: glAccountName || null,
+        glAccountCode: glAccountCode || null,
       },
     });
 

--- a/lib/gl-balance.ts
+++ b/lib/gl-balance.ts
@@ -1,0 +1,71 @@
+import { fetchFineractAPI } from "@/lib/api";
+
+export type GlBalanceSource =
+  | "fineract_calculated"
+  | "fineract_empty"
+  | "local_fallback"
+  | "local";
+
+export interface GlBalanceResult {
+  balance: number;
+  currency: string | null;
+  source: GlBalanceSource;
+  entryCount?: number;
+  error?: string;
+}
+
+/**
+ * Compute the current balance for a Fineract GL account by summing journal entries.
+ *
+ * Treats the account as an ASSET (DEBIT increases, CREDIT decreases). This matches
+ * how cash/till GL accounts (e.g. branch cash, bank vault) behave in Fineract and
+ * is what we use everywhere else in the codebase (see `app/api/banks/[id]/route.ts`).
+ *
+ * Pages through at most `limit` most-recent entries; default 500 is large enough
+ * for any reasonable single-account ledger and matches the existing bank logic.
+ */
+export async function getGlAccountBalance(
+  glAccountId: number,
+  options: { limit?: number } = {}
+): Promise<GlBalanceResult> {
+  const limit = options.limit ?? 500;
+
+  try {
+    const journalData = await fetchFineractAPI(
+      `/journalentries?glAccountId=${glAccountId}&limit=${limit}&orderBy=id&sortOrder=DESC`
+    );
+
+    if (journalData?.pageItems && journalData.pageItems.length > 0) {
+      let calculated = 0;
+      for (const entry of journalData.pageItems) {
+        if (entry.entryType?.value === "DEBIT") {
+          calculated += entry.amount || 0;
+        } else if (entry.entryType?.value === "CREDIT") {
+          calculated -= entry.amount || 0;
+        }
+      }
+
+      const latestEntry = journalData.pageItems[0];
+      return {
+        balance: calculated,
+        currency: latestEntry.currency?.code ?? null,
+        source: "fineract_calculated",
+        entryCount: journalData.pageItems.length,
+      };
+    }
+
+    return {
+      balance: 0,
+      currency: null,
+      source: "fineract_empty",
+      entryCount: 0,
+    };
+  } catch (error) {
+    return {
+      balance: 0,
+      currency: null,
+      source: "local_fallback",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/prisma/migrations/20260519143000_add_teller_gl_account/migration.sql
+++ b/prisma/migrations/20260519143000_add_teller_gl_account/migration.sql
@@ -1,0 +1,7 @@
+-- Add optional Fineract GL account link to Teller (mirrors Bank).
+-- When set, teller vault balance is sourced from the Fineract journal entries on this GL account.
+-- When null, the application falls back to the local CashAllocation ledger.
+ALTER TABLE "Teller"
+  ADD COLUMN "glAccountId"   INTEGER,
+  ADD COLUMN "glAccountName" TEXT,
+  ADD COLUMN "glAccountCode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -877,6 +877,9 @@ model Teller {
   officeName       String
   name             String
   description      String?
+  glAccountId      Int?             // Optional link to Fineract GL account (branch cash) for this teller's vault
+  glAccountName    String?          // Cached GL account name for display
+  glAccountCode    String?          // Cached GL account code
   status           String           @default("PENDING") // PENDING, ACTIVE, CLOSED
   startDate        DateTime
   endDate          DateTime?


### PR DESCRIPTION
Tellers can now optionally link to a Fineract GL account (branch cash), mirroring the existing bank pattern. When configured, the teller vault balance is calculated from journal entries on that GL; allocations from the parent bank also post a Fineract journal entry so the GL stays in sync. Falls back to the local CashAllocation ledger when no GL is set or when Fineract is unreachable.

- Add optional glAccountId/Name/Code to Teller (additive migration)
- Add shared lib/gl-balance.ts helper for journal-entry balance calc
- Read GL balance in teller list/detail, bank-teller list, and the cashier-allocate vault check
- POST teller allocate posts a JE (debit teller GL, credit bank GL) when both ends have a GL configured
- Add GL picker to Create and Edit Teller flows, surface the source on the teller detail card