### PR TITLE
fix: RCF lead form routing, facilityType persistence, and contract tab

### DIFF
--- a/app/(application)/leads/new/components/client-registration-form.tsx
+++ b/app/(application)/leads/new/components/client-registration-form.tsx
@@ -454,6 +454,7 @@ interface ClientRegistrationFormProps {
   onAllSectionsComplete?: (isComplete: boolean) => void;
   onLeadIdChange?: (leadId: string) => void;
   facilityType?: "TERM_LOAN" | "INVOICE_DISCOUNTING" | "REVOLVING_CREDIT";
+  draftUrlBase?: string;
 }
 
 export function ClientRegistrationForm({
@@ -470,6 +471,7 @@ export function ClientRegistrationForm({
   isSubmitting = false,
   onAllSectionsComplete,
   facilityType,
+  draftUrlBase = "/leads/new",
 }: ClientRegistrationFormProps) {
   const {
     success,
@@ -2677,6 +2679,7 @@ export function ClientRegistrationForm({
           ...formData,
           [fieldName]: value,
           fieldName: fieldName,
+          ...(facilityType ? { facilityType } : {}),
         },
         currentLeadId
       );
@@ -3884,7 +3887,7 @@ export function ClientRegistrationForm({
           window.history.replaceState(
             null,
             "",
-            `/leads/new?id=${result.leadId}`
+            `${draftUrlBase}?id=${result.leadId}`
           );
         }
 
@@ -7564,6 +7567,7 @@ export function ClientRegistrationForm({
                                             fineractClientId:
                                               Number(resolvedClientId),
                                           }),
+                                          ...(facilityType ? { facilityType } : {}),
                                         },
                                         currentLeadId
                                       );
@@ -7788,7 +7792,7 @@ export function ClientRegistrationForm({
                                         window.history.replaceState(
                                           null,
                                           "",
-                                          `/leads/new?id=${result.leadId}`
+                                          `${draftUrlBase}?id=${result.leadId}`
                                         );
                                       }
 

--- a/app/(application)/leads/new/components/new-lead-form.tsx
+++ b/app/(application)/leads/new/components/new-lead-form.tsx
@@ -375,7 +375,7 @@ export function NewLeadForm() {
 
     form.reset();
 
-    window.history.replaceState(null, "", "/leads/new");
+    window.history.replaceState(null, "", "/leads/new/loan");
 
     setShowWipeConfirm(false);
 
@@ -1175,7 +1175,7 @@ export function NewLeadForm() {
         console.log("==========> Updating URL with leadId:", result.leadId);
         setCurrentLeadId(result.leadId);
         // Update URL with the new lead ID using replace to avoid history clutter
-        window.history.replaceState(null, "", `/leads/new?id=${result.leadId}`);
+        window.history.replaceState(null, "", `/leads/new/loan?id=${result.leadId}`);
       } else {
         console.log("==========> Keeping existing leadId:", currentLeadId);
       }
@@ -1514,17 +1514,13 @@ export function NewLeadForm() {
                     setClientCreatedInFineract={setClientCreatedInFineract}
                     isSubmitting={isSubmitting}
                     onAllSectionsComplete={setAllClientSectionsComplete}
+                    draftUrlBase="/leads/new/loan"
                     onLeadIdChange={(newLeadId) => {
                       console.log(
                         "==========> Lead ID propagated from ClientRegistrationForm:",
                         newLeadId,
                       );
                       setCurrentLeadId(newLeadId);
-                      window.history.replaceState(
-                        null,
-                        "",
-                        `/leads/new?id=${newLeadId}`,
-                      );
                     }}
                     onClientCreated={() => {
                       setClientCreatedInFineract(true);

--- a/app/(application)/leads/new/rcf/components/rcf-lead-form.tsx
+++ b/app/(application)/leads/new/rcf/components/rcf-lead-form.tsx
@@ -6,6 +6,7 @@ import useSWR from "swr";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ClientRegistrationForm } from "../../components/client-registration-form";
 import { SimplifiedAffordabilityForm } from "../../components/simplified-affordability-form";
 import { RcfContracts } from "./rcf-contracts";
@@ -38,16 +39,8 @@ export function RcfLeadForm() {
   }, []);
 
   // Load template data (offices, legalForms, etc.) same as loan wizard
-  const { data: templateResult } = useSWR("/api/leads/template", fetcher);
-  const rawTemplate = templateResult?.data ?? {
-    offices: [],
-    legalForms: [],
-    genders: [],
-    clientTypes: [],
-    clientClassifications: [],
-    savingsProducts: [],
-    activationDate: null,
-  };
+  const { data: templateResult, error: templateError } = useSWR("/api/leads/template", fetcher);
+  const rawTemplate = templateResult?.data ?? {};
   const clientFormData = {
     ...rawTemplate,
     activationDate: rawTemplate.activationDate
@@ -81,6 +74,29 @@ export function RcfLeadForm() {
   const handleContractsComplete = () => {
     if (leadId) router.push(`/leads/${leadId}`);
   };
+
+  if (templateError) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-red-600 font-medium">Error loading form data: {templateError.message}</p>
+      </div>
+    );
+  }
+
+  if (!templateResult) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <div className="flex-shrink-0 px-2 py-2 lg:px-6 lg:py-6 border-b bg-background">
+          <Skeleton className="h-7 w-64 mb-1" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        <div className="flex-1 px-2 py-2 lg:px-6 lg:py-6 space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-96 w-full rounded-xl" />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -126,9 +142,9 @@ export function RcfLeadForm() {
                   isSubmitting={isSubmitting}
                   facilityType="REVOLVING_CREDIT"
                   onAllSectionsComplete={setAllClientSectionsComplete}
+                  draftUrlBase="/leads/new/rcf"
                   onLeadIdChange={(newLeadId) => {
                     setLeadId(newLeadId);
-                    window.history.replaceState(null, "", `/leads/new/rcf?id=${newLeadId}`);
                   }}
                   onClientCreated={() => {
                     setClientCreatedInFineract(true);

--- a/app/actions/client-actions-with-autosave.ts
+++ b/app/actions/client-actions-with-autosave.ts
@@ -47,6 +47,7 @@ const clientFormSchema = z.object({
   currentStep: z.number().default(1),
   fieldName: z.string().optional(), // The field that was just updated
   fineractClientId: z.number().optional(),
+  facilityType: z.enum(["TERM_LOAN", "INVOICE_DISCOUNTING", "REVOLVING_CREDIT"]).optional(),
   fineractAccountNo: z.string().optional(),
 });
 
@@ -214,6 +215,9 @@ export async function autoSaveField(
             clientCreatedInFineract: true,
             clientCreationDate: now,
           }),
+          ...(validatedData.facilityType !== undefined && {
+            facilityType: validatedData.facilityType,
+          }),
           ...(validatedData.fineractAccountNo !== undefined && {
             fineractAccountNo: validatedData.fineractAccountNo,
           }),
@@ -269,6 +273,7 @@ export async function autoSaveField(
             savingsProductId: validatedData.savingsProductId || null,
             savingsProductName: validatedData.savingsProductName || null,
             currentStep: validatedData.currentStep || 1,
+            facilityType: validatedData.facilityType ?? null,
             status: "PROSPECT",
             lastModified: now,
           },


### PR DESCRIPTION
## Summary

- **URL routing fix**: `ClientRegistrationForm` now accepts a `draftUrlBase` prop (default `/leads/new`) used in all `replaceState` calls — prevents accidental navigation to the product selection page when interacting with selects or creating a client in the RCF wizard (`/leads/new/rcf`) and loan wizard (`/leads/new/loan`)
- **Loan form URLs**: All `replaceState` calls in `new-lead-form.tsx` updated to `/leads/new/loan`
- **Template loading guard**: RCF lead form now waits for template data before rendering `ClientRegistrationForm`, so Office, Legal Form and other selects are pre-populated for new clients
- **facilityType persistence**: Added `facilityType` to `autoSaveField` schema and all autosave call sites — leads created via field-level autosave or the existing-client save-all path now correctly get `REVOLVING_CREDIT` set, fixing the "Agreement unavailable" error on the Contracts tab

## Test plan

- [ ] Create a new RCF lead — selecting Office/Legal Form does not navigate away from `/leads/new/rcf`
- [ ] Create a new loan lead — selecting Office/Legal Form does not navigate away from `/leads/new/loan`
- [ ] Search non-existent National ID in RCF wizard — selects (Office, Legal Form etc.) are pre-populated
- [ ] Create client in RCF wizard — stays on RCF page, moves to next tab
- [ ] Complete RCF lead through to Contracts tab — contract renders inline without "Agreement unavailable" error
- [ ] Restore RCF draft from URL `?id=` — form state restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)