### PR TITLE
feat(tellers): pure-GL vault balance + Return to Bank flow

### DIFF
--- a/app/(application)/banks/[id]/page.tsx
+++ b/app/(application)/banks/[id]/page.tsx
@@ -62,7 +62,9 @@ interface Teller {
   fineractTellerId?: number;
   officeName: string;
   status: string;
-  vaultBalance: number;
+  vaultBalance: number | null;
+  vaultBalanceSource?: "fineract_gl" | "unavailable";
+  glAccountCode?: string | null;
   activeCashiers: number;
 }
 
@@ -308,10 +310,16 @@ export default function BankDetailsPage({
                   <div className="flex items-center gap-6">
                     <div className="text-right">
                       <div className="font-medium">
-                        {formatCurrency(teller.vaultBalance, bank.currency)}
+                        {teller.vaultBalanceSource === "fineract_gl" &&
+                        teller.vaultBalance != null
+                          ? formatCurrency(teller.vaultBalance, bank.currency)
+                          : "—"}
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Vault balance
+                        {teller.vaultBalanceSource === "fineract_gl" &&
+                        teller.glAccountCode
+                          ? `Vault • GL ${teller.glAccountCode}`
+                          : "Vault balance unavailable"}
                       </div>
                     </div>
                     {getStatusBadge(teller.status)}

--- a/app/(application)/tellers/[id]/components/teller-actions.tsx
+++ b/app/(application)/tellers/[id]/components/teller-actions.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { DollarSign, Users, CheckCircle, Edit } from "lucide-react";
+import {
+  DollarSign,
+  Users,
+  CheckCircle,
+  Edit,
+  ArrowDownLeft,
+} from "lucide-react";
 import Link from "next/link";
 import { AllocateCashModal } from "../../components/allocate-cash-modal";
 import { EditTellerModal } from "../../components/edit-teller-modal";
+import { ReturnToBankModal } from "../../components/return-to-bank-modal";
 
 interface TellerActionsProps {
   tellerId: string;
@@ -21,12 +29,43 @@ interface TellerActionsProps {
     glAccountId?: number | null;
     glAccountName?: string | null;
     glAccountCode?: string | null;
+    bankId?: string | null;
+    bankName?: string | null;
+    bankGlAccountId?: number | null;
+    vaultBalance?: number | null;
+    vaultBalanceSource?: "fineract_gl" | "unavailable";
+    currency?: string | null;
   };
 }
 
-export function TellerActions({ tellerId, tellerName, teller }: TellerActionsProps) {
+export function TellerActions({
+  tellerId,
+  tellerName,
+  teller,
+}: TellerActionsProps) {
+  const router = useRouter();
   const [showAllocateModal, setShowAllocateModal] = useState(false);
+  const [showReturnModal, setShowReturnModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+
+  const canReturnToBank =
+    !!teller.glAccountId &&
+    !!teller.bankId &&
+    !!teller.bankGlAccountId &&
+    teller.vaultBalanceSource === "fineract_gl" &&
+    typeof teller.vaultBalance === "number" &&
+    teller.vaultBalance > 0;
+
+  const returnDisabledReason = (() => {
+    if (!teller.glAccountId) return "Teller has no GL account configured.";
+    if (!teller.bankId) return "Teller is not linked to a parent bank.";
+    if (!teller.bankGlAccountId) return "Parent bank has no GL account configured.";
+    if (teller.vaultBalanceSource !== "fineract_gl")
+      return "Vault balance is unavailable.";
+    if (!teller.vaultBalance || teller.vaultBalance <= 0)
+      return "Teller vault is empty.";
+    return "";
+  })();
 
   return (
     <>
@@ -38,8 +77,18 @@ export function TellerActions({ tellerId, tellerName, teller }: TellerActionsPro
         <DollarSign className="h-4 w-4 mr-2" />
         Allocate Cash
       </Button>
+      <Button
+        variant="outline"
+        className="w-full mt-2"
+        onClick={() => setShowReturnModal(true)}
+        disabled={!canReturnToBank}
+        title={canReturnToBank ? undefined : returnDisabledReason}
+      >
+        <ArrowDownLeft className="h-4 w-4 mr-2" />
+        Return to Bank
+      </Button>
       <Link href={`/tellers/${tellerId}/cashiers`}>
-        <Button variant="outline" className="w-full">
+        <Button variant="outline" className="w-full mt-2">
           <Users className="h-4 w-4 mr-2" />
           Manage Cashiers
         </Button>
@@ -63,6 +112,16 @@ export function TellerActions({ tellerId, tellerName, teller }: TellerActionsPro
         tellerName={tellerName}
         open={showAllocateModal}
         onOpenChange={setShowAllocateModal}
+      />
+      <ReturnToBankModal
+        tellerId={tellerId}
+        tellerName={tellerName}
+        bankName={teller.bankName}
+        vaultBalance={teller.vaultBalance ?? null}
+        currency={teller.currency ?? null}
+        open={showReturnModal}
+        onOpenChange={setShowReturnModal}
+        onSuccess={() => router.refresh()}
       />
       <EditTellerModal
         tellerId={tellerId}

--- a/app/(application)/tellers/[id]/page.tsx
+++ b/app/(application)/tellers/[id]/page.tsx
@@ -75,32 +75,27 @@ export default async function TellerDetailPage({
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {teller.currentAllocation
-                ? formatCurrency(
-                    teller.currentAllocation.amount,
-                    teller.currentAllocation.currency
-                  )
-                : "No allocation"}
+              {teller.vaultBalanceSource === "fineract_gl" &&
+              teller.availableBalance != null ? (
+                formatCurrency(
+                  teller.availableBalance,
+                  teller.currency || orgCurrency
+                )
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
             </div>
-            {teller.vaultBalance !== undefined && (
-              <div className="text-xs text-muted-foreground mt-1">
-                Vault: {formatCurrency(teller.vaultBalance, teller.currency || orgCurrency)}
-                {teller.allocatedToCashiers > 0 && (
-                  <span className="ml-2">
-                    • Allocated: {formatCurrency(teller.allocatedToCashiers, teller.currency || orgCurrency)}
-                  </span>
-                )}
-              </div>
-            )}
             {teller.vaultBalanceSource === "fineract_gl" && teller.glAccountCode && (
               <div className="text-xs text-green-700 dark:text-green-400 mt-1">
                 Sourced from GL {teller.glAccountCode}
                 {teller.glAccountName ? ` (${teller.glAccountName})` : ""}
               </div>
             )}
-            {teller.vaultBalanceSource === "local_fallback" && (
+            {teller.vaultBalanceSource !== "fineract_gl" && (
               <div className="text-xs text-amber-600 mt-1">
-                Could not reach Fineract GL — showing local ledger as fallback.
+                {teller.glUnavailableReason === "fineract_unreachable"
+                  ? "Could not reach Fineract GL — balance unavailable."
+                  : "Branch Cash GL not configured — balance unavailable."}
               </div>
             )}
           </CardContent>
@@ -198,7 +193,7 @@ export default async function TellerDetailPage({
                     </span>
                   ) : (
                     <span className="text-amber-600 text-sm">
-                      Not configured — vault balance falls back to local ledger
+                      Not configured — vault balance unavailable
                     </span>
                   )}
                 </div>

--- a/app/(application)/tellers/components/return-to-bank-modal.tsx
+++ b/app/(application)/tellers/components/return-to-bank-modal.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, CheckCircle2, ArrowDownLeft, Loader2 } from "lucide-react";
+import { SearchableSelect } from "@/components/searchable-select";
+import { useCurrency } from "@/contexts/currency-context";
+
+interface ReturnToBankModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tellerId: string;
+  tellerName?: string;
+  bankName?: string | null;
+  vaultBalance?: number | null;
+  currency?: string | null;
+  onSuccess?: () => void;
+}
+
+interface Currency {
+  code: string;
+  name: string;
+}
+
+export function ReturnToBankModal({
+  open,
+  onOpenChange,
+  tellerId,
+  tellerName,
+  bankName,
+  vaultBalance,
+  currency: tellerCurrency,
+  onSuccess,
+}: ReturnToBankModalProps) {
+  const { currencyCode: orgCurrency } = useCurrency();
+  const [loading, setLoading] = useState(false);
+  const [currencies, setCurrencies] = useState<Currency[]>([]);
+  const [loadingCurrencies, setLoadingCurrencies] = useState(false);
+  const [result, setResult] = useState<{
+    success: boolean;
+    message: string;
+    transactionId?: string;
+  } | null>(null);
+  const [formData, setFormData] = useState({
+    amount: "",
+    currency: tellerCurrency || orgCurrency,
+    notes: "",
+  });
+
+  useEffect(() => {
+    if (open) {
+      setResult(null);
+      setFormData({
+        amount: "",
+        currency: tellerCurrency || orgCurrency,
+        notes: "",
+      });
+      fetchCurrencies();
+    }
+  }, [open, tellerCurrency, orgCurrency]);
+
+  const fetchCurrencies = async () => {
+    setLoadingCurrencies(true);
+    try {
+      const response = await fetch("/api/fineract/currencies");
+      if (response.ok) {
+        const data = await response.json();
+        const currencyList: Currency[] = Array.isArray(
+          data.selectedCurrencyOptions
+        )
+          ? data.selectedCurrencyOptions
+          : Array.isArray(data)
+          ? data
+          : data.currencies || [];
+        setCurrencies(currencyList);
+      }
+    } catch (e) {
+      console.error("Error fetching currencies:", e);
+    } finally {
+      setLoadingCurrencies(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResult(null);
+
+    const amountNum = parseFloat(formData.amount);
+    if (!amountNum || amountNum <= 0) {
+      setResult({ success: false, message: "Enter an amount greater than 0." });
+      return;
+    }
+    if (
+      typeof vaultBalance === "number" &&
+      amountNum > vaultBalance
+    ) {
+      setResult({
+        success: false,
+        message: `Amount exceeds the teller's vault balance (${vaultBalance.toLocaleString(
+          undefined,
+          { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+        )} ${formData.currency}).`,
+      });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/tellers/${tellerId}/return-to-bank`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          amount: amountNum,
+          currency: formData.currency,
+          notes: formData.notes,
+        }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        setResult({
+          success: false,
+          message:
+            data.details || data.error || "Failed to return cash to bank.",
+        });
+        return;
+      }
+
+      setResult({
+        success: true,
+        message: `Returned ${amountNum.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })} ${formData.currency} to ${bankName || "bank"}.`,
+        transactionId: data.journalTransactionId,
+      });
+      setTimeout(() => {
+        onSuccess?.();
+        onOpenChange(false);
+      }, 1500);
+    } catch (e) {
+      console.error("Error returning to bank:", e);
+      setResult({
+        success: false,
+        message: e instanceof Error ? e.message : "Unknown error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowDownLeft className="h-5 w-5 text-blue-600" />
+            Return Cash to Bank
+          </DialogTitle>
+          <DialogDescription>
+            Move cash from {tellerName || "this teller"} back to{" "}
+            <span className="font-medium">{bankName || "its parent bank"}</span>
+            . A Fineract journal entry will be posted (DEBIT bank GL, CREDIT
+            teller GL).
+          </DialogDescription>
+        </DialogHeader>
+
+        {typeof vaultBalance === "number" && (
+          <div className="bg-muted/50 p-3 rounded-md text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Available in vault</span>
+              <span className="font-medium">
+                {vaultBalance.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}{" "}
+                {tellerCurrency || orgCurrency}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {result && (
+          <Alert variant={result.success ? "default" : "destructive"}>
+            {result.success ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+            ) : (
+              <AlertCircle className="h-4 w-4" />
+            )}
+            <AlertDescription>
+              {result.message}
+              {result.transactionId && (
+                <span className="block mt-1 font-mono text-xs">
+                  Transaction ID: {result.transactionId}
+                </span>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="amount">Amount *</Label>
+              <Input
+                id="amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={formData.amount}
+                onChange={(e) =>
+                  setFormData({ ...formData, amount: e.target.value })
+                }
+                required
+                placeholder="0.00"
+                disabled={loading}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Currency *</Label>
+              <SearchableSelect
+                options={currencies.map((c) => ({
+                  value: c.code,
+                  label: `${c.code}${c.name ? ` - ${c.name}` : ""}`,
+                }))}
+                value={formData.currency}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, currency: value })
+                }
+                placeholder={
+                  loadingCurrencies
+                    ? "Loading currencies..."
+                    : "Select currency"
+                }
+                emptyMessage="No currencies found"
+                disabled={loadingCurrencies || loading}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea
+                id="notes"
+                value={formData.notes}
+                onChange={(e) =>
+                  setFormData({ ...formData, notes: e.target.value })
+                }
+                placeholder="Why is cash being returned? (optional)"
+                rows={3}
+                disabled={loading}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading || result?.success}>
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Returning...
+                </>
+              ) : (
+                <>
+                  <ArrowDownLeft className="mr-2 h-4 w-4" />
+                  Return to Bank
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(application)/tellers/components/tellers-table.tsx
+++ b/app/(application)/tellers/components/tellers-table.tsx
@@ -153,10 +153,8 @@ export function TellersTable() {
       header: "Available Balance",
       cell: ({ row }) => {
         const allocation = row.original.currentAllocation;
-        if (!allocation || allocation.amount === 0) {
-          return (
-            <span className="text-muted-foreground text-sm">No balance</span>
-          );
+        if (!allocation) {
+          return <span className="text-muted-foreground text-sm">—</span>;
         }
         return (
           <span className="font-medium">

--- a/app/actions/teller-actions.ts
+++ b/app/actions/teller-actions.ts
@@ -4,8 +4,8 @@ import { PrismaClient } from "@/app/generated/prisma";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
-import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
-import { getGlAccountBalance } from "@/lib/gl-balance";
+import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { getTellerVaultDisplay } from "@/lib/gl-balance";
 import { unstable_noStore as noStore } from "next/cache";
 
 const db = prisma as PrismaClient;
@@ -71,14 +71,17 @@ export async function getTellerFromFineract(id: string) {
       console.error("Error fetching teller summary:", summaryError);
     }
 
-    // Fetch local database data for balance information
-    let vaultBalance = 0;
-    let availableBalance = 0;
-    let allocatedToCashiers = 0;
+    // Vault & available balance come *only* from the Fineract GL account.
+    // When the GL is missing or Fineract is unreachable, both values are
+    // `null` so the UI renders NaN ("—").
     const orgCurrency = await getOrgDefaultCurrencyCode();
+    let vaultBalance: number | null = null;
+    let availableBalance: number | null = null;
     let currency = orgCurrency;
     let recentSettlements: any[] = [];
-    let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
+    let vaultBalanceSource: "fineract_gl" | "unavailable" = "unavailable";
+    let glUnavailableReason: "not_configured" | "fineract_unreachable" | undefined =
+      "not_configured";
     let glAccountInfo: {
       glAccountId: number | null;
       glAccountName: string | null;
@@ -88,24 +91,35 @@ export async function getTellerFromFineract(id: string) {
       glAccountName: null,
       glAccountCode: null,
     };
+    let bankInfo: {
+      bankId: string | null;
+      bankName: string | null;
+      bankGlAccountId: number | null;
+      bankGlAccountCode: string | null;
+    } = {
+      bankId: null,
+      bankName: null,
+      bankGlAccountId: null,
+      bankGlAccountCode: null,
+    };
 
     try {
       const tenant = await getTenantFromHeaders();
-      
+
       if (tenant) {
-        // Find the local database teller by Fineract ID
         const dbTeller = await db.teller.findFirst({
           where: {
             fineractTellerId: tellerId,
             tenantId: tenant.id,
           },
           include: {
-            cashAllocations: {
-              where: {
-                status: "ACTIVE",
-                cashierId: null, // Only teller vault allocations
+            bank: {
+              select: {
+                id: true,
+                name: true,
+                glAccountId: true,
+                glAccountCode: true,
               },
-              orderBy: { allocatedDate: "desc" },
             },
             settlements: {
               orderBy: { settlementDate: "desc" },
@@ -121,73 +135,19 @@ export async function getTellerFromFineract(id: string) {
             glAccountCode: dbTeller.glAccountCode,
           };
 
-          const localVaultBalance = dbTeller.cashAllocations.reduce(
-            (sum: number, alloc: { amount: number }) => sum + alloc.amount,
-            0
-          );
-          vaultBalance = localVaultBalance;
-          currency = dbTeller.cashAllocations[0]?.currency || orgCurrency;
+          bankInfo = {
+            bankId: dbTeller.bank?.id ?? null,
+            bankName: dbTeller.bank?.name ?? null,
+            bankGlAccountId: dbTeller.bank?.glAccountId ?? null,
+            bankGlAccountCode: dbTeller.bank?.glAccountCode ?? null,
+          };
 
-          // Prefer Fineract GL balance when a GL account is linked.
-          if (dbTeller.glAccountId) {
-            const glResult = await getGlAccountBalance(dbTeller.glAccountId);
-            if (
-              glResult.source === "fineract_calculated" ||
-              glResult.source === "fineract_empty"
-            ) {
-              vaultBalance = glResult.balance;
-              vaultBalanceSource = "fineract_gl";
-              currency = glResult.currency || currency;
-            } else {
-              vaultBalanceSource = "local_fallback";
-            }
-          }
-
-          const cashierAllocations = await db.cashAllocation.findMany({
-            where: {
-              tellerId: dbTeller.id,
-              tenantId: tenant.id,
-              cashierId: { not: null },
-              status: "ACTIVE",
-              notes: { not: { contains: "Variance" } },
-            },
-          });
-          const localAllocated = (() => {
-            const positiveSum = cashierAllocations.reduce(
-              (sum: number, alloc: { amount: number }) => sum + (alloc.amount > 0 ? alloc.amount : 0),
-              0
-            );
-            const netSum = cashierAllocations.reduce(
-              (sum: number, alloc: { amount: number }) => sum + alloc.amount,
-              0
-            );
-            return Math.max(positiveSum, netSum);
-          })();
-
-          allocatedToCashiers = localAllocated;
-          try {
-            const fineractService = await getFineractServiceWithSession();
-            const fineractCashiers = await fineractService.getCashiers(tellerId);
-            let fineractAllocated = 0;
-            for (const fc of fineractCashiers || []) {
-              try {
-                const rawCurrency = await getOrgRawCurrencyCode();
-                const summary = await fineractService.getCashierSummaryAndTransactions(
-                  tellerId,
-                  fc.id,
-                  rawCurrency
-                );
-                fineractAllocated += summary.netCash ?? summary.sumCashAllocation ?? 0;
-              } catch (err) {
-                console.error(`Error getting Fineract summary for cashier ${fc.id}:`, err);
-              }
-            }
-            allocatedToCashiers = Math.max(localAllocated, fineractAllocated);
-          } catch (err) {
-            console.error("Error fetching Fineract cashier balances, using local DB:", err);
-          }
-
-          availableBalance = vaultBalance - allocatedToCashiers;
+          const vaultDisplay = await getTellerVaultDisplay(dbTeller);
+          vaultBalance = vaultDisplay.vaultBalance;
+          availableBalance = vaultDisplay.availableBalance;
+          vaultBalanceSource = vaultDisplay.vaultBalanceSource;
+          glUnavailableReason = vaultDisplay.glUnavailableReason;
+          currency = vaultDisplay.currency || orgCurrency;
           recentSettlements = dbTeller.settlements;
         }
       }
@@ -209,17 +169,18 @@ export async function getTellerFromFineract(id: string) {
         cashiers: cashiers || [],
         activeCashiers: (cashiers || []).filter((c: any) => c.isFullDay || c.startTime).length,
         summary: summary,
-        // Balance data (GL when configured, local fallback otherwise)
+        // Balance data — Fineract GL only; null when unavailable.
         vaultBalance,
         vaultBalanceSource,
+        glUnavailableReason,
         availableBalance,
-        allocatedToCashiers,
         currency,
         ...glAccountInfo,
-        currentAllocation: {
-          amount: availableBalance,
-          currency,
-        },
+        ...bankInfo,
+        currentAllocation:
+          availableBalance != null
+            ? { amount: availableBalance, currency }
+            : null,
         recentSettlements,
       }
     };

--- a/app/api/banks/[id]/route.ts
+++ b/app/api/banks/[id]/route.ts
@@ -4,7 +4,7 @@ import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { fetchFineractAPI } from "@/lib/api";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
-import { getGlAccountBalance } from "@/lib/gl-balance";
+import { getTellerVaultDisplay } from "@/lib/gl-balance";
 
 /**
  * GET /api/banks/[id]
@@ -63,33 +63,14 @@ export async function GET(
       return true;
     };
 
+    // Sum of bank → teller allocations is still tracked from the local ledger
+    // (it represents what the bank has shipped out, regardless of GL config).
+    // Per-teller `vaultBalance` is sourced *only* from Fineract GL — `null`
+    // when not configured or Fineract is unreachable.
     let allocatedToTellers = 0;
     const tellersWithBalances = await Promise.all(
       bank.tellers.map(async (teller) => {
-        // Local vault balance from CashAllocation ledger (used as fallback)
-        const localTellerVaultBalance = teller.cashAllocations.reduce(
-          (sum, alloc) => sum + alloc.amount,
-          0
-        );
-
-        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
-        let tellerVaultBalance = localTellerVaultBalance;
-        let tellerVaultBalanceSource:
-          | "fineract_gl"
-          | "local"
-          | "local_fallback" = "local";
-        if (teller.glAccountId) {
-          const glResult = await getGlAccountBalance(teller.glAccountId);
-          if (
-            glResult.source === "fineract_calculated" ||
-            glResult.source === "fineract_empty"
-          ) {
-            tellerVaultBalance = glResult.balance;
-            tellerVaultBalanceSource = "fineract_gl";
-          } else {
-            tellerVaultBalanceSource = "local_fallback";
-          }
-        }
+        const vaultDisplay = await getTellerVaultDisplay(teller);
 
         const bankAllocationsOnly = teller.cashAllocations
           .filter(isFromBank)
@@ -106,8 +87,8 @@ export async function GET(
           glAccountId: teller.glAccountId,
           glAccountName: teller.glAccountName,
           glAccountCode: teller.glAccountCode,
-          vaultBalance: tellerVaultBalance,
-          vaultBalanceSource: tellerVaultBalanceSource,
+          vaultBalance: vaultDisplay.vaultBalance,
+          vaultBalanceSource: vaultDisplay.vaultBalanceSource,
           activeCashiers: teller.cashiers.length,
         };
       })

--- a/app/api/banks/[id]/tellers/route.ts
+++ b/app/api/banks/[id]/tellers/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
-import { getGlAccountBalance } from "@/lib/gl-balance";
+import { getTellerVaultDisplay } from "@/lib/gl-balance";
 
 /**
  * GET /api/banks/[id]/tellers
@@ -57,52 +57,13 @@ export async function GET(
       },
     });
 
-    // Calculate balances for each teller
+    // Balances come *only* from the Fineract GL account. When no GL is
+    // configured or Fineract is unreachable, vaultBalance/availableBalance
+    // are null and the UI renders "—" / NaN.
     const tellersWithBalances = await Promise.all(
       tellers.map(async (teller) => {
-        const localVaultBalance = teller.cashAllocations.reduce(
-          (sum, alloc) => sum + alloc.amount,
-          0
-        );
-
-        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
-        let vaultBalance = localVaultBalance;
-        let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
-        let glCurrency: string | null = null;
-        if (teller.glAccountId) {
-          const glResult = await getGlAccountBalance(teller.glAccountId);
-          if (
-            glResult.source === "fineract_calculated" ||
-            glResult.source === "fineract_empty"
-          ) {
-            vaultBalance = glResult.balance;
-            vaultBalanceSource = "fineract_gl";
-            glCurrency = glResult.currency;
-          } else {
-            vaultBalanceSource = "local_fallback";
-          }
-        }
-
-        // Get allocations to cashiers
-        const cashierAllocations = await prisma.cashAllocation.findMany({
-          where: {
-            tellerId: teller.id,
-            tenantId: tenant.id,
-            cashierId: { not: null },
-            status: "ACTIVE",
-            notes: { not: { contains: "Variance" } },
-          },
-        });
-
-        // Only sum positive allocations - disbursements reduce till but not "allocated"
-        const allocatedToCashiers = cashierAllocations.reduce(
-          (sum, alloc) => sum + (alloc.amount > 0 ? alloc.amount : 0),
-          0
-        );
-
-        const availableBalance = vaultBalance - allocatedToCashiers;
-        const currency =
-          glCurrency || teller.cashAllocations[0]?.currency || orgCurrency;
+        const vaultDisplay = await getTellerVaultDisplay(teller);
+        const currency = vaultDisplay.currency || orgCurrency;
 
         return {
           id: teller.id,
@@ -117,10 +78,9 @@ export async function GET(
           glAccountId: teller.glAccountId,
           glAccountName: teller.glAccountName,
           glAccountCode: teller.glAccountCode,
-          vaultBalance,
-          vaultBalanceSource,
-          availableBalance,
-          allocatedToCashiers,
+          vaultBalance: vaultDisplay.vaultBalance,
+          vaultBalanceSource: vaultDisplay.vaultBalanceSource,
+          availableBalance: vaultDisplay.availableBalance,
           currency,
           activeCashiers: teller.cashiers.length,
           settlementCount: teller._count.settlements,

--- a/app/api/tellers/[id]/return-to-bank/route.ts
+++ b/app/api/tellers/[id]/return-to-bank/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { getSession } from "@/lib/auth";
+import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { fetchFineractAPI } from "@/lib/api";
+import { getGlAccountBalance } from "@/lib/gl-balance";
+
+/**
+ * POST /api/tellers/[id]/return-to-bank
+ *
+ * Move cash from a teller's vault back to its parent bank. Mirrors
+ * `POST /api/tellers/[id]/allocate` in reverse:
+ *
+ *   - Posts a Fineract journal entry: DEBIT bank GL, CREDIT teller GL.
+ *   - Writes a positive `BankAllocation` row so the bank's history page shows
+ *     the inflow.
+ *   - Writes a negative `CashAllocation` row (tellerId, cashierId=null) so the
+ *     teller's local ledger reflects the outflow.
+ *
+ * Requires teller.glAccountId, teller.bankId, and teller.bank.glAccountId to
+ * all be set – any "return" needs both halves of the double-entry to land.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const params = await context.params;
+    const { id: tellerId } = params;
+    const tenant = await getTenantFromHeaders();
+    const session = await getSession();
+
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { amount, currency, notes } = body;
+
+    if (!amount || amount <= 0) {
+      return NextResponse.json(
+        { error: "Amount must be greater than 0" },
+        { status: 400 }
+      );
+    }
+
+    let teller = await prisma.teller.findFirst({
+      where: { id: tellerId, tenantId: tenant.id },
+      include: { bank: true },
+    });
+
+    if (!teller && !Number.isNaN(Number(tellerId))) {
+      teller = await prisma.teller.findFirst({
+        where: { fineractTellerId: Number(tellerId), tenantId: tenant.id },
+        include: { bank: true },
+      });
+    }
+
+    if (!teller) {
+      return NextResponse.json({ error: "Teller not found" }, { status: 404 });
+    }
+
+    if (!teller.glAccountId) {
+      return NextResponse.json(
+        {
+          error: "Teller has no GL account configured",
+          details:
+            "Assign a Branch Cash GL account to this teller before returning cash to the bank.",
+        },
+        { status: 400 }
+      );
+    }
+    if (!teller.bankId || !teller.bank) {
+      return NextResponse.json(
+        {
+          error: "Teller is not linked to a parent bank",
+          details:
+            "Link this teller to a bank (Edit Teller) before returning cash.",
+        },
+        { status: 400 }
+      );
+    }
+    if (!teller.bank.glAccountId) {
+      return NextResponse.json(
+        {
+          error: "Parent bank has no GL account configured",
+          details:
+            "Assign a GL account to the parent bank before returning cash from a teller.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const orgCurrency = await getOrgDefaultCurrencyCode();
+    const requestedAmount = parseFloat(amount);
+    const returnCurrency = currency || orgCurrency;
+
+    const glResult = await getGlAccountBalance(teller.glAccountId);
+    const vaultBalance =
+      glResult.source === "fineract_calculated" ||
+      glResult.source === "fineract_empty"
+        ? glResult.balance
+        : null;
+
+    if (vaultBalance == null) {
+      return NextResponse.json(
+        {
+          error: "Could not read teller vault balance from Fineract",
+          details:
+            "Fineract is not reachable or returned an error. Please try again.",
+          glError: glResult.error,
+        },
+        { status: 502 }
+      );
+    }
+
+    if (requestedAmount > vaultBalance) {
+      return NextResponse.json(
+        {
+          error: "Insufficient teller vault balance",
+          details: `Teller vault balance: ${vaultBalance.toFixed(
+            2
+          )} ${returnCurrency}. Requested: ${requestedAmount.toFixed(
+            2
+          )} ${returnCurrency}.`,
+          vaultBalance,
+        },
+        { status: 400 }
+      );
+    }
+
+    const today = new Date();
+    const monthNames = [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ];
+    const fineractDate = `${today
+      .getDate()
+      .toString()
+      .padStart(2, "0")} ${monthNames[today.getMonth()]} ${today.getFullYear()}`;
+
+    let journalTransactionId: string | null = null;
+    try {
+      const journalResult = await fetchFineractAPI("/journalentries", {
+        method: "POST",
+        body: JSON.stringify({
+          officeId: teller.officeId,
+          transactionDate: fineractDate,
+          currencyCode: returnCurrency,
+          debits: [
+            { glAccountId: teller.bank.glAccountId, amount: requestedAmount },
+          ],
+          credits: [
+            { glAccountId: teller.glAccountId, amount: requestedAmount },
+          ],
+          comments: `Return from teller ${teller.name} to bank ${
+            teller.bank.name
+          }${notes ? ` - ${notes}` : ""}`.trim(),
+          referenceNumber: `TELLER-RETURN-${teller.id}-${Date.now()}`,
+          locale: "en",
+          dateFormat: "dd MMMM yyyy",
+        }),
+      });
+      journalTransactionId =
+        journalResult?.transactionId || journalResult?.resourceId || null;
+    } catch (err) {
+      console.error(
+        "Failed to post Fineract journal entry for teller return-to-bank:",
+        err
+      );
+      return NextResponse.json(
+        {
+          error: "Failed to post journal entry in Fineract",
+          details:
+            "The return could not be recorded because Fineract did not accept the journal entry. No local rows were written.",
+        },
+        { status: 502 }
+      );
+    }
+
+    // Record both legs locally for audit + so the bank/teller history pages
+    // surface this movement. The teller-side row is a negative amount so the
+    // local ledger sum still matches the GL direction.
+    const noteTag = journalTransactionId ? ` [GL JE: ${journalTransactionId}]` : "";
+
+    const cashAllocation = await prisma.cashAllocation.create({
+      data: {
+        tenantId: tenant.id,
+        tellerId: teller.id,
+        cashierId: null,
+        fineractAllocationId: null,
+        amount: -requestedAmount,
+        currency: returnCurrency,
+        allocatedBy: session.user.id,
+        notes: `Return to bank ${teller.bank.name}${
+          notes ? ` - ${notes}` : ""
+        }${noteTag}`.trim(),
+        status: "ACTIVE",
+      },
+    });
+
+    const bankAllocation = await prisma.bankAllocation.create({
+      data: {
+        tenantId: tenant.id,
+        bankId: teller.bank.id,
+        amount: requestedAmount,
+        currency: returnCurrency,
+        allocatedBy: session.user.id,
+        notes: `Return from teller ${teller.name} (${teller.officeName})${
+          notes ? ` - ${notes}` : ""
+        }${noteTag}`.trim(),
+        status: "ACTIVE",
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      journalTransactionId,
+      cashAllocation,
+      bankAllocation,
+    });
+  } catch (error) {
+    console.error("Error returning cash to bank:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to return cash to bank",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tellers/[id]/route.ts
+++ b/app/api/tellers/[id]/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
-import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
-import { getGlAccountBalance } from "@/lib/gl-balance";
+import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { getTellerVaultDisplay } from "@/lib/gl-balance";
 
 /**
  * GET /api/tellers/[id]
@@ -133,104 +133,19 @@ export async function GET(
       return NextResponse.json({ error: "Teller not found" }, { status: 404 });
     }
 
-    // Calculate balances - available must DECREASE when loans are disbursed, and handle deposits
-    // allocatedToCashiers = cash currently in cashier tills; use netCash (current balance), not sumCashAllocation (cumulative)
+    // Vault & available balance come *only* from the Fineract GL account.
+    // When the GL is missing or Fineract is unreachable we return nulls so the
+    // UI can render NaN ("—") rather than a blended/local value.
     const orgCurrency = await getOrgDefaultCurrencyCode();
+    const vaultDisplay = await getTellerVaultDisplay(dbTeller);
+    const vaultBalance = vaultDisplay.vaultBalance;
+    const availableBalance = vaultDisplay.availableBalance;
+    const vaultBalanceSource = vaultDisplay.vaultBalanceSource;
+    const currency = vaultDisplay.currency || orgCurrency;
 
-    const localVaultBalance = dbTeller.cashAllocations.reduce(
-      (sum, alloc) => sum + alloc.amount,
-      0
-    );
-
-    // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
-    // Falls back to the local CashAllocation ledger if GL is not configured or Fineract is unreachable.
-    let vaultBalance = localVaultBalance;
-    let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
-    let glAccountBalance: {
-      balance: number;
-      currency: string;
-      source: string;
-      entryCount?: number;
-      error?: string;
-    } | null = null;
-    let currency = orgCurrency;
-
-    if (dbTeller.glAccountId) {
-      const glResult = await getGlAccountBalance(dbTeller.glAccountId);
-      if (
-        glResult.source === "fineract_calculated" ||
-        glResult.source === "fineract_empty"
-      ) {
-        vaultBalance = glResult.balance;
-        vaultBalanceSource = "fineract_gl";
-        currency = glResult.currency || orgCurrency;
-        glAccountBalance = {
-          balance: glResult.balance,
-          currency,
-          source: glResult.source,
-          entryCount: glResult.entryCount,
-        };
-      } else {
-        vaultBalanceSource = "local_fallback";
-        glAccountBalance = {
-          balance: localVaultBalance,
-          currency,
-          source: "local_fallback",
-          error: glResult.error,
-        };
-      }
-    }
-    
-    // Compute allocatedToCashiers: always include local DB allocations so we never undercount
-    // (Fineract may return 0 due to currency/timing; local allocations are source of truth for our allocations)
-    const cashierAllocationsForTeller = await prisma.cashAllocation.findMany({
-      where: {
-        tellerId: dbTeller.id,
-        tenantId: tenant.id,
-        cashierId: { not: null },
-        status: "ACTIVE",
-        notes: { not: { contains: "Variance" } },
-      },
-    });
-    const localAllocatedToCashiers = (() => {
-      const positiveSum = cashierAllocationsForTeller.reduce(
-        (sum, alloc) => sum + (alloc.amount > 0 ? alloc.amount : 0),
-        0
-      );
-      const netSum = cashierAllocationsForTeller.reduce((sum, alloc) => sum + alloc.amount, 0);
-      return Math.max(positiveSum, netSum);
-    })();
-
-    let allocatedToCashiers = localAllocatedToCashiers;
-    if (dbTeller.fineractTellerId) {
-      try {
-        const fineractService = await getFineractServiceWithSession();
-        const fineractCashiers = await fineractService.getCashiers(dbTeller.fineractTellerId);
-        let fineractAllocated = 0;
-        for (const fc of fineractCashiers) {
-          try {
-            const rawCurrency = await getOrgRawCurrencyCode();
-            const summary = await fineractService.getCashierSummaryAndTransactions(
-              dbTeller.fineractTellerId,
-              fc.id,
-              rawCurrency
-            );
-            fineractAllocated += summary.netCash ?? summary.sumCashAllocation ?? 0;
-          } catch (err) {
-            console.error(`Error getting Fineract summary for cashier ${fc.id}:`, err);
-          }
-        }
-        // Use the larger of Fineract or local to avoid undercounting (e.g. when Fineract returns 0)
-        allocatedToCashiers = Math.max(localAllocatedToCashiers, fineractAllocated);
-      } catch (err) {
-        console.error("Error fetching Fineract cashier balances, using local DB:", err);
-        // allocatedToCashiers already set from local
-      }
-    }
-
-    const availableBalance = vaultBalance - allocatedToCashiers;
-
-    // Prepare base response with database data
+    // Prepare base response with database data.
+    // `vaultBalance`/`availableBalance` are `null` when no GL is configured or
+    // Fineract is unreachable — the UI displays "—" in that case.
     const baseResponse = {
       id: dbTeller.id,
       name: dbTeller.name,
@@ -243,15 +158,14 @@ export async function GET(
       glAccountId: dbTeller.glAccountId,
       glAccountName: dbTeller.glAccountName,
       glAccountCode: dbTeller.glAccountCode,
-      currentAllocation: {
-        amount: availableBalance, // Show available balance, not vault balance
-        currency: currency,
-      },
-      vaultBalance: vaultBalance,
+      currentAllocation:
+        availableBalance != null
+          ? { amount: availableBalance, currency }
+          : null,
+      vaultBalance,
       vaultBalanceSource,
-      glAccountBalance,
-      availableBalance: availableBalance,
-      allocatedToCashiers: allocatedToCashiers,
+      glUnavailableReason: vaultDisplay.glUnavailableReason,
+      availableBalance,
       activeCashiers: dbTeller.cashiers.length,
       cashAllocations: dbTeller.cashAllocations,
       cashiers: dbTeller.cashiers,
@@ -277,9 +191,9 @@ export async function GET(
           officeName: fineractTeller.officeName || dbTeller.officeName,
           status: fineractTeller.status || dbTeller.status,
           vaultBalance: baseResponse.vaultBalance,
-          allocatedToCashiers: baseResponse.allocatedToCashiers,
           availableBalance: baseResponse.availableBalance,
           currentAllocation: baseResponse.currentAllocation,
+          vaultBalanceSource: baseResponse.vaultBalanceSource,
         });
       } catch (error) {
         console.error("Error fetching from Fineract:", error);

--- a/app/api/tellers/route.ts
+++ b/app/api/tellers/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
-import { getOrgDefaultCurrencyCode, getOrgRawCurrencyCode } from "@/lib/currency-utils";
-import { getGlAccountBalance } from "@/lib/gl-balance";
+import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import { getTellerVaultDisplay } from "@/lib/gl-balance";
 
 /**
  * GET /api/tellers
@@ -142,72 +142,15 @@ export async function GET(request: NextRequest) {
       })
     );
 
-    // Calculate balances - use max(Fineract, local) for allocatedToCashiers so we never undercount
+    // Balances come *only* from the Fineract GL account. When no GL is
+    // configured or Fineract is unreachable, vaultBalance/availableBalance
+    // are null and the UI renders "—".
     const dbTellerBalances = await Promise.all(
       dbTellers.map(async (dbTeller) => {
-        const localVaultBalance = dbTeller.cashAllocations.reduce(
-          (sum, alloc) => sum + alloc.amount,
-          0
-        );
-
-        // Prefer Fineract GL balance for the teller's vault when a GL account is linked.
-        // Falls back to the local CashAllocation ledger if GL is not configured or Fineract is unreachable.
-        let vaultBalance = localVaultBalance;
-        let vaultBalanceSource: "fineract_gl" | "local" | "local_fallback" = "local";
-        let vaultCurrency: string | null = null;
-        if (dbTeller.glAccountId) {
-          const glResult = await getGlAccountBalance(dbTeller.glAccountId);
-          if (glResult.source === "fineract_calculated" || glResult.source === "fineract_empty") {
-            vaultBalance = glResult.balance;
-            vaultBalanceSource = "fineract_gl";
-            vaultCurrency = glResult.currency;
-          } else {
-            vaultBalanceSource = "local_fallback";
-          }
-        }
-
-        const cashierAllocations = await prisma.cashAllocation.findMany({
-          where: {
-            tellerId: dbTeller.id,
-            tenantId: tenant.id,
-            cashierId: { not: null },
-            status: "ACTIVE",
-            notes: { not: { contains: "Variance" } },
-          },
-        });
-        const localAllocated = (() => {
-          const positiveSum = cashierAllocations.reduce(
-            (sum, alloc) => sum + (alloc.amount > 0 ? alloc.amount : 0),
-            0
-          );
-          const netSum = cashierAllocations.reduce((sum, alloc) => sum + alloc.amount, 0);
-          return Math.max(positiveSum, netSum);
-        })();
-
-        let allocatedToCashiers = localAllocated;
-        const fineractCashiers = tellerCashiersMap.get(dbTeller.fineractTellerId!) || [];
-        if (fineractCashiers.length > 0) {
-          const summaries = await Promise.all(
-            fineractCashiers.map(async (fc: any) => {
-              try {
-                const rawCurrency = await getOrgRawCurrencyCode();
-                const summary = await fineractService.getCashierSummaryAndTransactions(
-                  dbTeller.fineractTellerId!,
-                  fc.id,
-                  rawCurrency
-                );
-                return summary.netCash ?? summary.sumCashAllocation ?? 0;
-              } catch (err) {
-                return 0;
-              }
-            })
-          );
-          const fineractAllocated = summaries.reduce((sum, val) => sum + val, 0);
-          allocatedToCashiers = Math.max(localAllocated, fineractAllocated);
-        }
-
-        const availableBalance = vaultBalance - allocatedToCashiers;
-        const currency = vaultCurrency || orgCurrency;
+        const vaultDisplay = await getTellerVaultDisplay(dbTeller);
+        const fineractCashiers =
+          tellerCashiersMap.get(dbTeller.fineractTellerId!) || [];
+        const currency = vaultDisplay.currency || orgCurrency;
 
         return {
           fineractTellerId: dbTeller.fineractTellerId,
@@ -217,11 +160,13 @@ export async function GET(request: NextRequest) {
           glAccountId: dbTeller.glAccountId,
           glAccountName: dbTeller.glAccountName,
           glAccountCode: dbTeller.glAccountCode,
-          vaultBalance,
-          vaultBalanceSource,
-          availableBalance,
-          allocatedToCashiers,
-          currentAllocation: { amount: availableBalance, currency },
+          vaultBalance: vaultDisplay.vaultBalance,
+          vaultBalanceSource: vaultDisplay.vaultBalanceSource,
+          availableBalance: vaultDisplay.availableBalance,
+          currentAllocation:
+            vaultDisplay.availableBalance != null
+              ? { amount: vaultDisplay.availableBalance, currency }
+              : null,
           activeCashiers: fineractCashiers.length,
           settlementCount: dbTeller._count.settlements,
         };
@@ -255,7 +200,6 @@ export async function GET(request: NextRequest) {
           vaultBalance: dbData.vaultBalance,
           vaultBalanceSource: dbData.vaultBalanceSource,
           availableBalance: dbData.availableBalance,
-          allocatedToCashiers: dbData.allocatedToCashiers,
           settlementCount: dbData.settlementCount,
         }),
         // Use Fineract cashier count (already set above)

--- a/lib/gl-balance.ts
+++ b/lib/gl-balance.ts
@@ -69,3 +69,72 @@ export async function getGlAccountBalance(
     };
   }
 }
+
+/**
+ * The displayed vault balance for a teller is sourced *only* from Fineract.
+ * No local-ledger fallback, no subtraction of local allocations — when the GL
+ * value is unavailable, the consumer renders NaN ("—").
+ */
+export type TellerVaultDisplaySource = "fineract_gl" | "unavailable";
+
+export interface TellerVaultDisplay {
+  vaultBalance: number | null;
+  availableBalance: number | null;
+  vaultBalanceSource: TellerVaultDisplaySource;
+  currency: string | null;
+  glAccountId: number | null;
+  glAccountCode: string | null;
+  glAccountName: string | null;
+  glUnavailableReason?: "not_configured" | "fineract_unreachable";
+  glError?: string;
+}
+
+/**
+ * Resolve the teller vault balance for display purposes from the Fineract GL
+ * account *only*. Available = vault (no subtraction of cashier allocations).
+ * Returns `null` for both values when no GL is configured or Fineract is
+ * unreachable, so the caller can render NaN / "—".
+ */
+export async function getTellerVaultDisplay(teller: {
+  glAccountId: number | null;
+  glAccountCode: string | null;
+  glAccountName: string | null;
+}): Promise<TellerVaultDisplay> {
+  const baseGl = {
+    glAccountId: teller.glAccountId,
+    glAccountCode: teller.glAccountCode,
+    glAccountName: teller.glAccountName,
+  };
+
+  if (!teller.glAccountId) {
+    return {
+      vaultBalance: null,
+      availableBalance: null,
+      vaultBalanceSource: "unavailable",
+      currency: null,
+      glUnavailableReason: "not_configured",
+      ...baseGl,
+    };
+  }
+
+  const r = await getGlAccountBalance(teller.glAccountId);
+  if (r.source === "fineract_calculated" || r.source === "fineract_empty") {
+    return {
+      vaultBalance: r.balance,
+      availableBalance: r.balance,
+      vaultBalanceSource: "fineract_gl",
+      currency: r.currency,
+      ...baseGl,
+    };
+  }
+
+  return {
+    vaultBalance: null,
+    availableBalance: null,
+    vaultBalanceSource: "unavailable",
+    currency: null,
+    glUnavailableReason: "fineract_unreachable",
+    glError: r.error,
+    ...baseGl,
+  };
+}


### PR DESCRIPTION
Display teller vault balance strictly from Fineract GL (no blended local fallback). When the GL is missing or unreachable we now show a dash instead of an inflated local-only number.

Adds a proper Return to Bank flow:

- New POST /api/tellers/[id]/return-to-bank endpoint posts a Fineract journal entry (DEBIT bank GL, CREDIT teller GL), writes a positive BankAllocation row and a negative CashAllocation row so both the bank and teller local history reflect the movement.
- New ReturnToBankModal component plus a Return to Bank button on the teller detail page, enabled only when the teller, parent bank and both GL accounts are configured and the vault has funds.
- getTellerFromFineract now returns the linked bank id, name and GL so the UI can gate the button correctly.