### PR TITLE
feat(tellers): pick destination bank when returning cash

### DIFF
--- a/app/(application)/tellers/[id]/components/teller-actions.tsx
+++ b/app/(application)/tellers/[id]/components/teller-actions.tsx
@@ -48,18 +48,17 @@ export function TellerActions({
   const [showReturnModal, setShowReturnModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
 
+  // The destination bank is now picked inside the modal, so we only require
+  // the teller side here (GL + readable vault with funds). The modal/API will
+  // surface clearer errors if the chosen bank is missing a GL.
   const canReturnToBank =
     !!teller.glAccountId &&
-    !!teller.bankId &&
-    !!teller.bankGlAccountId &&
     teller.vaultBalanceSource === "fineract_gl" &&
     typeof teller.vaultBalance === "number" &&
     teller.vaultBalance > 0;
 
   const returnDisabledReason = (() => {
     if (!teller.glAccountId) return "Teller has no GL account configured.";
-    if (!teller.bankId) return "Teller is not linked to a parent bank.";
-    if (!teller.bankGlAccountId) return "Parent bank has no GL account configured.";
     if (teller.vaultBalanceSource !== "fineract_gl")
       return "Vault balance is unavailable.";
     if (!teller.vaultBalance || teller.vaultBalance <= 0)
@@ -116,7 +115,8 @@ export function TellerActions({
       <ReturnToBankModal
         tellerId={tellerId}
         tellerName={tellerName}
-        bankName={teller.bankName}
+        defaultBankId={teller.bankId ?? null}
+        defaultBankName={teller.bankName ?? null}
         vaultBalance={teller.vaultBalance ?? null}
         currency={teller.currency ?? null}
         open={showReturnModal}

--- a/app/(application)/tellers/components/return-to-bank-modal.tsx
+++ b/app/(application)/tellers/components/return-to-bank-modal.tsx
@@ -23,7 +23,8 @@ interface ReturnToBankModalProps {
   onOpenChange: (open: boolean) => void;
   tellerId: string;
   tellerName?: string;
-  bankName?: string | null;
+  defaultBankId?: string | null;
+  defaultBankName?: string | null;
   vaultBalance?: number | null;
   currency?: string | null;
   onSuccess?: () => void;
@@ -34,20 +35,33 @@ interface Currency {
   name: string;
 }
 
+interface BankOption {
+  id: string;
+  name: string;
+  code: string;
+  glAccountId: number | null;
+  glAccountCode: string | null;
+  status: string;
+  isActive: boolean;
+}
+
 export function ReturnToBankModal({
   open,
   onOpenChange,
   tellerId,
   tellerName,
-  bankName,
+  defaultBankId,
+  defaultBankName,
   vaultBalance,
   currency: tellerCurrency,
   onSuccess,
-}: ReturnToBankModalProps) {
+}: Readonly<ReturnToBankModalProps>) {
   const { currencyCode: orgCurrency } = useCurrency();
   const [loading, setLoading] = useState(false);
   const [currencies, setCurrencies] = useState<Currency[]>([]);
   const [loadingCurrencies, setLoadingCurrencies] = useState(false);
+  const [banks, setBanks] = useState<BankOption[]>([]);
+  const [loadingBanks, setLoadingBanks] = useState(false);
   const [result, setResult] = useState<{
     success: boolean;
     message: string;
@@ -57,6 +71,7 @@ export function ReturnToBankModal({
     amount: "",
     currency: tellerCurrency || orgCurrency,
     notes: "",
+    bankId: defaultBankId || "",
   });
 
   useEffect(() => {
@@ -66,10 +81,12 @@ export function ReturnToBankModal({
         amount: "",
         currency: tellerCurrency || orgCurrency,
         notes: "",
+        bankId: defaultBankId || "",
       });
       fetchCurrencies();
+      fetchBanks();
     }
-  }, [open, tellerCurrency, orgCurrency]);
+  }, [open, tellerCurrency, orgCurrency, defaultBankId]);
 
   const fetchCurrencies = async () => {
     setLoadingCurrencies(true);
@@ -93,22 +110,43 @@ export function ReturnToBankModal({
     }
   };
 
+  const fetchBanks = async () => {
+    setLoadingBanks(true);
+    try {
+      const response = await fetch("/api/banks?status=ACTIVE");
+      if (response.ok) {
+        const data = await response.json();
+        const list: BankOption[] = Array.isArray(data) ? data : [];
+        // Only banks that have a GL account can receive a return.
+        setBanks(list.filter((b) => b.glAccountId && b.isActive !== false));
+      }
+    } catch (e) {
+      console.error("Error fetching banks:", e);
+    } finally {
+      setLoadingBanks(false);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setResult(null);
 
-    const amountNum = parseFloat(formData.amount);
+    const amountNum = Number.parseFloat(formData.amount);
     if (!amountNum || amountNum <= 0) {
       setResult({ success: false, message: "Enter an amount greater than 0." });
       return;
     }
-    if (
-      typeof vaultBalance === "number" &&
-      amountNum > vaultBalance
-    ) {
+    if (!formData.bankId) {
       setResult({
         success: false,
-        message: `Amount exceeds the teller's vault balance (${vaultBalance.toLocaleString(
+        message: "Select a destination bank.",
+      });
+      return;
+    }
+    if (typeof vaultBalance === "number" && amountNum > vaultBalance) {
+      setResult({
+        success: false,
+        message: `Amount exceeds the teller vault balance (${vaultBalance.toLocaleString(
           undefined,
           { minimumFractionDigits: 2, maximumFractionDigits: 2 }
         )} ${formData.currency}).`,
@@ -125,6 +163,7 @@ export function ReturnToBankModal({
           amount: amountNum,
           currency: formData.currency,
           notes: formData.notes,
+          bankId: formData.bankId,
         }),
       });
 
@@ -138,12 +177,17 @@ export function ReturnToBankModal({
         return;
       }
 
+      const selectedBank = banks.find((b) => b.id === formData.bankId);
+      const destinationName =
+        selectedBank?.name ||
+        (formData.bankId === defaultBankId ? defaultBankName : null) ||
+        "bank";
       setResult({
         success: true,
         message: `Returned ${amountNum.toLocaleString(undefined, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
-        })} ${formData.currency} to ${bankName || "bank"}.`,
+        })} ${formData.currency} to ${destinationName}.`,
         transactionId: data.journalTransactionId,
       });
       setTimeout(() => {
@@ -170,10 +214,11 @@ export function ReturnToBankModal({
             Return Cash to Bank
           </DialogTitle>
           <DialogDescription>
-            Move cash from {tellerName || "this teller"} back to{" "}
-            <span className="font-medium">{bankName || "its parent bank"}</span>
-            . A Fineract journal entry will be posted (DEBIT bank GL, CREDIT
-            teller GL).
+            Move cash from {tellerName || "this teller"} back to a bank. Defaults
+            to the teller&apos;s parent bank
+            {defaultBankName ? ` (${defaultBankName})` : ""} but you can pick
+            any other configured bank. A Fineract journal entry will be posted
+            (DEBIT destination bank GL, CREDIT teller GL).
           </DialogDescription>
         </DialogHeader>
 
@@ -212,6 +257,34 @@ export function ReturnToBankModal({
 
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="bank">Destination Bank *</Label>
+              <SearchableSelect
+                options={banks.map((b) => {
+                  const label = `${b.name}${b.code ? ` (${b.code})` : ""}${
+                    b.id === defaultBankId ? " — default" : ""
+                  }`;
+                  return { value: b.id, label };
+                })}
+                value={formData.bankId}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, bankId: value })
+                }
+                placeholder={
+                  loadingBanks ? "Loading banks..." : "Select destination bank"
+                }
+                emptyMessage="No banks with GL accounts found"
+                disabled={loadingBanks || loading}
+              />
+              {formData.bankId &&
+                defaultBankId &&
+                formData.bankId !== defaultBankId && (
+                  <p className="text-xs text-amber-600">
+                    Not the teller&apos;s parent bank — cash will be returned to
+                    a different bank.
+                  </p>
+                )}
+            </div>
             <div className="space-y-2">
               <Label htmlFor="amount">Amount *</Label>
               <Input

--- a/app/api/tellers/[id]/return-to-bank/route.ts
+++ b/app/api/tellers/[id]/return-to-bank/route.ts
@@ -39,7 +39,7 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { amount, currency, notes } = body;
+    const { amount, currency, notes, bankId: requestedBankId } = body;
 
     if (!amount || amount <= 0) {
       return NextResponse.json(
@@ -74,22 +74,41 @@ export async function POST(
         { status: 400 }
       );
     }
-    if (!teller.bankId || !teller.bank) {
+
+    // Resolve destination bank: explicit bankId overrides teller's parent bank.
+    // When no override is provided we fall back to the teller's parent bank.
+    let destinationBank = teller.bank;
+    if (requestedBankId && requestedBankId !== teller.bankId) {
+      destinationBank = await prisma.bank.findFirst({
+        where: { id: requestedBankId, tenantId: tenant.id },
+      });
+      if (!destinationBank) {
+        return NextResponse.json(
+          {
+            error: "Destination bank not found",
+            details: "The selected bank does not exist for this tenant.",
+          },
+          { status: 404 }
+        );
+      }
+    }
+
+    if (!destinationBank) {
       return NextResponse.json(
         {
-          error: "Teller is not linked to a parent bank",
+          error: "No destination bank available",
           details:
-            "Link this teller to a bank (Edit Teller) before returning cash.",
+            "Select a bank to return cash to, or link this teller to a parent bank.",
         },
         { status: 400 }
       );
     }
-    if (!teller.bank.glAccountId) {
+
+    if (!destinationBank.glAccountId) {
       return NextResponse.json(
         {
-          error: "Parent bank has no GL account configured",
-          details:
-            "Assign a GL account to the parent bank before returning cash from a teller.",
+          error: "Destination bank has no GL account configured",
+          details: `Bank "${destinationBank.name}" needs a GL account before cash can be returned to it.`,
         },
         { status: 400 }
       );
@@ -158,17 +177,17 @@ export async function POST(
       const journalResult = await fetchFineractAPI("/journalentries", {
         method: "POST",
         body: JSON.stringify({
-          officeId: teller.officeId,
+          officeId: destinationBank.officeId ?? teller.officeId,
           transactionDate: fineractDate,
           currencyCode: returnCurrency,
           debits: [
-            { glAccountId: teller.bank.glAccountId, amount: requestedAmount },
+            { glAccountId: destinationBank.glAccountId, amount: requestedAmount },
           ],
           credits: [
             { glAccountId: teller.glAccountId, amount: requestedAmount },
           ],
           comments: `Return from teller ${teller.name} to bank ${
-            teller.bank.name
+            destinationBank.name
           }${notes ? ` - ${notes}` : ""}`.trim(),
           referenceNumber: `TELLER-RETURN-${teller.id}-${Date.now()}`,
           locale: "en",
@@ -206,7 +225,7 @@ export async function POST(
         amount: -requestedAmount,
         currency: returnCurrency,
         allocatedBy: session.user.id,
-        notes: `Return to bank ${teller.bank.name}${
+        notes: `Return to bank ${destinationBank.name}${
           notes ? ` - ${notes}` : ""
         }${noteTag}`.trim(),
         status: "ACTIVE",
@@ -216,7 +235,7 @@ export async function POST(
     const bankAllocation = await prisma.bankAllocation.create({
       data: {
         tenantId: tenant.id,
-        bankId: teller.bank.id,
+        bankId: destinationBank.id,
         amount: requestedAmount,
         currency: returnCurrency,
         allocatedBy: session.user.id,


### PR DESCRIPTION
The Return to Bank flow used to lock the destination to the teller parent bank. Now the modal renders a Destination Bank selector populated from active banks that have a GL account configured. It defaults to the parent bank (clearly tagged), and an inline hint warns when a non-parent bank is selected.

- API now accepts an optional bankId in the body and validates the destination bank (tenant scope + GL account). The journal entry, BankAllocation row and CashAllocation note all reference the selected destination bank, not the parent bank.
- Button gating loosened: only requires the teller GL plus a readable non-zero vault. The destination bank is chosen in the modal.