### PR TITLE
fix(docker): include templates directory in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN chown nextjs:nodejs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/templates ./templates
 
 USER nextjs
 

--- a/app/(application)/reports/[reportName]/page.tsx
+++ b/app/(application)/reports/[reportName]/page.tsx
@@ -788,7 +788,10 @@ export default function ReportDetailPage() {
                     <TableHeader>
                       <TableRow>
                         {reportData.columnHeaders.map((header, index) => (
-                          <TableHead key={index} className="font-medium">
+                          <TableHead
+                            key={index}
+                            className="font-medium border-r border-border last:border-r-0"
+                          >
                             {header.columnName}
                           </TableHead>
                         ))}
@@ -798,7 +801,10 @@ export default function ReportDetailPage() {
                       {reportData.data.slice(0, 100).map((item, rowIndex) => (
                         <TableRow key={rowIndex}>
                           {item.row.map((cell, cellIndex) => (
-                            <TableCell key={cellIndex}>
+                            <TableCell
+                              key={cellIndex}
+                              className="border-r border-border last:border-r-0"
+                            >
                               {formatCellValue(cell)}
                             </TableCell>
                           ))}


### PR DESCRIPTION
## Summary
- Adds `COPY --from=builder --chown=nextjs:nodejs /app/templates ./templates` to the Dockerfile runner stage
- The `templates/` directory (rulethu and omama contract HTML files) was never copied into the container, so `fs.existsSync` always returned false at runtime
- This caused the contract template API to return `null` html, making the UI silently fall back to the generic Goodfellow contract for all tenants using local file templates (including rulethu at `rulethu.kenacloanmatrix.com`)
- Also includes minor report table column border styling

## Test plan
- [ ] Deploy to rulethu tenant and verify the contract tab shows the Rulethu Acknowledgement of Debt template instead of the Goodfellow contract
- [ ] Verify omama tenant contract still loads correctly
- [ ] Verify tenants with DB-stored templates are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)