### PR TITLE
feat(access): add role and office access controls

### DIFF
--- a/app/(application)/banks/page.tsx
+++ b/app/(application)/banks/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Plus, Download } from "lucide-react";
+import { Plus, Download, Building2 } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -7,11 +7,17 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { BanksTable } from "./components/banks-table";
+import { getOfficeVisibilityScope } from "@/lib/office-access";
 
-export default function BanksPage() {
+export default async function BanksPage() {
+  const scope = await getOfficeVisibilityScope();
+  const scopedToBranch = scope.kind === "office";
+  const titleSuffix = scopedToBranch ? ` — ${scope.officeName}` : "";
+
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -41,10 +47,19 @@ export default function BanksPage() {
       {/* Banks Table */}
       <Card>
         <CardHeader>
-          <CardTitle>All Banks</CardTitle>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle>All Banks{titleSuffix}</CardTitle>
+            {scopedToBranch && (
+              <Badge variant="outline" className="gap-1 text-xs font-normal">
+                <Building2 className="h-3 w-3" />
+                Branch view: {scope.officeName}
+              </Badge>
+            )}
+          </div>
           <CardDescription>
-            Manage banks, allocate funds, and assign tellers. Banks are the top
-            level of the cash management hierarchy.
+            {scopedToBranch
+              ? `Showing banks assigned to ${scope.officeName}. Other branches are not visible to your role.`
+              : "Manage banks, allocate funds, and assign tellers. Banks are the top level of the cash management hierarchy."}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/(application)/leads/[id]/page.tsx
+++ b/app/(application)/leads/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   UserX,
   CheckCircle2,
   XCircle,
+  Lock,
 } from "lucide-react";
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
@@ -27,6 +28,11 @@ import {
 import { canPrintLoanContract } from "@/lib/loan-contract-print";
 import { getFacilityLoanLink } from "@/lib/fineract-credit-facility";
 import { isCreditFacilityEnabled } from "@/lib/tenant-features";
+import {
+  decideLeadAccess,
+  describeLeadAccess,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 const FINERACT_BASE_URL = process.env.FINERACT_BASE_URL || "http://10.10.0.143";
 
@@ -425,7 +431,23 @@ export default async function LeadDetailPage({
     currentUserId != null &&
     lead?.assignedToUserId != null &&
     String(lead.assignedToUserId) === currentUserId;
-  const isReadOnly = !isAssignedUser;
+
+  // Role-based visibility check (loan officer / branch manager / admin). If the
+  // user has read-only access we still render the page but show a banner.
+  let accessBannerMessage: string | null = null;
+  let isReadOnlyFromAccess = false;
+  if (lead?.tenantId) {
+    const scope = await getLeadVisibilityScope(lead.tenantId);
+    const accessDecision = decideLeadAccess(scope, lead);
+    if (accessDecision.level !== "full") {
+      isReadOnlyFromAccess = true;
+      accessBannerMessage = describeLeadAccess(accessDecision);
+    }
+  }
+
+  // Existing rule: only the assignee can edit. Combine with role-based access
+  // so out-of-scope viewers also land in read-only mode.
+  const isReadOnly = !isAssignedUser || isReadOnlyFromAccess;
   const canEditPendingLoanTerms =
     isPendingLoanApplicationEditTenant(tenantSlug) &&
     canEditPendingLoanApplication(session, fineractLoanStatus);
@@ -486,6 +508,17 @@ export default async function LeadDetailPage({
           <span className="text-muted-foreground/50">/</span>
           <span className="text-foreground font-medium">Lead #{id}</span>
         </nav>
+
+        {/* Read-only access banner (e.g. loan officer viewing a colleague's lead) */}
+        {accessBannerMessage && (
+          <div
+            role="status"
+            className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200 sm:text-sm"
+          >
+            <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{accessBannerMessage}</span>
+          </div>
+        )}
 
         {/* Header */}
         <div className="flex items-start gap-3">

--- a/app/(application)/leads/components/leads-status-tabs.tsx
+++ b/app/(application)/leads/components/leads-status-tabs.tsx
@@ -586,22 +586,11 @@ export function LeadsStatusTabs() {
     return { type: "all" as const, label: "All Leads" };
   }, [session, useOmamaOfficeAdminDashboard, isAdminUser, hasRole, userOfficeName, userName]);
 
-  // Filter data based on user's role scope
-  const getRoleScopedData = useCallback((data: any[]): any[] => {
-    if (!data || userFilterScope.type === "all") return data;
-    
-    return data.filter((row) => {
-      if (userFilterScope.type === "branch") {
-        const branch = row.branch || row.Branch || row.office || row.Office || "";
-        return String(branch).trim().toLowerCase() === String(userFilterScope.value).trim().toLowerCase();
-      }
-      if (userFilterScope.type === "user") {
-        const submittedBy = row.submitted_by || row.created_by || row["Submitted By"] || row["Created By"] || row.loan_officer || "";
-        return String(submittedBy).toLowerCase().includes(String(userFilterScope.value).toLowerCase());
-      }
-      return true;
-    });
-  }, [userFilterScope]);
+  // Server-side enforcement (lib/lead-access.ts) is the source of truth for
+  // which rows the user is allowed to see. `userFilterScope` is now only used
+  // for the visible "My Leads" / "Branch" label; we no longer client-filter
+  // the data so this is effectively an identity function.
+  const getRoleScopedData = useCallback((data: any[]): any[] => data ?? [], []);
 
   // Debug: Log role detection
   useEffect(() => {

--- a/app/(application)/organization/features/page.tsx
+++ b/app/(application)/organization/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Card,
   CardContent,
@@ -13,12 +13,19 @@ import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2, AlertCircle, CheckCircle2, Users } from "lucide-react";
 import {
   setupCreditFacilityDatatables,
   setupCreditFacilityReports,
 } from "@/app/actions/credit-facility-actions";
-import type { TenantFeatures } from "@/shared/types/tenant";
+import type { RoleFeatureOverrides, TenantFeatures } from "@/shared/types/tenant";
 
 interface FeatureConfig {
   key: keyof TenantFeatures;
@@ -110,15 +117,47 @@ const FEATURE_CONFIGS: FeatureConfig[] = [
   },
 ];
 
+interface FineractRole {
+  id: number;
+  name: string;
+  disabled?: boolean;
+}
+
+// Mirror lib/feature-flags.normalizeRoleName so the UI keys match what the API stores.
+function normalizeRoleName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
 export default function FeaturesSettingsPage() {
-  const [features, setFeatures] = useState<TenantFeatures | null>(null);
+  // Global tenant defaults (raw, before any role override is applied).
+  const [globalFeatures, setGlobalFeatures] = useState<TenantFeatures | null>(
+    null
+  );
+  // Per-role overrides keyed by normalized role name.
+  const [roleOverrides, setRoleOverrides] = useState<RoleFeatureOverrides>({});
+  // Available Fineract roles for the per-role dropdown.
+  const [roles, setRoles] = useState<FineractRole[]>([]);
+  const [selectedRoleName, setSelectedRoleName] = useState<string | null>(null);
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<keyof TenantFeatures | null>(null);
+  const [savingOverrideKey, setSavingOverrideKey] = useState<string | null>(
+    null
+  );
   const [error, setError] = useState<string | null>(null);
   const [savedKey, setSavedKey] = useState<keyof TenantFeatures | null>(null);
-  const [setupStatus, setSetupStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+
+  const [setupStatus, setSetupStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
   const [setupError, setSetupError] = useState<string | null>(null);
-  const [reportsStatus, setReportsStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [reportsStatus, setReportsStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
   const [reportsError, setReportsError] = useState<string | null>(null);
 
   const fetchFeatures = useCallback(async () => {
@@ -126,7 +165,8 @@ export default function FeaturesSettingsPage() {
       const res = await fetch("/api/tenant/features");
       if (!res.ok) throw new Error("Failed to load features");
       const data = await res.json();
-      setFeatures(data.features);
+      setGlobalFeatures(data.global ?? data.features);
+      setRoleOverrides(data.roleFeatureOverrides ?? {});
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -134,18 +174,36 @@ export default function FeaturesSettingsPage() {
     }
   }, []);
 
+  const fetchRoles = useCallback(async () => {
+    try {
+      const res = await fetch("/api/tenant/roles");
+      if (!res.ok) return;
+      const data = await res.json();
+      const list: FineractRole[] = Array.isArray(data?.roles) ? data.roles : [];
+      setRoles(list);
+      if (!selectedRoleName && list.length > 0) {
+        setSelectedRoleName(normalizeRoleName(list[0].name));
+      }
+    } catch (err) {
+      console.error("Error loading roles:", err);
+    }
+  }, [selectedRoleName]);
+
   useEffect(() => {
     fetchFeatures();
-  }, [fetchFeatures]);
+    fetchRoles();
+  }, [fetchFeatures, fetchRoles]);
 
-  const handleToggle = async (key: keyof TenantFeatures, value: boolean) => {
-    if (!features) return;
+  // ----- Global toggle handler -----------------------------------------------
+  const handleToggleGlobal = async (
+    key: keyof TenantFeatures,
+    value: boolean
+  ) => {
+    if (!globalFeatures) return;
     setSaving(key);
     setError(null);
-
-    const optimistic = { ...features, [key]: value };
-    setFeatures(optimistic);
-
+    const optimistic = { ...globalFeatures, [key]: value };
+    setGlobalFeatures(optimistic);
     try {
       const res = await fetch("/api/tenant/features", {
         method: "PUT",
@@ -157,17 +215,81 @@ export default function FeaturesSettingsPage() {
         throw new Error(data.error || "Failed to save");
       }
       const data = await res.json();
-      setFeatures(data.features);
+      setGlobalFeatures(data.global ?? data.features);
+      setRoleOverrides(data.roleFeatureOverrides ?? {});
       setSavedKey(key);
       setTimeout(() => setSavedKey(null), 2000);
     } catch (err) {
-      setFeatures({ ...features });
-      setError(err instanceof Error ? err.message : "Failed to save feature flag");
+      setGlobalFeatures({ ...globalFeatures });
+      setError(
+        err instanceof Error ? err.message : "Failed to save feature flag"
+      );
     } finally {
       setSaving(null);
     }
   };
 
+  // ----- Per-role override handler -------------------------------------------
+  /**
+   * `next` semantics:
+   *   - true  -> force-enable this feature for the role
+   *   - false -> force-disable this feature for the role
+   *   - undefined -> inherit (clear the override for this key)
+   */
+  const handleSetOverride = async (
+    roleName: string,
+    key: keyof TenantFeatures,
+    next: boolean | undefined
+  ) => {
+    const normalized = normalizeRoleName(roleName);
+    if (!normalized) return;
+    const overrideKey = `${normalized}:${key}`;
+    setSavingOverrideKey(overrideKey);
+    setError(null);
+
+    // Optimistic local update.
+    const previousOverrides = roleOverrides;
+    const nextOverrides: RoleFeatureOverrides = { ...previousOverrides };
+    const currentForRole = { ...(nextOverrides[normalized] ?? {}) };
+    if (next === undefined) {
+      delete (currentForRole as Record<string, unknown>)[key];
+    } else {
+      (currentForRole as Record<string, boolean>)[key] = next;
+    }
+    if (Object.keys(currentForRole).length === 0) {
+      delete nextOverrides[normalized];
+    } else {
+      nextOverrides[normalized] = currentForRole;
+    }
+    setRoleOverrides(nextOverrides);
+
+    try {
+      // The server normalizes undefined -> "clear" within a Partial<TenantFeatures>.
+      const payloadValue: Record<string, boolean | undefined> = {
+        [key]: next,
+      };
+      const res = await fetch("/api/tenant/features", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          roleFeatureOverrides: { [normalized]: payloadValue },
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to save override");
+      }
+      const data = await res.json();
+      setRoleOverrides(data.roleFeatureOverrides ?? {});
+    } catch (err) {
+      setRoleOverrides(previousOverrides);
+      setError(err instanceof Error ? err.message : "Failed to save override");
+    } finally {
+      setSavingOverrideKey(null);
+    }
+  };
+
+  // ----- Setup actions (unchanged) -------------------------------------------
   const handleSetupDatatables = async () => {
     setSetupStatus("loading");
     setSetupError(null);
@@ -194,6 +316,20 @@ export default function FeaturesSettingsPage() {
     }
   };
 
+  // ----- Derived values for the per-role section -----------------------------
+  const overridesForSelectedRole = useMemo<Partial<TenantFeatures>>(() => {
+    if (!selectedRoleName) return {};
+    return roleOverrides[selectedRoleName] ?? {};
+  }, [roleOverrides, selectedRoleName]);
+
+  const overrideCounts = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const [role, overrides] of Object.entries(roleOverrides)) {
+      out[role] = Object.keys(overrides).length;
+    }
+    return out;
+  }, [roleOverrides]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
@@ -203,11 +339,12 @@ export default function FeaturesSettingsPage() {
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-3xl space-y-6">
       <div>
         <h1 className="text-xl font-semibold">Feature Flags</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Enable or disable product features for this tenant.
+          Enable or disable product features globally and, optionally, override
+          them per role.
         </p>
       </div>
 
@@ -243,8 +380,12 @@ export default function FeaturesSettingsPage() {
               disabled={setupStatus === "loading"}
               className="shrink-0"
             >
-              {setupStatus === "loading" && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />}
-              {setupStatus === "success" && <CheckCircle2 className="h-3.5 w-3.5 text-green-500 mr-1.5" />}
+              {setupStatus === "loading" && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+              )}
+              {setupStatus === "success" && (
+                <CheckCircle2 className="h-3.5 w-3.5 text-green-500 mr-1.5" />
+              )}
               {setupStatus === "success" ? "Done" : "Run Setup"}
             </Button>
           </div>
@@ -265,8 +406,12 @@ export default function FeaturesSettingsPage() {
               disabled={reportsStatus === "loading"}
               className="shrink-0"
             >
-              {reportsStatus === "loading" && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />}
-              {reportsStatus === "success" && <CheckCircle2 className="h-3.5 w-3.5 text-green-500 mr-1.5" />}
+              {reportsStatus === "loading" && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+              )}
+              {reportsStatus === "success" && (
+                <CheckCircle2 className="h-3.5 w-3.5 text-green-500 mr-1.5" />
+              )}
               {reportsStatus === "success" ? "Done" : "Run Setup"}
             </Button>
           </div>
@@ -275,14 +420,15 @@ export default function FeaturesSettingsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Products &amp; Modules</CardTitle>
+          <CardTitle className="text-sm font-medium">Products &amp; Modules (Global)</CardTitle>
           <CardDescription className="text-xs">
-            Changes take effect immediately for all users.
+            These flags apply to everyone in the tenant. Use the section below
+            to override individual features for specific roles.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {FEATURE_CONFIGS.map((config) => {
-            const value = features?.[config.key] ?? false;
+            const value = globalFeatures?.[config.key] ?? false;
             const isSaving = saving === config.key;
             const isSaved = savedKey === config.key;
 
@@ -293,7 +439,10 @@ export default function FeaturesSettingsPage() {
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <Label htmlFor={`feature-${config.key}`} className="text-sm font-medium cursor-pointer">
+                    <Label
+                      htmlFor={`feature-${config.key}`}
+                      className="text-sm font-medium cursor-pointer"
+                    >
                       {config.label}
                     </Label>
                     {config.tag && (
@@ -305,14 +454,20 @@ export default function FeaturesSettingsPage() {
                       <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground mt-0.5">{config.description}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {config.description}
+                  </p>
                 </div>
                 <div className="flex items-center gap-2 shrink-0 pt-0.5">
-                  {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+                  {isSaving && (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                  )}
                   <Switch
                     id={`feature-${config.key}`}
                     checked={value}
-                    onCheckedChange={(checked) => handleToggle(config.key, checked)}
+                    onCheckedChange={(checked) =>
+                      handleToggleGlobal(config.key, checked)
+                    }
                     disabled={isSaving}
                   />
                 </div>
@@ -321,6 +476,199 @@ export default function FeaturesSettingsPage() {
           })}
         </CardContent>
       </Card>
+
+      <RoleOverridesCard
+        roles={roles}
+        selectedRoleName={selectedRoleName}
+        setSelectedRoleName={setSelectedRoleName}
+        overridesForSelectedRole={overridesForSelectedRole}
+        overrideCounts={overrideCounts}
+        globalFeatures={globalFeatures}
+        savingOverrideKey={savingOverrideKey}
+        onSetOverride={handleSetOverride}
+      />
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-role override card
+// ---------------------------------------------------------------------------
+
+interface RoleOverridesCardProps {
+  roles: FineractRole[];
+  selectedRoleName: string | null;
+  setSelectedRoleName: (name: string | null) => void;
+  overridesForSelectedRole: Partial<TenantFeatures>;
+  overrideCounts: Record<string, number>;
+  globalFeatures: TenantFeatures | null;
+  savingOverrideKey: string | null;
+  onSetOverride: (
+    roleName: string,
+    key: keyof TenantFeatures,
+    next: boolean | undefined
+  ) => void | Promise<void>;
+}
+
+function RoleOverridesCard(props: RoleOverridesCardProps) {
+  const {
+    roles,
+    selectedRoleName,
+    setSelectedRoleName,
+    overridesForSelectedRole,
+    overrideCounts,
+    globalFeatures,
+    savingOverrideKey,
+    onSetOverride,
+  } = props;
+
+  const selectedRole = roles.find(
+    (r) => normalizeRoleName(r.name) === selectedRoleName
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm font-medium">
+              Per-Role Overrides
+            </CardTitle>
+          </div>
+          <div className="flex items-center gap-2">
+            <Select
+              value={selectedRoleName ?? undefined}
+              onValueChange={(v) => setSelectedRoleName(v)}
+            >
+              <SelectTrigger className="w-[220px]">
+                <SelectValue placeholder="Select a role…" />
+              </SelectTrigger>
+              <SelectContent>
+                {roles.map((r) => {
+                  const normalized = normalizeRoleName(r.name);
+                  const count = overrideCounts[normalized] ?? 0;
+                  return (
+                    <SelectItem key={r.id} value={normalized}>
+                      <span className="flex items-center gap-2">
+                        <span>{r.name}</span>
+                        {count > 0 && (
+                          <Badge variant="secondary" className="text-[10px]">
+                            {count} override{count === 1 ? "" : "s"}
+                          </Badge>
+                        )}
+                      </span>
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <CardDescription className="text-xs">
+          Overrides apply on top of the global flags. <strong>Inherit</strong>{" "}
+          uses the global value. <strong>On</strong> force-enables for this
+          role; <strong>Off</strong> force-disables. When a user holds multiple
+          roles the most-permissive value wins.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {!selectedRole && (
+          <p className="text-sm text-muted-foreground">
+            No role selected. {roles.length === 0
+              ? "Roles failed to load — make sure the current user can READ Fineract roles."
+              : "Pick a role from the dropdown to configure overrides."}
+          </p>
+        )}
+
+        {selectedRole &&
+          FEATURE_CONFIGS.map((config) => {
+            const override = overridesForSelectedRole[config.key];
+            const globalValue = globalFeatures?.[config.key] ?? false;
+            const isSaving =
+              savingOverrideKey ===
+              `${normalizeRoleName(selectedRole.name)}:${config.key}`;
+
+            const buttonClasses = (active: boolean) =>
+              active
+                ? "h-7 px-2 text-xs"
+                : "h-7 px-2 text-xs text-muted-foreground";
+
+            return (
+              <div
+                key={config.key}
+                className="flex items-start justify-between gap-4 py-2 border-b last:border-0"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{config.label}</span>
+                    {override === undefined && (
+                      <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+                        Inheriting {globalValue ? "ON" : "OFF"}
+                      </span>
+                    )}
+                    {override === true && (
+                      <Badge
+                        variant="default"
+                        className="text-[10px] bg-emerald-500 text-white"
+                      >
+                        Force ON
+                      </Badge>
+                    )}
+                    {override === false && (
+                      <Badge variant="destructive" className="text-[10px]">
+                        Force OFF
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {config.description}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0 pt-0.5">
+                  {isSaving && (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                  )}
+                  <div className="inline-flex rounded-md border bg-background">
+                    <Button
+                      size="sm"
+                      variant={override === undefined ? "secondary" : "ghost"}
+                      className={buttonClasses(override === undefined)}
+                      onClick={() =>
+                        onSetOverride(selectedRole.name, config.key, undefined)
+                      }
+                      disabled={isSaving}
+                    >
+                      Inherit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={override === true ? "secondary" : "ghost"}
+                      className={buttonClasses(override === true)}
+                      onClick={() =>
+                        onSetOverride(selectedRole.name, config.key, true)
+                      }
+                      disabled={isSaving}
+                    >
+                      On
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={override === false ? "secondary" : "ghost"}
+                      className={buttonClasses(override === false)}
+                      onClick={() =>
+                        onSetOverride(selectedRole.name, config.key, false)
+                      }
+                      disabled={isSaving}
+                    >
+                      Off
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+      </CardContent>
+    </Card>
   );
 }

--- a/app/(application)/tellers/page.tsx
+++ b/app/(application)/tellers/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Plus, Download } from "lucide-react";
+import { Plus, Download, Building2 } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -7,11 +7,17 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { TellersTable } from "./components/tellers-table";
+import { getOfficeVisibilityScope } from "@/lib/office-access";
 
-export default function TellersPage() {
+export default async function TellersPage() {
+  const scope = await getOfficeVisibilityScope();
+  const scopedToBranch = scope.kind === "office";
+  const titleSuffix = scopedToBranch ? ` — ${scope.officeName}` : "";
+
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -41,10 +47,19 @@ export default function TellersPage() {
       {/* Tellers Table */}
       <Card>
         <CardHeader>
-          <CardTitle>All Tellers</CardTitle>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle>All Tellers{titleSuffix}</CardTitle>
+            {scopedToBranch && (
+              <Badge variant="outline" className="gap-1 text-xs font-normal">
+                <Building2 className="h-3 w-3" />
+                Branch view: {scope.officeName}
+              </Badge>
+            )}
+          </div>
           <CardDescription>
-            Manage tellers, assign cashiers, allocate cash, and process
-            settlements
+            {scopedToBranch
+              ? `Showing tellers assigned to ${scope.officeName}. Other branches are not visible to your role.`
+              : "Manage tellers, assign cashiers, allocate cash, and process settlements"}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/actions/client-actions-with-autosave.ts
+++ b/app/actions/client-actions-with-autosave.ts
@@ -87,6 +87,8 @@ export async function autoSaveField(
       throw new Error("User not authenticated");
     }
     const userId = session.user.id;
+    const createdByUserName =
+      session.user.name || session.user.email || userId;
 
     let tenantId: string;
     const tenant = await getTenantFromHeaders();
@@ -238,6 +240,7 @@ export async function autoSaveField(
         const lead = await prisma.lead.create({
           data: {
             userId,
+            createdByUserName,
             tenantId,
             currentStageId: initialStage?.id ?? null,
             officeId: validatedData.officeId || null,
@@ -294,6 +297,7 @@ export async function autoSaveField(
           // Use type assertion to bypass TypeScript's type checking
           const leadData = {
             userId,
+            createdByUserName,
             tenantId,
             currentStageId: initialStage?.id ?? null,
             officeId: validatedData.officeId || null,

--- a/app/actions/leads-actions.ts
+++ b/app/actions/leads-actions.ts
@@ -11,6 +11,10 @@ import { UssdLeadsMetrics, UssdLoanApplication } from "./ussd-leads-actions";
 import { Lead, PipelineStage } from "@/shared/types/lead";
 import { getSession } from "@/lib/auth";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 const FINERACT_BASE_URL = process.env.FINERACT_BASE_URL || "http://10.10.0.143";
 
@@ -90,14 +94,13 @@ export async function getLeadsMetricsOnly(
       throw new Error("Tenant not found");
     }
 
-    // Build where clause
-    const where: any = {
-      tenantId: tenant.id,
-    };
-
+    // Build where clause — always scope to current user's role.
+    const scope = await getLeadVisibilityScope(tenant.id);
+    const extra: Record<string, unknown> = {};
     if (assignedToUserId) {
-      where.assignedToUserId = assignedToUserId;
+      extra.assignedToUserId = assignedToUserId;
     }
+    const where = buildLeadWhere(scope, tenant.id, extra);
 
     // Get total count
     const totalLeads = await prisma.lead.count({ where });
@@ -172,15 +175,14 @@ export async function getLeadsData(
     status?: string;
     limit?: number;
     offset?: number;
-    assignedToUserId?: number; // Filter by assigned user ID (for Loan Officers)
-    loanOfficerFilter?: { oderId: number; userIdString: string }; // Filter for loan officers (created OR assigned)
+    assignedToUserId?: number; // Filter by assigned user ID (legacy single-filter)
     skipFineractStatus?: boolean; // Skip slow Fineract status lookups for faster loading
     search?: string; // Text search for client name
     leadStatus?: string; // Filter by Fineract loan status
   } = {}
 ): Promise<LeadsData> {
   try {
-    const { stage, status, limit = 50, offset = 0, assignedToUserId, loanOfficerFilter, skipFineractStatus = false, search, leadStatus } = options;
+    const { stage, status, limit = 50, offset = 0, assignedToUserId, skipFineractStatus = false, search, leadStatus } = options;
 
     // Get tenant - prefer headers for consistency with API routes
     let tenant = await getTenantFromHeaders();
@@ -195,54 +197,27 @@ export async function getLeadsData(
       throw new Error("Tenant not found");
     }
 
-    // Build where clause
-    const where: any = {
-      tenantId: tenant.id,
-    };
+    // Build extra filters first; visibility scope is layered on by buildLeadWhere
+    // so it cannot be widened by callers.
+    const extra: Record<string, unknown> = {};
+    if (stage) extra.currentStageId = stage;
+    if (status) extra.status = status;
+    if (assignedToUserId) extra.assignedToUserId = assignedToUserId;
 
-    if (stage) {
-      where.currentStageId = stage;
-    }
-
-    if (status) {
-      where.status = status;
-    }
-
-    // Filter by assigned user ID if provided (legacy single filter)
-    if (assignedToUserId) {
-      where.assignedToUserId = assignedToUserId;
-    }
-
-    // Loan officer filter: see leads they created OR leads assigned to them
-    if (loanOfficerFilter) {
-      const { oderId, userIdString } = loanOfficerFilter;
-      where.OR = [
-        { userId: userIdString }, // Leads they created
-        { assignedToUserId: oderId }, // Leads assigned to them
-      ];
-    }
-
-    // Text search for client name, ID, or phone
+    // Text search for client name, ID, or phone — must be OR-combined with the
+    // visibility scope's OR via AND. We add it to `extra.OR` and let
+    // buildLeadWhere() do the AND-combination.
     if (search && search.length >= 2) {
-      // If we already have an OR clause (from loanOfficerFilter), we need to use AND
-      const searchConditions = [
+      extra.OR = [
         { firstname: { contains: search, mode: "insensitive" } },
         { lastname: { contains: search, mode: "insensitive" } },
         { externalId: { contains: search, mode: "insensitive" } },
         { mobileNo: { contains: search, mode: "insensitive" } },
       ];
-
-      if (where.OR) {
-        // Combine loan officer filter with search using AND
-        where.AND = [
-          { OR: where.OR },
-          { OR: searchConditions },
-        ];
-        delete where.OR;
-      } else {
-        where.OR = searchConditions;
-      }
     }
+
+    const scope = await getLeadVisibilityScope(tenant.id);
+    const where = buildLeadWhere(scope, tenant.id, extra) as Record<string, unknown>;
 
     // Get leads with related data
     const leads = await prisma.lead.findMany({

--- a/app/api/banks/[id]/allocate/route.ts
+++ b/app/api/banks/[id]/allocate/route.ts
@@ -3,6 +3,10 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import {
+  canAccessOffice,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * POST /api/banks/[id]/allocate
@@ -43,6 +47,12 @@ export async function POST(
     });
 
     if (!bank) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
+    }
+
+    // Branch users cannot allocate funds to banks from other branches.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: bank.officeId })) {
       return NextResponse.json({ error: "Bank not found" }, { status: 404 });
     }
 

--- a/app/api/banks/[id]/route.ts
+++ b/app/api/banks/[id]/route.ts
@@ -5,6 +5,10 @@ import { getSession } from "@/lib/auth";
 import { fetchFineractAPI } from "@/lib/api";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
 import { getTellerVaultDisplay } from "@/lib/gl-balance";
+import {
+  canAccessOffice,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * GET /api/banks/[id]
@@ -51,6 +55,14 @@ export async function GET(
     });
 
     if (!bank) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
+    }
+
+    // Enforce branch scoping: a non-admin viewing a bank that belongs to
+    // another branch gets a 404 — mirroring "not found" rather than leaking
+    // the bank's existence.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: bank.officeId })) {
       return NextResponse.json({ error: "Bank not found" }, { status: 404 });
     }
 
@@ -225,6 +237,12 @@ export async function PUT(
       return NextResponse.json({ error: "Bank not found" }, { status: 404 });
     }
 
+    // Branch users can't edit banks belonging to a different branch.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: existingBank.officeId })) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
+    }
+
     // Check if code is being changed to an existing code
     if (code && code.toUpperCase() !== existingBank.code) {
       const codeExists = await prisma.bank.findFirst({
@@ -295,6 +313,18 @@ export async function DELETE(
 
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Block cross-branch deletes.
+    const existingBank = await prisma.bank.findFirst({
+      where: { id, tenantId: tenant.id },
+    });
+    if (!existingBank) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
+    }
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: existingBank.officeId })) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
     }
 
     // Check if bank has active tellers

--- a/app/api/banks/[id]/tellers/route.ts
+++ b/app/api/banks/[id]/tellers/route.ts
@@ -4,6 +4,10 @@ import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
 import { getTellerVaultDisplay } from "@/lib/gl-balance";
+import {
+  canAccessOffice,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * GET /api/banks/[id]/tellers
@@ -31,6 +35,13 @@ export async function GET(
     });
 
     if (!bank) {
+      return NextResponse.json({ error: "Bank not found" }, { status: 404 });
+    }
+
+    // Branch-scope check: a non-admin user cannot list tellers belonging to
+    // a bank from another branch.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: bank.officeId })) {
       return NextResponse.json({ error: "Bank not found" }, { status: 404 });
     }
 

--- a/app/api/banks/route.ts
+++ b/app/api/banks/route.ts
@@ -4,6 +4,10 @@ import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { fetchFineractAPI } from "@/lib/api";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import {
+  buildOfficeWhere,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * GET /api/banks
@@ -21,18 +25,13 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get("status");
     const officeId = searchParams.get("officeId");
 
-    // Build where clause
-    const whereClause: any = {
-      tenantId: tenant.id,
-    };
+    // Always scope to the current user's branch. Admin / Authoriser see all.
+    const scope = await getOfficeVisibilityScope();
+    const extra: Record<string, unknown> = {};
+    if (status) extra.status = status;
+    if (officeId) extra.officeId = parseInt(officeId);
 
-    if (status) {
-      whereClause.status = status;
-    }
-
-    if (officeId) {
-      whereClause.officeId = parseInt(officeId);
-    }
+    const whereClause = buildOfficeWhere(scope, tenant.id, extra);
 
     // Get all banks with allocations and teller counts
     const banks = await prisma.bank.findMany({

--- a/app/api/leads/[id]/route.ts
+++ b/app/api/leads/[id]/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import {
+  decideLeadAccess,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 export async function GET(
   request: NextRequest,
@@ -44,6 +48,16 @@ export async function GET(
       return NextResponse.json({ error: "Lead not found" }, { status: 404 });
     }
 
+    // Determine the current user's access level for this lead. Out-of-scope
+    // users still get the lead back (read-only fallback per product spec) but
+    // can use the `access` block to render a banner / hide edit controls.
+    const accessScope = lead.tenantId
+      ? await getLeadVisibilityScope(lead.tenantId)
+      : null;
+    const accessDecision = accessScope
+      ? decideLeadAccess(accessScope, lead)
+      : { level: "full" as const };
+
     // Fetch tenant settings for email-optional check
     const tenant = lead.tenantId
       ? await prisma.tenant.findUnique({
@@ -65,6 +79,7 @@ export async function GET(
     // Format the response with additional computed fields
     const response = {
       ...lead,
+      access: accessDecision,
       computed: {
         timeInCurrentStage: Math.floor(
           timeInCurrentStage / (1000 * 60 * 60 * 24)
@@ -106,6 +121,31 @@ export async function PUT(
     const { id } = await params;
 
     const body = await request.json();
+
+    // Access check: block out-of-scope users from mutating the lead, even
+    // though they can fetch it read-only via GET.
+    const existing = await prisma.lead.findUnique({
+      where: { id },
+      select: {
+        tenantId: true,
+        userId: true,
+        assignedToUserId: true,
+        officeName: true,
+      },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Lead not found" }, { status: 404 });
+    }
+    if (existing.tenantId) {
+      const scope = await getLeadVisibilityScope(existing.tenantId);
+      const decision = decideLeadAccess(scope, existing);
+      if (decision.level !== "full") {
+        return NextResponse.json(
+          { error: "You do not have permission to edit this lead." },
+          { status: 403 }
+        );
+      }
+    }
 
     // Update lead by ID (without tenant filter to support cross-tenant client-side fetches)
     const updatedLead = await prisma.lead.update({
@@ -154,12 +194,30 @@ export async function PATCH(
     // Find the lead first (without tenant filter to avoid issues)
     const lead = await prisma.lead.findUnique({
       where: { id: leadId },
-      select: { id: true, tenantId: true },
+      select: {
+        id: true,
+        tenantId: true,
+        userId: true,
+        assignedToUserId: true,
+        officeName: true,
+      },
     });
 
     if (!lead) {
       console.error("Lead not found:", leadId);
       return NextResponse.json({ error: "Lead not found" }, { status: 404 });
+    }
+
+    // Access check: block out-of-scope users from mutating the lead.
+    if (lead.tenantId) {
+      const scope = await getLeadVisibilityScope(lead.tenantId);
+      const decision = decideLeadAccess(scope, lead);
+      if (decision.level !== "full") {
+        return NextResponse.json(
+          { error: "You do not have permission to edit this lead." },
+          { status: 403 }
+        );
+      }
     }
 
     console.log("Lead found, updating...");

--- a/app/api/leads/operations/route.ts
+++ b/app/api/leads/operations/route.ts
@@ -541,6 +541,8 @@ async function handleSaveDraft(data: any, leadId?: string) {
       const newLead = await prisma.lead.create({
         data: {
           userId,
+          createdByUserName:
+            session.user.name || session.user.email || userId,
           tenantId,
           currentStageId: initialStageId,
           officeId: validatedData.officeId,
@@ -1479,6 +1481,8 @@ async function handleCreateLeadForExistingClient(data: any) {
     const newLead = await prisma.lead.create({
       data: {
         userId: session.user.id,
+        createdByUserName:
+          session.user.name || session.user.email || session.user.id,
         tenantId: currentTenant.id,
         currentStageId: initialStageId,
         officeId: client.officeId,

--- a/app/api/leads/paginated/route.ts
+++ b/app/api/leads/paginated/route.ts
@@ -1,55 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getLeadsData } from "@/app/actions/leads-actions";
-import { getSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-import { getFineractTenantId } from "@/lib/fineract-tenant-service";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
 
-// Check if user has Loan Officer role (sees their created and assigned leads)
-async function getUserRoleFilter(): Promise<{ isLoanOfficer: boolean; userId: number | null; userIdString: string | null }> {
-  try {
-    const session = await getSession();
-    if (!session?.user?.userId) {
-      return { isLoanOfficer: false, userId: null, userIdString: null };
-    }
-
-    const mifosUserId = session.user.userId;
-    const mifosUserIdString = mifosUserId.toString();
-    const fineractTenantId = await getFineractTenantId();
-
-    // Get tenant
-    const tenant = await prisma.tenant.findFirst({
-      where: { slug: fineractTenantId },
-    });
-
-    if (!tenant) {
-      return { isLoanOfficer: false, userId: null, userIdString: null };
-    }
-
-    // Check if user has Loan Officer role in local DB
-    const userRoles = await prisma.userRole.findMany({
-      where: {
-        tenantId: tenant.id,
-        mifosUserId: mifosUserId,
-        isActive: true,
-      },
-      include: {
-        role: true,
-      },
-    });
-
-    // Check if any role is "LOAN_OFFICER"
-    const isLoanOfficer = userRoles.some(
-      (ur) => ur.role.name === "LOAN_OFFICER"
-    );
-
-    return { isLoanOfficer, userId: mifosUserId, userIdString: mifosUserIdString };
-  } catch (error) {
-    console.error("Error checking user role:", error);
-    return { isLoanOfficer: false, userId: null, userIdString: null };
-  }
-}
-
+/**
+ * GET /api/leads/paginated
+ *
+ * Visibility scoping (loan officer sees their own / assigned leads, branch
+ * manager sees branch leads, admin sees everything) is enforced inside
+ * `getLeadsData` via `lib/lead-access.ts`. We no longer compute the role
+ * filter here.
+ */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -57,14 +17,11 @@ export async function GET(request: NextRequest) {
 
     const stage = searchParams.get("stage") || undefined;
     const status = searchParams.get("status") || undefined;
-    const limit = parseInt(searchParams.get("limit") || "10");
-    const offset = parseInt(searchParams.get("offset") || "0");
+    const limit = parseInt(searchParams.get("limit") || "10", 10);
+    const offset = parseInt(searchParams.get("offset") || "0", 10);
     const skipFineractStatus = searchParams.get("skipFineractStatus") === "true";
     const search = searchParams.get("search") || undefined;
     const leadStatus = searchParams.get("leadStatus") || undefined;
-
-    // Check if user is a Loan Officer (sees their created and assigned leads)
-    const { isLoanOfficer, userId, userIdString } = await getUserRoleFilter();
 
     const leadsData = await getLeadsData(tenantSlug, {
       stage,
@@ -74,10 +31,6 @@ export async function GET(request: NextRequest) {
       skipFineractStatus,
       search,
       leadStatus,
-      // Loan officers see leads they created OR leads assigned to them
-      ...(isLoanOfficer && userId && userIdString
-        ? { loanOfficerFilter: { oderId: userId, userIdString } }
-        : {}),
     });
 
     return NextResponse.json(leadsData);

--- a/app/api/leads/pipeline-progress/route.ts
+++ b/app/api/leads/pipeline-progress/route.ts
@@ -5,6 +5,10 @@ import {
   getOrCreateDefaultTenant,
   extractTenantSlugFromRequest,
 } from "@/lib/tenant-service";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 export async function GET(request: NextRequest) {
   try {
@@ -35,8 +39,13 @@ export async function GET(request: NextRequest) {
     const stageMap = new Map(stages.map((s) => [s.id, s]));
     const stagePositionMap = new Map(nonFinalStages.map((s, i) => [s.id, i]));
 
+    // Apply visibility scope so loan officers don't get progress info on
+    // leads they don't own (otherwise they could probe IDs from the list URL).
+    const scope = await getLeadVisibilityScope(tenant.id);
+    const where = buildLeadWhere(scope, tenant.id, { id: { in: ids } });
+
     const leads = await prisma.lead.findMany({
-      where: { id: { in: ids } },
+      where: where as any,
       select: {
         id: true,
         currentStageId: true,

--- a/app/api/leads/reports/route.ts
+++ b/app/api/leads/reports/route.ts
@@ -9,6 +9,13 @@ import {
   matchesOfficeName,
   shouldUseOmamaOfficeAdminDashboard,
 } from "@/lib/omama-office-admin";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+  isReportRowVisible,
+  type LeadAccessFields,
+  type LeadVisibilityScope,
+} from "@/lib/lead-access";
 
 /**
  * GET /api/leads/reports
@@ -79,6 +86,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Resolve the current user's lead-visibility scope once (cached per request).
+    const visibilityScope: LeadVisibilityScope | null = tenant?.id
+      ? await getLeadVisibilityScope(tenant.id)
+      : null;
+
     // Handle drafts from local database
     if (report === "drafts") {
       return await getDraftsFromLocalDB({
@@ -88,6 +100,7 @@ export async function GET(request: NextRequest) {
         tenantSlug,
         allowOpenDateRange,
         officeNameFilter: officeAdminOfficeName,
+        visibilityScope,
       });
     }
 
@@ -138,6 +151,8 @@ export async function GET(request: NextRequest) {
 
         if (loanIds.length > 0 || externalIds.length > 0) {
           // Look up local leads by fineractLoanId OR by lead ID (external_id from Fineract report)
+          // Include userId / assignedToUserId / officeName so we can apply
+          // visibility scope filtering to the rows we ultimately return.
           const leads = await prisma.lead.findMany({
             where: {
               tenantId: tenant.id,
@@ -151,6 +166,9 @@ export async function GET(request: NextRequest) {
               fineractLoanId: true,
               preferredPaymentMethod: true,
               facilityType: true,
+              userId: true,
+              assignedToUserId: true,
+              officeName: true,
             },
           });
 
@@ -254,6 +272,28 @@ export async function GET(request: NextRequest) {
             return enrichedRow;
           });
 
+          // Apply lead-visibility scope (loan officer / branch manager / admin).
+          // Done after enrichment so we can use the resolved local lead's
+          // userId / assignedToUserId / officeName to make the decision.
+          if (visibilityScope && visibilityScope.kind !== "all") {
+            result = result.filter((row: any) => {
+              const rowLoanId = row.loan_id != null ? Number(row.loan_id) : null;
+              const rowExternalId =
+                row.external_id || row.client_external_id || row.lead_id || null;
+              let resolvedLead = rowLoanId
+                ? leadByFineractLoanId.get(rowLoanId) ?? null
+                : null;
+              if (!resolvedLead && rowExternalId) {
+                resolvedLead = leadByIdMap.get(String(rowExternalId)) || null;
+              }
+              return isReportRowVisible(
+                visibilityScope,
+                (resolvedLead as LeadAccessFields | null) ?? null,
+                row
+              );
+            });
+          }
+
           if (officeAdminOfficeName) {
             result = result.filter((row: any) =>
               matchesOfficeName(
@@ -267,6 +307,16 @@ export async function GET(request: NextRequest) {
         } else {
           // No local leads found — still add payment_type/facility_type columns so they're visible
           result = result.map((row: any) => ({ ...row, payment_type: null, facility_type: null }));
+
+          // Apply visibility scope when no local leads were resolvable.
+          // For "creator" scope this drops everything; for "branch" scope we
+          // fall back to the report's branch column.
+          if (visibilityScope && visibilityScope.kind !== "all") {
+            result = result.filter((row: any) =>
+              isReportRowVisible(visibilityScope, null, row)
+            );
+          }
+
           if (officeAdminOfficeName) {
             result = result.filter((row: any) =>
               matchesOfficeName(
@@ -282,6 +332,21 @@ export async function GET(request: NextRequest) {
     // Ensure payment_type column is always present even if enrichment was skipped
     if (result.length > 0 && !("payment_type" in result[0])) {
       result = result.map((row: any) => ({ ...row, payment_type: null }));
+    }
+
+    // Final defense-in-depth: if enrichment was skipped entirely (no loanIds /
+    // externalIds extracted) loan officers should not see any rows since we
+    // can't prove ownership. For branch scope we fall back to the report's
+    // branch column.
+    if (
+      result.length > 0 &&
+      visibilityScope &&
+      visibilityScope.kind !== "all" &&
+      !("lead_id" in result[0])
+    ) {
+      result = result.filter((row: any) =>
+        isReportRowVisible(visibilityScope, null, row)
+      );
     }
 
     if (officeAdminOfficeName && report !== "drafts") {
@@ -326,6 +391,7 @@ async function getDraftsFromLocalDB({
   tenantSlug,
   allowOpenDateRange,
   officeNameFilter,
+  visibilityScope,
 }: {
   startDate: string | null;
   endDate: string | null;
@@ -333,6 +399,7 @@ async function getDraftsFromLocalDB({
   tenantSlug: string;
   allowOpenDateRange: boolean;
   officeNameFilter?: string | null;
+  visibilityScope?: LeadVisibilityScope | null;
 }) {
   try {
     if (!tenantId) {
@@ -401,16 +468,26 @@ async function getDraftsFromLocalDB({
       };
     }
 
+    const draftsExtra: Record<string, unknown> = {
+      loanSubmittedToFineract: false,
+      status: "DRAFT",
+    };
+    if (officeNameFilter) {
+      draftsExtra.officeName = { equals: officeNameFilter, mode: "insensitive" };
+    }
+    if (createdAtFilter) {
+      draftsExtra.createdAt = createdAtFilter;
+    }
+
+    // Layer the user's visibility scope on top (loan officers only see their
+    // own / assigned drafts; branch managers only their branch). If we have
+    // no scope (caller didn't pass one), default to tenant-only filtering.
+    const draftsWhere = visibilityScope
+      ? (buildLeadWhere(visibilityScope, tenantId, draftsExtra) as Record<string, unknown>)
+      : { tenantId, ...draftsExtra };
+
     const drafts = await prisma.lead.findMany({
-      where: {
-        tenantId,
-        loanSubmittedToFineract: false,
-        status: "DRAFT",
-        ...(officeNameFilter
-          ? { officeName: { equals: officeNameFilter, mode: "insensitive" } }
-          : {}),
-        ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
-      },
+      where: draftsWhere as any,
       orderBy: { createdAt: "desc" },
       select: {
         id: true,

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getTenantBySlug, extractTenantSlugFromRequest } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 export async function GET(request: NextRequest) {
   try {
@@ -24,18 +28,14 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get("limit") || "50");
     const offset = parseInt(searchParams.get("offset") || "0");
 
-    // Build where clause
-    const where: any = {
-      tenantId: tenant.id,
-    };
+    // Build extra filters; visibility scope is applied via buildLeadWhere so it
+    // cannot be widened by callers.
+    const extra: Record<string, unknown> = {};
+    if (stage) extra.currentStageId = stage;
+    if (status) extra.status = status;
 
-    if (stage) {
-      where.currentStageId = stage;
-    }
-
-    if (status) {
-      where.status = status;
-    }
+    const scope = await getLeadVisibilityScope(tenant.id);
+    const where = buildLeadWhere(scope, tenant.id, extra) as Record<string, unknown>;
 
     // Get leads with related data
     const leads = await prisma.lead.findMany({

--- a/app/api/leads/search-by-external-id/route.ts
+++ b/app/api/leads/search-by-external-id/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 /**
  * GET /api/leads/search-by-external-id?externalId={externalId}
@@ -26,16 +30,18 @@ export async function GET(request: Request) {
       );
     }
 
+    // Apply visibility scope so loan officers don't discover colleagues' leads
+    // via this search endpoint.
+    const scope = await getLeadVisibilityScope(tenant.id);
+    const where = buildLeadWhere(scope, tenant.id, {
+      externalId,
+      // Only get leads that have been created in Fineract (have fineractClientId)
+      fineractClientId: { not: null },
+    });
+
     // Search for leads with the given external ID
     const leads = await prisma.lead.findMany({
-      where: {
-        tenantId: tenant.id,
-        externalId: externalId,
-        // Only get leads that have been created in Fineract (have fineractClientId)
-        fineractClientId: {
-          not: null,
-        },
-      },
+      where: where as any,
       select: {
         id: true,
         externalId: true,

--- a/app/api/tellers/[id]/route.ts
+++ b/app/api/tellers/[id]/route.ts
@@ -4,6 +4,10 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
 import { getTellerVaultDisplay } from "@/lib/gl-balance";
+import {
+  canAccessOffice,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * GET /api/tellers/[id]
@@ -133,6 +137,13 @@ export async function GET(
       return NextResponse.json({ error: "Teller not found" }, { status: 404 });
     }
 
+    // Enforce branch scoping: branch users cannot view a teller belonging to
+    // another office. Return 404 (not 403) so we don't leak existence.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: dbTeller.officeId })) {
+      return NextResponse.json({ error: "Teller not found" }, { status: 404 });
+    }
+
     // Vault & available balance come *only* from the Fineract GL account.
     // When the GL is missing or Fineract is unreachable we return nulls so the
     // UI can render NaN ("—") rather than a blended/local value.
@@ -251,6 +262,12 @@ export async function PUT(
       return NextResponse.json({ error: "Teller not found" }, { status: 404 });
     }
 
+    // Branch users cannot edit tellers belonging to another office.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: dbTeller.officeId })) {
+      return NextResponse.json({ error: "Teller not found" }, { status: 404 });
+    }
+
     // Update in Fineract if we have the ID
     if (dbTeller.fineractTellerId) {
       const fineractService = await getFineractServiceWithSession();
@@ -318,6 +335,12 @@ export async function DELETE(
     }
 
     if (!dbTeller) {
+      return NextResponse.json({ error: "Teller not found" }, { status: 404 });
+    }
+
+    // Branch users cannot delete tellers belonging to another office.
+    const scope = await getOfficeVisibilityScope();
+    if (!canAccessOffice(scope, { officeId: dbTeller.officeId })) {
       return NextResponse.json({ error: "Teller not found" }, { status: 404 });
     }
 

--- a/app/api/tellers/route.ts
+++ b/app/api/tellers/route.ts
@@ -4,6 +4,10 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
 import { getTellerVaultDisplay } from "@/lib/gl-balance";
+import {
+  buildOfficeWhere,
+  getOfficeVisibilityScope,
+} from "@/lib/office-access";
 
 /**
  * GET /api/tellers
@@ -17,14 +21,32 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const officeId = searchParams.get("officeId");
+    const officeIdParam = searchParams.get("officeId");
 
     const orgCurrency = await getOrgDefaultCurrencyCode();
+
+    // Resolve the user's branch scope. Loan officers / branch managers see
+    // only their own office; admins/authorisers see everything.
+    const scope = await getOfficeVisibilityScope();
+
+    // Determine which officeId to pass to Fineract.
+    //   - "all" scope: respect the query-string officeId if provided.
+    //   - "office" scope: always restrict to the user's own office, ignoring
+    //     any officeId the client sent (defence in depth — branch users
+    //     can't peek into other offices by tweaking the URL).
+    let fineractOfficeFilter: number | undefined;
+    if (scope.kind === "office") {
+      fineractOfficeFilter = scope.officeId;
+    } else if (scope.kind === "all" && officeIdParam) {
+      fineractOfficeFilter = parseInt(officeIdParam);
+    } else if (scope.kind === "none") {
+      return NextResponse.json([]);
+    }
 
     // Get tellers from Fineract - this is the source of truth
     const fineractService = await getFineractServiceWithSession();
     const fineractTellers = await fineractService.getTellers(
-      officeId ? parseInt(officeId) : undefined
+      fineractOfficeFilter
     );
 
     console.log("Fineract tellers count:", fineractTellers.length);
@@ -94,12 +116,10 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Now get all database tellers with enrichment data
+    // Now get all database tellers with enrichment data — scoped to the
+    // current user's branch (admins/authorisers see all).
     const dbTellers = await prisma.teller.findMany({
-      where: {
-        tenantId: tenant.id,
-        isActive: true,
-      },
+      where: buildOfficeWhere(scope, tenant.id, { isActive: true }),
       include: {
         bank: {
           select: {

--- a/app/api/tenant/features/route.ts
+++ b/app/api/tenant/features/route.ts
@@ -1,16 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
-import { DEFAULT_FEATURES, TenantFeatures } from "@/shared/types/tenant";
+import { getSession } from "@/lib/auth";
+import {
+  DEFAULT_FEATURES,
+  RoleFeatureOverrides,
+  TenantFeatures,
+} from "@/shared/types/tenant";
+import {
+  mergeGlobalFeatures,
+  normalizeRoleOverrides,
+  resolveFeaturesForRoles,
+} from "@/lib/feature-flags";
 
 /**
  * GET /api/tenant/features
- * Fetch feature flags for the current tenant
+ *
+ * Returns the *effective* feature flags for the current user (global flags
+ * + per-role overrides applied). For admin-style consumers the response
+ * also includes the raw global flags and the full per-role override map so
+ * the management UI can render the configuration as it is stored.
  */
 export async function GET(request: NextRequest) {
   try {
     const tenantSlug = extractTenantSlugFromRequest(request);
-    
+
     const tenant = await prisma.tenant.findFirst({
       where: { slug: tenantSlug, isActive: true },
       select: {
@@ -19,24 +33,42 @@ export async function GET(request: NextRequest) {
         settings: true,
       },
     });
-    
+
     if (!tenant) {
       return NextResponse.json({
         features: DEFAULT_FEATURES,
+        global: DEFAULT_FEATURES,
+        roleFeatureOverrides: {},
         tenantSlug,
         error: "Tenant not found, using defaults",
       });
     }
-    
-    // Extract features from settings, merging with defaults
-    const settings = tenant.settings as any;
-    const features: TenantFeatures = {
-      ...DEFAULT_FEATURES,
-      ...settings?.features,
-    };
-    
+
+    const settings = tenant.settings as
+      | {
+          features?: Partial<TenantFeatures>;
+          roleFeatureOverrides?: RoleFeatureOverrides;
+        }
+      | null;
+
+    const global = mergeGlobalFeatures(settings?.features);
+    const roleOverrides = normalizeRoleOverrides(settings?.roleFeatureOverrides);
+
+    // Resolve effective flags for the current session (anonymous → global).
+    const session = await getSession();
+    const userRoles = Array.isArray(session?.user?.roles)
+      ? session!.user!.roles!
+          .filter((r) => !r?.disabled)
+          .map((r) => r.name as string | null | undefined)
+      : [];
+
+    const resolved = resolveFeaturesForRoles(global, roleOverrides, userRoles);
+
     return NextResponse.json({
-      features,
+      features: resolved.features,
+      global: resolved.global,
+      roleFeatureOverrides: roleOverrides,
+      featureSource: resolved.source,
       tenantSlug: tenant.slug,
     });
   } catch (error) {
@@ -44,6 +76,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         features: DEFAULT_FEATURES,
+        global: DEFAULT_FEATURES,
+        roleFeatureOverrides: {},
         error: "Failed to fetch tenant features",
       },
       { status: 500 }
@@ -53,59 +87,151 @@ export async function GET(request: NextRequest) {
 
 /**
  * PUT /api/tenant/features
- * Update feature flags for the current tenant (admin only)
+ *
+ * Body shape — both fields are optional, at least one is required:
+ *
+ *   {
+ *     "features": { ussdLeads: false },          // patch global flags
+ *     "roleFeatureOverrides": {                   // patch role overrides
+ *       "loan officer": { aiAssistant: false }    // null/{} removes a role
+ *     }
+ *   }
+ *
+ * Passing `null` (or an empty object) under a role name clears its overrides.
  */
 export async function PUT(request: NextRequest) {
   try {
     const tenantSlug = extractTenantSlugFromRequest(request);
     const body = await request.json();
-    const { features } = body;
-    
-    if (!features || typeof features !== "object") {
+    const featuresPatch = body?.features as
+      | Partial<TenantFeatures>
+      | undefined;
+    const overridesPatch = body?.roleFeatureOverrides as
+      | Record<string, Partial<TenantFeatures> | null>
+      | undefined;
+
+    if (!featuresPatch && !overridesPatch) {
       return NextResponse.json(
-        { error: "Invalid features object" },
+        {
+          error:
+            "Provide at least one of: `features` or `roleFeatureOverrides`",
+        },
         { status: 400 }
       );
     }
-    
+
+    if (featuresPatch && typeof featuresPatch !== "object") {
+      return NextResponse.json(
+        { error: "Invalid `features` object" },
+        { status: 400 }
+      );
+    }
+
+    if (overridesPatch && typeof overridesPatch !== "object") {
+      return NextResponse.json(
+        { error: "Invalid `roleFeatureOverrides` object" },
+        { status: 400 }
+      );
+    }
+
     const tenant = await prisma.tenant.findFirst({
       where: { slug: tenantSlug, isActive: true },
     });
-    
+
     if (!tenant) {
-      return NextResponse.json(
-        { error: "Tenant not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
     }
-    
-    // Get current settings and merge with new features
-    const currentSettings = (tenant.settings as any) || {};
+
+    const currentSettings = (tenant.settings as Record<string, unknown>) || {};
+    const currentGlobal = mergeGlobalFeatures(
+      (currentSettings.features as Partial<TenantFeatures> | undefined) ?? null
+    );
+    const currentOverrides = normalizeRoleOverrides(
+      (currentSettings.roleFeatureOverrides as
+        | RoleFeatureOverrides
+        | undefined) ?? null
+    );
+
+    // Merge global patch into existing global.
+    const nextGlobal: TenantFeatures = featuresPatch
+      ? { ...currentGlobal, ...featuresPatch }
+      : currentGlobal;
+
+    // Merge role overrides patch with last-write-wins semantics. A role whose
+    // value is `null` or an empty object is removed from the map entirely.
+    const nextOverrides: RoleFeatureOverrides = { ...currentOverrides };
+    if (overridesPatch) {
+      for (const [rawRole, value] of Object.entries(overridesPatch)) {
+        const role = rawRole.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+        if (!role) continue;
+        if (value == null || Object.keys(value).length === 0) {
+          delete nextOverrides[role];
+          continue;
+        }
+        const merged: Partial<TenantFeatures> = {
+          ...(nextOverrides[role] ?? {}),
+        };
+        for (const [k, v] of Object.entries(value)) {
+          if (v === undefined) {
+            // Explicit `undefined` means "clear this feature override"
+            delete (merged as Record<string, unknown>)[k];
+          } else if (typeof v === "boolean" && k in DEFAULT_FEATURES) {
+            (merged as Record<string, boolean>)[k] = v;
+          }
+        }
+        if (Object.keys(merged).length === 0) {
+          delete nextOverrides[role];
+        } else {
+          nextOverrides[role] = merged;
+        }
+      }
+    }
+
     const updatedSettings = {
       ...currentSettings,
-      features: {
-        ...DEFAULT_FEATURES,
-        ...currentSettings.features,
-        ...features,
-      },
+      features: nextGlobal,
+      roleFeatureOverrides: nextOverrides,
     };
-    
-    // Update tenant settings
+
     const updatedTenant = await prisma.tenant.update({
       where: { id: tenant.id },
-      data: {
-        settings: updatedSettings,
-      },
-      select: {
-        id: true,
-        slug: true,
-        settings: true,
-      },
+      data: { settings: updatedSettings },
+      select: { id: true, slug: true, settings: true },
     });
-    
+
+    const settings = updatedTenant.settings as
+      | {
+          features?: Partial<TenantFeatures>;
+          roleFeatureOverrides?: RoleFeatureOverrides;
+        }
+      | null;
+
+    const global = mergeGlobalFeatures(settings?.features);
+    const roleFeatureOverrides = normalizeRoleOverrides(
+      settings?.roleFeatureOverrides
+    );
+
+    // Re-resolve for the current session so the caller sees the new effective
+    // value immediately.
+    const session = await getSession();
+    const userRoles = Array.isArray(session?.user?.roles)
+      ? session!.user!.roles!
+          .filter((r) => !r?.disabled)
+          .map((r) => r.name as string | null | undefined)
+      : [];
+
+    const resolved = resolveFeaturesForRoles(
+      global,
+      roleFeatureOverrides,
+      userRoles
+    );
+
     return NextResponse.json({
       success: true,
-      features: (updatedTenant.settings as any)?.features || DEFAULT_FEATURES,
+      features: resolved.features,
+      global: resolved.global,
+      roleFeatureOverrides,
+      featureSource: resolved.source,
       tenantSlug: updatedTenant.slug,
     });
   } catch (error) {

--- a/app/api/tenant/roles/route.ts
+++ b/app/api/tenant/roles/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { getFineractTenantId } from "@/lib/fineract-tenant-service";
+
+/**
+ * GET /api/tenant/roles
+ *
+ * Enumerates all Fineract roles defined for the current tenant. Used by the
+ * Feature Flags admin page to populate the "per-role overrides" picker.
+ *
+ * Auth: requires an authenticated session. The Fineract `/roles` endpoint
+ * itself enforces role-permission; if the calling user can't read roles
+ * we fall back to the roles attached to their own session so the UI can
+ * still render at least their own row.
+ */
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.userId) {
+      return NextResponse.json({ roles: [] }, { status: 200 });
+    }
+
+    const fineractTenantId = await getFineractTenantId();
+    const baseUrl =
+      process.env.FINERACT_BASE_URL || "http://mifos-be.kenac.co.zw";
+    const authToken =
+      session.base64EncodedAuthenticationKey || session.accessToken;
+
+    const rolesUrl = `${baseUrl}/fineract-provider/api/v1/roles`;
+
+    let roles: Array<{ id: number; name: string; disabled?: boolean }> = [];
+    try {
+      const res = await fetch(rolesUrl, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Basic ${authToken}`,
+          "Fineract-Platform-TenantId": fineractTenantId,
+        },
+      });
+      if (res.ok) {
+        const data = (await res.json()) as Array<{
+          id: number;
+          name: string;
+          disabled?: boolean;
+        }>;
+        roles = data
+          .filter((r) => !r.disabled)
+          .map((r) => ({ id: r.id, name: r.name, disabled: r.disabled }));
+      }
+    } catch (err) {
+      console.error("[/api/tenant/roles] Fineract /roles failed:", err);
+    }
+
+    // Fallback to the session's own roles if the API call gave us nothing.
+    if (roles.length === 0 && Array.isArray(session.user.roles)) {
+      roles = session.user.roles
+        .filter((r) => r && !r.disabled)
+        .map((r) => ({ id: r.id, name: r.name, disabled: r.disabled }));
+    }
+
+    // Stable alphabetical ordering for the UI.
+    roles.sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json({ roles });
+  } catch (error) {
+    console.error("Error fetching tenant roles:", error);
+    return NextResponse.json({ roles: [] }, { status: 200 });
+  }
+}

--- a/app/api/ussd-leads/[id]/to-lead/route.ts
+++ b/app/api/ussd-leads/[id]/to-lead/route.ts
@@ -48,6 +48,8 @@ export async function POST(
     // Resolve current user for required Lead.userId
     const session = await getSession();
     const currentUserId = session?.user?.id || 'system';
+    const currentUserDisplayName =
+      session?.user?.name || session?.user?.email || currentUserId;
 
     const initialStage = await prisma.pipelineStage.findFirst({
       where: { tenantId: app.tenantId, isInitialState: true, isActive: true },
@@ -58,6 +60,7 @@ export async function POST(
       data: {
         tenantId: app.tenantId,
         userId: currentUserId,
+        createdByUserName: currentUserDisplayName,
         currentStageId: initialStage?.id ?? null,
         status: 'DRAFT',
         externalId: app.referenceNumber || app.messageId,

--- a/lib/dashboard-service.ts
+++ b/lib/dashboard-service.ts
@@ -1,6 +1,14 @@
 import { fetchFineractAPI } from "@/lib/api";
 import { prisma } from "@/lib/prisma";
 import { DashboardData } from "@/shared/types/dashboard";
+import {
+  getOrCreateDefaultTenant,
+  getTenantFromHeaders,
+} from "@/lib/tenant-service";
+import {
+  buildLeadWhere,
+  getLeadVisibilityScope,
+} from "@/lib/lead-access";
 
 export async function fetchDashboardData(): Promise<DashboardData> {
   try {
@@ -165,33 +173,38 @@ export async function fetchDashboardData(): Promise<DashboardData> {
       });
     }
 
-    // Fetch recent leads from database
+    // Fetch recent leads from database — tenant-scoped and visibility-scoped
+    // (loan officer only sees their own / assigned, branch manager only their
+    // branch, admin sees all).
     let recentLeads: any[] = [];
     try {
-      const draftMaxAge = new Date(Date.now() - 48 * 60 * 60 * 1000);
-      recentLeads = await prisma.lead.findMany({
-        where: {
+      const tenant = (await getTenantFromHeaders()) ?? (await getOrCreateDefaultTenant());
+      if (tenant) {
+        const draftMaxAge = new Date(Date.now() - 48 * 60 * 60 * 1000);
+        const scope = await getLeadVisibilityScope(tenant.id);
+        const where = buildLeadWhere(scope, tenant.id, {
           OR: [
             { status: "SUBMITTED" },
             { status: "DRAFT", createdAt: { gte: draftMaxAge } },
           ],
-        },
-        orderBy: {
-          createdAt: "desc",
-        },
-        take: 10,
-        select: {
-          id: true,
-          firstname: true,
-          lastname: true,
-          requestedAmount: true,
-          loanPurpose: true,
-          status: true,
-          createdAt: true,
-          submittedOnDate: true,
-        },
-      });
-      console.log("Fetched leads from database:", recentLeads.length);
+        });
+        recentLeads = await prisma.lead.findMany({
+          where: where as any,
+          orderBy: { createdAt: "desc" },
+          take: 10,
+          select: {
+            id: true,
+            firstname: true,
+            lastname: true,
+            requestedAmount: true,
+            loanPurpose: true,
+            status: true,
+            createdAt: true,
+            submittedOnDate: true,
+          },
+        });
+        console.log("Fetched leads from database:", recentLeads.length);
+      }
     } catch (error) {
       console.error("Error fetching leads:", error);
       recentLeads = [];

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,163 @@
+/**
+ * Feature flag resolution — server-side.
+ *
+ * The tenant stores a global feature map (`tenant.settings.features`) and an
+ * optional per-role override map (`tenant.settings.roleFeatureOverrides`).
+ * This module resolves the *effective* feature set for a given list of
+ * roles by layering overrides on top of the global defaults.
+ *
+ * Semantics ("most-permissive-wins"):
+ *
+ *   effective[f] = DEFAULT_FEATURES[f]
+ *   effective[f] = tenant.features[f]        (if defined)
+ *   effective[f] |= any override.roles[f]    (any role that enables → wins)
+ *
+ *   If no role overrides `f` but at least one of the user's roles is in the
+ *   overrides map and that role's value for `f` is `false`, that disables
+ *   the feature only when no other role re-enables it. In other words: a
+ *   user is granted a feature if either the global flag is on AND no role
+ *   they hold explicitly disables it, OR any of their roles explicitly
+ *   enables it.
+ *
+ * This avoids the footgun of accidentally hiding a feature from an admin
+ * just because they happen to *also* hold a more restricted role.
+ */
+
+import {
+  DEFAULT_FEATURES,
+  RoleFeatureOverrides,
+  TenantFeatures,
+} from "@/shared/types/tenant";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a role name so user-typed values match what's stored. Mirrors
+ * the normalization used in `lib/lead-access.ts` so the two stay in sync.
+ */
+export function normalizeRoleName(name?: string | null): string {
+  return (name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * Merge global features with `DEFAULT_FEATURES` so callers always get a
+ * fully-populated `TenantFeatures` object even when the tenant predates a
+ * newly-added flag.
+ */
+export function mergeGlobalFeatures(
+  raw: Partial<TenantFeatures> | null | undefined
+): TenantFeatures {
+  return { ...DEFAULT_FEATURES, ...(raw ?? {}) };
+}
+
+/**
+ * Sanitize overrides keyed by raw role name into a normalized map keyed by
+ * normalized role name. Discards empty overrides so we don't bloat the
+ * stored JSON.
+ */
+export function normalizeRoleOverrides(
+  raw: RoleFeatureOverrides | null | undefined
+): RoleFeatureOverrides {
+  if (!raw) return {};
+  const out: RoleFeatureOverrides = {};
+  for (const [rawName, overrides] of Object.entries(raw)) {
+    const name = normalizeRoleName(rawName);
+    if (!name) continue;
+    if (!overrides || Object.keys(overrides).length === 0) continue;
+    // Filter to known feature keys so we don't store bogus values.
+    const cleaned: Partial<TenantFeatures> = {};
+    for (const [key, value] of Object.entries(overrides)) {
+      if (typeof value === "boolean" && key in DEFAULT_FEATURES) {
+        (cleaned as Record<string, boolean>)[key] = value;
+      }
+    }
+    if (Object.keys(cleaned).length > 0) {
+      // If the same role is provided twice with different casings, merge
+      // last-write-wins for individual keys.
+      out[name] = { ...(out[name] ?? {}), ...cleaned };
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Core resolver
+// ---------------------------------------------------------------------------
+
+export interface ResolvedFeatureInfo {
+  /** Final effective flags for the user. */
+  features: TenantFeatures;
+  /** Global flags before overrides — useful for diagnostics. */
+  global: TenantFeatures;
+  /** Per-feature reason for the effective value (`global` or role name). */
+  source: Record<keyof TenantFeatures, "global" | "role-override">;
+}
+
+/**
+ * Resolve effective feature flags for a list of role names.
+ */
+export function resolveFeaturesForRoles(
+  globalFeatures: Partial<TenantFeatures> | null | undefined,
+  overrides: RoleFeatureOverrides | null | undefined,
+  roleNames: Array<string | null | undefined>
+): ResolvedFeatureInfo {
+  const global = mergeGlobalFeatures(globalFeatures);
+  const normalizedOverrides = normalizeRoleOverrides(overrides);
+  const userRoles = (roleNames || [])
+    .map(normalizeRoleName)
+    .filter((n) => n.length > 0);
+
+  // Pull together the overrides that apply to this user.
+  const relevantOverrides = userRoles
+    .map((r) => ({ role: r, overrides: normalizedOverrides[r] }))
+    .filter((entry): entry is { role: string; overrides: Partial<TenantFeatures> } =>
+      entry.overrides != null
+    );
+
+  const features = { ...global } as TenantFeatures;
+  const source: Record<string, "global" | "role-override"> = {};
+  for (const key of Object.keys(global) as Array<keyof TenantFeatures>) {
+    source[key] = "global";
+  }
+
+  if (relevantOverrides.length === 0) {
+    return {
+      features,
+      global,
+      source: source as ResolvedFeatureInfo["source"],
+    };
+  }
+
+  // Apply most-permissive-wins:
+  //   - If any role overrides a feature to `true`  -> enable.
+  //   - Else if any role overrides a feature to `false` AND global is true -> disable.
+  //   - Otherwise keep global.
+  for (const key of Object.keys(global) as Array<keyof TenantFeatures>) {
+    let sawTrue = false;
+    let sawFalse = false;
+    for (const { overrides } of relevantOverrides) {
+      const v = overrides[key];
+      if (v === true) sawTrue = true;
+      else if (v === false) sawFalse = true;
+    }
+    if (sawTrue) {
+      features[key] = true;
+      source[key] = "role-override";
+    } else if (sawFalse) {
+      features[key] = false;
+      source[key] = "role-override";
+    }
+  }
+
+  return {
+    features,
+    global,
+    source: source as ResolvedFeatureInfo["source"],
+  };
+}

--- a/lib/lead-access.ts
+++ b/lib/lead-access.ts
@@ -1,0 +1,384 @@
+/**
+ * Lead access control.
+ *
+ * Single source of truth for "which leads can the current user see?".
+ *
+ * Roles & precedence (most permissive wins):
+ *   1. ALL_FUNCTIONS permission, OR admin/super/head-office role  -> "all"
+ *   2. Authoriser role                                            -> "all"
+ *   3. Branch manager role (with officeName)                      -> "branch"
+ *   4. Loan officer (Fineract role OR local LOAN_OFFICER role)    -> "creator"
+ *   5. Anyone else (safe default)                                 -> "creator"
+ *   6. Missing session                                            -> "none" (empty results)
+ *
+ * For loan officers the "creator" scope means:
+ *   Lead.userId == session.user.id                  (lead they created)
+ *   OR Lead.assignedToUserId == session.user.userId (lead currently assigned to them)
+ *
+ * Usage in API routes / server actions:
+ *
+ *   const scope = await getLeadVisibilityScope(tenant.id);
+ *   const leads = await prisma.lead.findMany({
+ *     where: buildLeadWhere(scope, tenant.id, { status: "DRAFT" }),
+ *   });
+ *
+ * Usage on single-lead pages (read-only fallback rather than 403):
+ *
+ *   const access = decideLeadAccess(scope, lead);
+ *   if (access.level === "denied") { return <NotFound /> }
+ *   const isReadOnly = access.level !== "full";
+ */
+
+import { cache } from "react";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
+import { SpecificPermission } from "@/shared/types/auth";
+import { matchesOfficeName } from "@/lib/omama-office-admin";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LeadVisibilityScope =
+  | { kind: "all" }
+  | { kind: "branch"; officeName: string }
+  | {
+      kind: "creator";
+      mifosUserId: number;
+      mifosUserIdString: string;
+    }
+  | { kind: "none" };
+
+export interface LeadAccessFields {
+  userId?: string | null;
+  assignedToUserId?: number | null;
+  officeName?: string | null;
+}
+
+export type LeadAccessLevel = "full" | "readOnly" | "denied";
+
+export interface LeadAccessDecision {
+  level: LeadAccessLevel;
+  reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Role / permission helpers
+// ---------------------------------------------------------------------------
+
+type RoleLike = { name?: string | null; disabled?: boolean | null };
+
+function normalizeRoleName(name?: string | null): string {
+  return (name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+function hasAllFunctions(permissions?: SpecificPermission[] | null): boolean {
+  return Array.isArray(permissions) &&
+    permissions.includes(SpecificPermission.ALL_FUNCTIONS);
+}
+
+function hasMatchingRole(
+  roles: RoleLike[] | null | undefined,
+  predicate: (normalized: string) => boolean
+): boolean {
+  if (!Array.isArray(roles)) return false;
+  return roles.some(
+    (role) => !role?.disabled && predicate(normalizeRoleName(role?.name))
+  );
+}
+
+// Note: "branch" pattern intentionally excluded here so that "Branch Manager"
+// does not get classified as admin.
+const ADMIN_ROLE_NAMES = new Set([
+  "admin",
+  "administrator",
+  "app administrator",
+  "super user",
+  "super admin",
+  "system administrator",
+]);
+
+const SUPER_ROLE_PATTERNS = ["super", "all functions", "head office", "headquarters"];
+
+function isAdminOrSuper(roles: RoleLike[] | null | undefined): boolean {
+  return hasMatchingRole(roles, (n) => {
+    if (ADMIN_ROLE_NAMES.has(n)) return true;
+    if (n.endsWith(" admin") || n.endsWith(" administrator")) return true;
+    return SUPER_ROLE_PATTERNS.some((p) => n.includes(p));
+  });
+}
+
+function isAuthoriser(roles: RoleLike[] | null | undefined): boolean {
+  return hasMatchingRole(roles, (n) => n.includes("authoriser") || n.includes("authorizer"));
+}
+
+function isBranchManager(roles: RoleLike[] | null | undefined): boolean {
+  // Match e.g. "Branch Manager", "Branch Admin" (the latter is also caught above,
+  // but precedence ensures admin wins). Avoid matching "branch officer" if such
+  // a role ever exists by requiring a "branch" word plus a management-like word.
+  return hasMatchingRole(roles, (n) => {
+    if (!n.includes("branch")) return false;
+    return (
+      n.includes("manager") ||
+      n.includes("supervisor") ||
+      n.includes("head") ||
+      // Bare "branch" role assumed to be a branch-scoped role
+      n === "branch"
+    );
+  });
+}
+
+function isFineractLoanOfficer(roles: RoleLike[] | null | undefined): boolean {
+  return hasMatchingRole(roles, (n) => n.includes("loan officer"));
+}
+
+async function isLocalLoanOfficer(
+  tenantId: string,
+  mifosUserId: number
+): Promise<boolean> {
+  try {
+    const userRoles = await prisma.userRole.findMany({
+      where: { tenantId, mifosUserId, isActive: true },
+      include: { role: true },
+    });
+    return userRoles.some((ur) => ur.role.name === "LOAN_OFFICER");
+  } catch (error) {
+    console.error("[lead-access] isLocalLoanOfficer failed:", error);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the current user's lead-visibility scope. Cached per request via
+ * React's `cache()` so multiple call sites in the same request don't re-query
+ * the database.
+ */
+export const getLeadVisibilityScope = cache(
+  async (tenantId: string): Promise<LeadVisibilityScope> => {
+    const session = await getSession();
+    const userIdString = session?.user?.id;
+    const mifosUserId = session?.user?.userId;
+    const officeName = session?.user?.officeName ?? null;
+    const roles = (session?.user?.roles ?? null) as RoleLike[] | null;
+    const permissions = session?.user?.permissions ?? null;
+
+    if (!userIdString || mifosUserId == null) {
+      return { kind: "none" };
+    }
+
+    // 1. ALL_FUNCTIONS / admin / super -> sees everything
+    if (hasAllFunctions(permissions) || isAdminOrSuper(roles)) {
+      return { kind: "all" };
+    }
+
+    // 2. Authoriser -> sees everything (needs cross-branch visibility to approve)
+    if (isAuthoriser(roles)) {
+      return { kind: "all" };
+    }
+
+    // 3. Branch manager -> branch-scoped
+    if (isBranchManager(roles) && officeName) {
+      return { kind: "branch", officeName };
+    }
+
+    // 4. Loan officer (Fineract role OR local LOAN_OFFICER role)
+    let isLoanOfficer = isFineractLoanOfficer(roles);
+    if (!isLoanOfficer) {
+      isLoanOfficer = await isLocalLoanOfficer(tenantId, mifosUserId);
+    }
+
+    if (isLoanOfficer) {
+      return {
+        kind: "creator",
+        mifosUserId,
+        mifosUserIdString: userIdString,
+      };
+    }
+
+    // 5. Default-deny: anyone we couldn't classify only sees their own / assigned
+    // leads. Safer than leaking everything to an unrecognized role.
+    return {
+      kind: "creator",
+      mifosUserId,
+      mifosUserIdString: userIdString,
+    };
+  }
+);
+
+/**
+ * Build a Prisma `where` clause that combines tenant scoping with the
+ * current user's visibility scope. Always preserves any caller-provided
+ * extra filters; correctly combines `OR` clauses via `AND` when needed.
+ *
+ * NOTE: the returned object can be passed directly to `prisma.lead.findMany`
+ * / `findFirst` / `count`.
+ */
+export function buildLeadWhere(
+  scope: LeadVisibilityScope,
+  tenantId: string,
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const base: Record<string, unknown> = { tenantId, ...extra };
+
+  if (scope.kind === "all") {
+    return base;
+  }
+
+  if (scope.kind === "branch") {
+    // Add an officeName equality filter; do not clobber an existing one.
+    if (base.officeName === undefined) {
+      base.officeName = { equals: scope.officeName, mode: "insensitive" };
+    }
+    return base;
+  }
+
+  if (scope.kind === "creator") {
+    const creatorOr = [
+      { userId: scope.mifosUserIdString },
+      { assignedToUserId: scope.mifosUserId },
+    ];
+
+    // If the caller already supplied an `OR`, combine with `AND` so we don't
+    // accidentally widen visibility.
+    if (Array.isArray(base.OR)) {
+      const existingOr = base.OR;
+      delete base.OR;
+      const existingAnd = Array.isArray(base.AND) ? base.AND : [];
+      base.AND = [...existingAnd, { OR: existingOr }, { OR: creatorOr }];
+    } else if (Array.isArray(base.AND)) {
+      (base.AND as unknown[]).push({ OR: creatorOr });
+    } else {
+      base.OR = creatorOr;
+    }
+    return base;
+  }
+
+  // scope.kind === "none": return an impossible filter so callers get [].
+  // Using an empty `OR` array is treated as "no match" by Prisma.
+  base.OR = [];
+  return base;
+}
+
+/**
+ * Decide what access level the current user has to a specific lead.
+ *
+ *  - "full":     full read/write access (lead they created, assigned to, in scope office, or admin).
+ *  - "readOnly": user can view but not edit (e.g. loan officer looking at another officer's lead).
+ *  - "denied":   no access at all (no session, etc.).
+ *
+ * Per product decision: loan officers viewing colleagues' leads do NOT get
+ * a 403 — they see a read-only view with a banner explaining the restriction.
+ */
+export function decideLeadAccess(
+  scope: LeadVisibilityScope,
+  lead: LeadAccessFields | null | undefined
+): LeadAccessDecision {
+  if (!lead) {
+    return { level: "denied", reason: "lead-missing" };
+  }
+
+  switch (scope.kind) {
+    case "all":
+      return { level: "full" };
+
+    case "branch": {
+      if (matchesOfficeName(lead.officeName ?? null, scope.officeName)) {
+        return { level: "full" };
+      }
+      return {
+        level: "readOnly",
+        reason: "lead-out-of-branch",
+      };
+    }
+
+    case "creator": {
+      const isCreator =
+        lead.userId != null && lead.userId === scope.mifosUserIdString;
+      const isAssignee =
+        lead.assignedToUserId != null &&
+        lead.assignedToUserId === scope.mifosUserId;
+      if (isCreator || isAssignee) {
+        return { level: "full" };
+      }
+      return {
+        level: "readOnly",
+        reason: "lead-not-owned",
+      };
+    }
+
+    case "none":
+    default:
+      return { level: "denied", reason: "no-session" };
+  }
+}
+
+/**
+ * Human-readable message for surfacing a read-only banner on the UI.
+ */
+export function describeLeadAccess(decision: LeadAccessDecision): string {
+  switch (decision.reason) {
+    case "lead-not-owned":
+      return "You're viewing this lead in read-only mode because it was created by (and is currently assigned to) another loan officer.";
+    case "lead-out-of-branch":
+      return "You're viewing this lead in read-only mode because it belongs to a different branch.";
+    case "no-session":
+      return "Sign in to view this lead.";
+    case "lead-missing":
+      return "Lead not found.";
+    default:
+      return "You have read-only access to this lead.";
+  }
+}
+
+/**
+ * Convenience: check whether a row from a Fineract report (or any object that
+ * has `lead_id`/`external_id` plus an enriched local lead) is visible to the
+ * current user. Caller is responsible for resolving the local lead first; this
+ * is just the boolean check.
+ */
+export function isReportRowVisible(
+  scope: LeadVisibilityScope,
+  resolvedLead: LeadAccessFields | null | undefined,
+  reportRow: { branch?: unknown; office?: unknown; office_name?: unknown }
+): boolean {
+  if (scope.kind === "all") return true;
+
+  if (scope.kind === "none") return false;
+
+  if (scope.kind === "branch") {
+    // Prefer the local lead's officeName (authoritative) over the report column.
+    if (resolvedLead?.officeName) {
+      return matchesOfficeName(resolvedLead.officeName, scope.officeName);
+    }
+    const reportOffice = (reportRow.branch ||
+      reportRow.office ||
+      reportRow.office_name ||
+      null) as string | null;
+    return matchesOfficeName(reportOffice, scope.officeName);
+  }
+
+  if (scope.kind === "creator") {
+    if (!resolvedLead) {
+      // No local lead matched. We can't tell who created it from Fineract alone;
+      // treat as not visible (loan officers shouldn't see un-linked rows).
+      return false;
+    }
+    const isCreator =
+      resolvedLead.userId != null &&
+      resolvedLead.userId === scope.mifosUserIdString;
+    const isAssignee =
+      resolvedLead.assignedToUserId != null &&
+      resolvedLead.assignedToUserId === scope.mifosUserId;
+    return isCreator || isAssignee;
+  }
+
+  return false;
+}

--- a/lib/office-access.ts
+++ b/lib/office-access.ts
@@ -1,0 +1,236 @@
+/**
+ * Office (branch) access control.
+ *
+ * Single source of truth for "which office-scoped resources (banks, tellers,
+ * etc.) can the current user see?".
+ *
+ * This mirrors `lib/lead-access.ts` but for resources that are tied directly
+ * to a Fineract office rather than to a specific user. The roles share the
+ * same classifier as the lead-access module so that scoping is consistent
+ * across the app.
+ *
+ * Roles & precedence (most permissive wins):
+ *   1. ALL_FUNCTIONS permission OR admin/super/head-office role -> "all"
+ *   2. Authoriser role                                          -> "all"
+ *   3. Branch manager / Loan officer / any other non-admin role -> "office"
+ *      (limited to the user's own Fineract office)
+ *   4. Missing session or office                                -> "none"
+ *
+ * Usage in API routes / server actions:
+ *
+ *   const scope = await getOfficeVisibilityScope();
+ *   const banks = await prisma.bank.findMany({
+ *     where: buildOfficeWhere(scope, tenant.id, { status: "ACTIVE" }),
+ *   });
+ *
+ * For single-item endpoints:
+ *
+ *   if (!canAccessOffice(scope, { officeId: bank.officeId })) {
+ *     return NextResponse.json({ error: "Not found" }, { status: 404 });
+ *   }
+ */
+
+import { cache } from "react";
+import { getSession } from "@/lib/auth";
+import { SpecificPermission } from "@/shared/types/auth";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OfficeVisibilityScope =
+  | { kind: "all" }
+  | { kind: "office"; officeId: number; officeName: string }
+  | { kind: "none" };
+
+export interface OfficeAccessFields {
+  officeId?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Role / permission helpers (kept consistent with lead-access.ts)
+// ---------------------------------------------------------------------------
+
+type RoleLike = { name?: string | null; disabled?: boolean | null };
+
+function normalizeRoleName(name?: string | null): string {
+  return (name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+function hasAllFunctions(permissions?: SpecificPermission[] | null): boolean {
+  return (
+    Array.isArray(permissions) &&
+    permissions.includes(SpecificPermission.ALL_FUNCTIONS)
+  );
+}
+
+function hasMatchingRole(
+  roles: RoleLike[] | null | undefined,
+  predicate: (normalized: string) => boolean
+): boolean {
+  if (!Array.isArray(roles)) return false;
+  return roles.some(
+    (role) => !role?.disabled && predicate(normalizeRoleName(role?.name))
+  );
+}
+
+// Same classifier as lead-access so the two stay in lock-step.
+const ADMIN_ROLE_NAMES = new Set([
+  "admin",
+  "administrator",
+  "app administrator",
+  "super user",
+  "super admin",
+  "system administrator",
+]);
+
+const SUPER_ROLE_PATTERNS = [
+  "super",
+  "all functions",
+  "head office",
+  "headquarters",
+];
+
+function isAdminOrSuper(roles: RoleLike[] | null | undefined): boolean {
+  return hasMatchingRole(roles, (n) => {
+    if (ADMIN_ROLE_NAMES.has(n)) return true;
+    if (n.endsWith(" admin") || n.endsWith(" administrator")) return true;
+    return SUPER_ROLE_PATTERNS.some((p) => n.includes(p));
+  });
+}
+
+function isAuthoriser(roles: RoleLike[] | null | undefined): boolean {
+  return hasMatchingRole(
+    roles,
+    (n) => n.includes("authoriser") || n.includes("authorizer")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the current user's office-visibility scope. Cached per request via
+ * React's `cache()` so multiple call sites in the same request reuse the
+ * same scope without re-reading the session.
+ */
+export const getOfficeVisibilityScope = cache(
+  async (): Promise<OfficeVisibilityScope> => {
+    const session = await getSession();
+    const userIdString = session?.user?.id;
+    const officeId = session?.user?.officeId ?? null;
+    const officeName = session?.user?.officeName ?? null;
+    const roles = (session?.user?.roles ?? null) as RoleLike[] | null;
+    const permissions = session?.user?.permissions ?? null;
+
+    if (!userIdString) {
+      return { kind: "none" };
+    }
+
+    // 1. ALL_FUNCTIONS / admin / super -> sees every office
+    if (hasAllFunctions(permissions) || isAdminOrSuper(roles)) {
+      return { kind: "all" };
+    }
+
+    // 2. Authoriser -> sees every office (needs cross-branch visibility)
+    if (isAuthoriser(roles)) {
+      return { kind: "all" };
+    }
+
+    // 3. Everyone else is restricted to their own office. We need an officeId
+    //    to enforce this — if the session is missing it (shouldn't happen for
+    //    a real Fineract login) we default-deny rather than leak.
+    if (officeId == null || !officeName) {
+      return { kind: "none" };
+    }
+
+    return { kind: "office", officeId, officeName };
+  }
+);
+
+/**
+ * Build a Prisma `where` clause that combines tenant scoping with the
+ * current user's office-visibility scope. Always preserves any caller-
+ * provided extra filters.
+ *
+ * - "all":    no office filter applied.
+ * - "office": adds `officeId = scope.officeId`. Caller-supplied `officeId`
+ *             (e.g. an explicit query-string filter) is respected only when
+ *             it matches the user's own office; otherwise it's clamped to
+ *             prevent users from peeking at other offices via the URL.
+ * - "none":   returns an impossible filter so callers get [].
+ */
+export function buildOfficeWhere(
+  scope: OfficeVisibilityScope,
+  tenantId: string,
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const base: Record<string, unknown> = { tenantId, ...extra };
+
+  if (scope.kind === "all") {
+    return base;
+  }
+
+  if (scope.kind === "office") {
+    const requestedOfficeId = base.officeId;
+    if (
+      typeof requestedOfficeId === "number" &&
+      requestedOfficeId !== scope.officeId
+    ) {
+      // Caller asked for a different office than the user owns — force an
+      // empty result rather than silently widening or silently substituting.
+      base.officeId = -1;
+    } else {
+      base.officeId = scope.officeId;
+    }
+    return base;
+  }
+
+  // scope.kind === "none": return an impossible filter so callers get [].
+  base.OR = [];
+  return base;
+}
+
+/**
+ * Decide whether the current user can see a single office-scoped item.
+ * Use for `/api/<resource>/[id]` handlers — return 404 when this is false
+ * to avoid leaking the resource's existence.
+ */
+export function canAccessOffice(
+  scope: OfficeVisibilityScope,
+  item: OfficeAccessFields | null | undefined
+): boolean {
+  if (!item) return false;
+
+  switch (scope.kind) {
+    case "all":
+      return true;
+    case "office":
+      // Treat unknown/null office as out-of-scope for branch users; admins
+      // already returned true above so global resources still surface for them.
+      return item.officeId != null && item.officeId === scope.officeId;
+    case "none":
+    default:
+      return false;
+  }
+}
+
+/**
+ * Useful for log/banner strings: short label describing the active scope.
+ */
+export function describeOfficeScope(scope: OfficeVisibilityScope): string {
+  switch (scope.kind) {
+    case "all":
+      return "All branches";
+    case "office":
+      return scope.officeName;
+    case "none":
+    default:
+      return "No access";
+  }
+}

--- a/package.json
+++ b/package.json
@@ -93,5 +93,6 @@
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.2.9",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       form-data:
         specifier: ^4.0.5
         version: 4.0.5
@@ -477,6 +480,12 @@ packages:
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
+
   '@floating-ui/core@1.7.0':
     resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
 
@@ -549,92 +558,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -714,28 +709,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.3':
     resolution: {integrity: sha512-u3PEIzuguSenoZviZJahNLgCexGFhso5mxWCrrIMdvpZn6lkME5vc/ADZG8UUk5K1uWRy4hqSFECrON6UKQBbQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.3':
     resolution: {integrity: sha512-lDtOOScYDZxI2BENN9m0pfVPJDSuUkAD1YXSvlJF0DKwZt0WlA7T7o3wrcEr4Q+iHYGzEaVuZcsIbCps4K27sA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.3':
     resolution: {integrity: sha512-9vWVUnsx9PrY2NwdVRJ4dUURAQ8Su0sLRPqcCCxtX5zIQUBES12eRVHq6b70bbfaVaxIDGJN2afHui0eDm+cLg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.3':
     resolution: {integrity: sha512-1CU20FZzY9LFQigRi6jM45oJMU3KziA5/sSG+dXeVaTm661snQP6xu3ykGxxwU5sLG3sh14teO/IOEPVsQMRfA==}
@@ -1864,28 +1855,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.6':
     resolution: {integrity: sha512-8kjivE5xW0qAQ9HX9reVFmZj3t+VmljDLVRJpVBEoTR+3bKMnvC7iLcoSGNIUJGOZy1mLVq7x/gerVg0T+IsYw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.6':
     resolution: {integrity: sha512-A4spQhwnWVpjWDLXnOW9PSinO2PTKJQNRmL/aIl2U/O+RARls8doDfs6R41+DAXK0ccacvRyDpR46aVQJJCoCg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.6':
     resolution: {integrity: sha512-YRee+6ZqdzgiQAHVSLfl3RYmqeeaWVCk796MhXhLQu2kJu2COHBkqlqsqKYx3p8Hmk5pGCQd2jTAoMWWFeyG2A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.6':
     resolution: {integrity: sha512-qAp4ooTYrBQ5pk5jgg54/U1rCJ/9FLYOkkQ/nTE+bVMseMfB6O7J8zb19YTpWuu4UdfRf5zzOrNKfl6T64MNrQ==}
@@ -1952,6 +1939,9 @@ packages:
 
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
+
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
   '@types/node@20.17.46':
     resolution: {integrity: sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==}
@@ -2055,49 +2045,41 @@ packages:
     resolution: {integrity: sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.2':
     resolution: {integrity: sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.2':
     resolution: {integrity: sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.2':
     resolution: {integrity: sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.2':
     resolution: {integrity: sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.2':
     resolution: {integrity: sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.2':
     resolution: {integrity: sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.2':
     resolution: {integrity: sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.2':
     resolution: {integrity: sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==}
@@ -2157,6 +2139,18 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2207,6 +2201,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2232,6 +2229,22 @@ packages:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
@@ -2246,8 +2259,22 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
   buffer-more-ints@1.0.0:
     resolution: {integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2279,6 +2306,9 @@ packages:
   cfb@1.2.2:
     resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
     engines: {node: '>=0.8'}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2336,6 +2366,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2358,6 +2392,9 @@ packages:
   core-js@3.45.1:
     resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -2366,6 +2403,10 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2397,6 +2438,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2456,6 +2500,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2465,6 +2512,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
@@ -2647,6 +2697,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   express-rate-limit@7.5.0:
     resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
     engines: {node: '>= 16'}
@@ -2656,6 +2710,10 @@ packages:
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2757,10 +2815,21 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2798,6 +2867,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2856,9 +2929,15 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2867,6 +2946,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2991,6 +3074,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -3043,6 +3129,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3053,9 +3142,16 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-darwin-arm64@1.29.2:
     resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
@@ -3086,28 +3182,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.2:
     resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.2:
     resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.2:
     resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.2:
     resolution: {integrity: sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==}
@@ -3125,12 +3217,49 @@ packages:
     resolution: {integrity: sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==}
     engines: {node: '>= 12.0.0'}
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -3143,6 +3272,12 @@ packages:
 
   lodash.startswith@4.2.1:
     resolution: {integrity: sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3199,6 +3334,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3213,6 +3352,10 @@ packages:
   minizlib@3.0.2:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
     engines: {node: '>= 18'}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -3313,6 +3456,10 @@ packages:
       encoding:
         optional: true
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   oauth@0.9.15:
     resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
 
@@ -3394,6 +3541,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -3411,6 +3561,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3480,6 +3634,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3610,6 +3767,16 @@ packages:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
@@ -3651,6 +3818,11 @@ packages:
     resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
     engines: {node: '>= 0.8.15'}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3661,6 +3833,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3675,6 +3850,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -3712,6 +3891,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3795,6 +3977,12 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -3848,6 +4036,10 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
@@ -3862,6 +4054,10 @@ packages:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3872,6 +4068,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3936,6 +4135,9 @@ packages:
   unrs-resolver@1.7.2:
     resolution: {integrity: sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==}
 
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3975,6 +4177,9 @@ packages:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
@@ -4046,6 +4251,9 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xstate@5.20.1:
     resolution: {integrity: sha512-i9ZpNnm/XhCOMUxae1suT8PjYNTStZWbhmuKt4xeTPaYG5TS0Fz0i+Ka5yxoNPpaHW3VW6JIowrwFgSTZONxig==}
 
@@ -4059,6 +4267,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zod-to-json-schema@3.24.5:
     resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
@@ -4243,6 +4455,25 @@ snapshots:
     dependencies:
       '@eslint/core': 0.13.0
       levn: 0.4.1
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@floating-ui/core@1.7.0':
     dependencies:
@@ -5729,6 +5960,8 @@ snapshots:
       '@types/node': 20.17.46
       form-data: 4.0.5
 
+  '@types/node@14.18.63': {}
+
   '@types/node@20.17.46':
     dependencies:
       undici-types: 6.19.8
@@ -5924,6 +6157,42 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.4:
@@ -6001,6 +6270,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
@@ -6023,6 +6294,23 @@ snapshots:
 
   base64-arraybuffer@1.0.2:
     optional: true
+
+  base64-js@1.5.1: {}
+
+  big-integer@1.6.52: {}
+
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  bluebird@3.4.7: {}
 
   body-parser@2.2.0:
     dependencies:
@@ -6051,7 +6339,18 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-crc32@0.2.13: {}
+
+  buffer-indexof-polyfill@1.0.2: {}
+
   buffer-more-ints@1.0.0: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -6092,6 +6391,10 @@ snapshots:
     dependencies:
       adler-32: 1.3.1
       crc-32: 1.2.2
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
 
   chalk@4.1.2:
     dependencies:
@@ -6154,6 +6457,13 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   concat-map@0.0.1: {}
 
   content-disposition@1.0.0:
@@ -6169,12 +6479,19 @@ snapshots:
   core-js@3.45.1:
     optional: true
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
 
   crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6214,6 +6531,8 @@ snapshots:
       is-data-view: 1.0.2
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.20: {}
 
   debug@3.2.7:
     dependencies:
@@ -6262,11 +6581,19 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
+
   ee-first@1.1.1: {}
 
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.1:
     dependencies:
@@ -6617,6 +6944,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.1
 
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.20
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.5
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   express-rate-limit@7.5.0(express@5.1.0):
     dependencies:
       express: 5.1.0
@@ -6652,6 +6991,11 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -6751,8 +7095,19 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -6804,6 +7159,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   globals@14.0.0: {}
 
@@ -6858,7 +7222,11 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -6866,6 +7234,11 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -6995,6 +7368,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -7052,6 +7427,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7062,10 +7444,18 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-darwin-arm64@1.29.2:
     optional: true
@@ -7112,11 +7502,35 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.29.2
       lightningcss-win32-x64-msvc: 1.29.2
 
+  listenercount@1.0.1: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.debounce@4.0.8: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.difference@4.5.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
+  lodash.isnil@4.0.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isundefined@3.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
@@ -7125,6 +7539,10 @@ snapshots:
   lodash.reduce@4.6.0: {}
 
   lodash.startswith@4.2.1: {}
+
+  lodash.union@4.6.0: {}
+
+  lodash.uniq@4.5.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -7171,6 +7589,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -7182,6 +7604,10 @@ snapshots:
   minizlib@3.0.2:
     dependencies:
       minipass: 7.1.2
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   mkdirp@3.0.1: {}
 
@@ -7257,6 +7683,8 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  normalize-path@3.0.0: {}
 
   oauth@0.9.15: {}
 
@@ -7349,6 +7777,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   pako@2.1.0: {}
 
   papaparse@5.5.3: {}
@@ -7360,6 +7790,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -7414,6 +7846,8 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
+
+  process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -7587,6 +8021,26 @@ snapshots:
 
   react@19.1.0: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
+
   redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
@@ -7635,6 +8089,10 @@ snapshots:
   rgbcolor@1.0.1:
     optional: true
 
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
   router@2.2.0:
     dependencies:
       debug: 4.4.0
@@ -7657,6 +8115,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -7671,6 +8131,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
 
@@ -7727,6 +8191,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -7867,6 +8333,14 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -7901,6 +8375,14 @@ snapshots:
 
   tapable@2.2.1: {}
 
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar@7.4.3:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -7922,6 +8404,8 @@ snapshots:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7929,6 +8413,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  traverse@0.3.9: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -8030,6 +8516,19 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.7.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.7.2
 
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -8063,6 +8562,8 @@ snapshots:
   use-sync-external-store@1.5.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  util-deprecate@1.0.2: {}
 
   utrie@1.0.2:
     dependencies:
@@ -8146,6 +8647,8 @@ snapshots:
       wmf: 1.0.2
       word: 0.3.0
 
+  xmlchars@2.2.0: {}
+
   xstate@5.20.1: {}
 
   yallist@4.0.0: {}
@@ -8153,6 +8656,12 @@ snapshots:
   yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zod-to-json-schema@3.24.5(zod@3.24.4):
     dependencies:

--- a/shared/types/tenant.ts
+++ b/shared/types/tenant.ts
@@ -58,11 +58,31 @@ export interface TenantAutoPopulateFields {
 }
 
 /**
+ * Per-role overrides for feature flags.
+ *
+ * Keyed by normalized role name (lowercase, single-spaced). Each role can
+ * override any subset of `TenantFeatures` — unspecified features inherit
+ * the global tenant value. When a user has multiple roles, the most-
+ * permissive override wins (i.e. a feature is enabled if ANY of the user's
+ * roles enables it, or if the global flag is enabled and no role disables
+ * it).
+ *
+ * Example:
+ *   {
+ *     "loan officer": { ussdLeads: false },
+ *     "branch manager": { aiAssistant: false, reports: true }
+ *   }
+ */
+export type RoleFeatureOverrides = Record<string, Partial<TenantFeatures>>;
+
+/**
  * Tenant settings stored in the database
  */
 export interface TenantSettings {
   theme: string;
   features: TenantFeatures;
+  /** Per-role overrides applied on top of the global `features` map */
+  roleFeatureOverrides?: RoleFeatureOverrides;
   /** How loan interest rates should be displayed in the UI and documents */
   loanTermsInterestRateDisplay?: InterestRateDisplayMode;
   /** Field-level auto-population controls for lead creation */


### PR DESCRIPTION
## Summary

This PR introduces role- and office-based access controls across leads and office-scoped resources, and extends tenant feature management to support per-role feature overrides.

## What changed

- Added a shared lead visibility layer in `lib/lead-access.ts`
- Added a shared office visibility layer in `lib/office-access.ts`
- Updated lead APIs, dashboard queries, reports, and lead detail views to enforce scoped access consistently
- Added read-only handling on the lead detail page for users who can view but not fully edit a lead
- Added server-side feature flag resolution in `lib/feature-flags.ts`
- Extended tenant feature settings to support per-role feature overrides
- Added `GET /api/tenant/roles` to load available Fineract roles for feature configuration
- Updated the organization feature settings UI to manage both global feature flags and role-based overrides

## Access behavior

- Admin, super, head-office, and `ALL_FUNCTIONS` users retain full visibility
- Authorisers retain cross-branch visibility
- Branch managers are restricted to their branch
- Loan officers are restricted to leads they created or are assigned to
- Office-scoped resources such as banks and tellers are restricted to the user’s office unless they have global visibility

## Notes for reviewers

- Access rules are now centralized instead of being implemented ad hoc in individual routes
- Feature flags now resolve from tenant defaults plus normalized per-role overrides using most-permissive-wins semantics
- No working tree changes remain after the commit

## Testing

- Manual verification recommended for:
  - loan officer lead visibility
  - branch manager branch-only access
  - admin/authoriser full visibility
  - role-based feature override behavior in the organization settings page