### PR TITLE
feat: loan product eligibility upload and USSD batch sync

### DIFF
--- a/app/(application)/collections/loan-product-eligibility/components/loan-product-eligibility-manager.tsx
+++ b/app/(application)/collections/loan-product-eligibility/components/loan-product-eligibility-manager.tsx
@@ -1,0 +1,827 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import Papa from "papaparse";
+import { format } from "date-fns";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Search, Upload, CheckCircle2, XCircle, Clock, AlertCircle, Eye } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+type LoanProductOption = {
+  id: number;
+  name: string;
+  shortName?: string;
+};
+
+type LoanProductApiRecord = {
+  id?: unknown;
+  name?: unknown;
+  shortName?: unknown;
+};
+
+type UploadRecord = {
+  id: string;
+  fileName: string;
+  productExternalId: string;
+  productName: string;
+  uploadedBy: string;
+  status: string;
+  totalRows: number;
+  syncedRows: number;
+  failedRows: number;
+  syncError: string | null;
+  createdAt: string;
+  _count?: { items: number };
+};
+
+type ParsedItem = {
+  rowNumber: number;
+  name: string;
+  nrc: string;
+  phone: string;
+};
+
+type UploadItem = {
+  id: string;
+  rowNumber: number;
+  name: string;
+  nrc: string;
+  phone: string;
+  normalizedPhone: string;
+  status: string;
+};
+
+type ItemsPage = {
+  items: UploadItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+const REQUIRED_HEADERS = ["name", "nrc", "phone"] as const;
+
+const STATUS_STYLES: Record<string, string> = {
+  STAGING: "bg-amber-100 text-amber-800",
+  SYNCING: "bg-blue-100 text-blue-800",
+  SYNCED: "bg-green-100 text-green-800",
+  FAILED: "bg-red-100 text-red-800",
+  PARTIAL: "bg-orange-100 text-orange-800",
+};
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
+export function LoanProductEligibilityManager() {
+  const [products, setProducts] = useState<LoanProductOption[]>([]);
+  const [uploads, setUploads] = useState<UploadRecord[]>([]);
+  const [selectedProductId, setSelectedProductId] = useState<string>("");
+  const [file, setFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [loadingProducts, setLoadingProducts] = useState(false);
+  const [loadingUploads, setLoadingUploads] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [syncingUploadId, setSyncingUploadId] = useState<string | null>(null);
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [viewUpload, setViewUpload] = useState<UploadRecord | null>(null);
+  const [recordsData, setRecordsData] = useState<ItemsPage | null>(null);
+  const [recordsPage, setRecordsPage] = useState(1);
+  const [recordsSearch, setRecordsSearch] = useState("");
+  const [loadingRecords, setLoadingRecords] = useState(false);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const selectedProduct = useMemo(
+    () => products.find((p) => String(p.id) === selectedProductId) || null,
+    [products, selectedProductId]
+  );
+
+  // uploads is sorted newest-first; only the latest upload per product can be resynced,
+  // and only if it still has failed rows
+  const syncEligibleIds = useMemo(() => {
+    const seen = new Set<string>();
+    const eligible = new Set<string>();
+    for (const upload of uploads) {
+      if (!seen.has(upload.productExternalId)) {
+        seen.add(upload.productExternalId);
+        if (upload.failedRows > 0) {
+          eligible.add(upload.id);
+        }
+      }
+    }
+    return eligible;
+  }, [uploads]);
+
+  const fetchProducts = useCallback(async () => {
+    setLoadingProducts(true);
+    try {
+      const response = await fetch("/api/fineract/loanproducts");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data?.error || "Failed to load loan products");
+
+      const options: LoanProductOption[] = (Array.isArray(data) ? data : [])
+        .map((item) => item as LoanProductApiRecord)
+        .filter((item) => item.id != null && item.name != null)
+        .map((item) => ({
+          id: Number(item.id),
+          name: String(item.name),
+          shortName: item.shortName != null ? String(item.shortName) : undefined,
+        }));
+
+      setProducts(options);
+    } catch (e: unknown) {
+      toast.error(getErrorMessage(e, "Failed to load loan products"));
+    } finally {
+      setLoadingProducts(false);
+    }
+  }, []);
+
+  const fetchUploads = useCallback(async () => {
+    setLoadingUploads(true);
+    try {
+      const response = await fetch("/api/loan-product-eligibility/uploads");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data?.error || "Failed to load uploads");
+      setUploads(Array.isArray(data) ? data : []);
+    } catch (e: unknown) {
+      setError(getErrorMessage(e, "Failed to load uploads"));
+    } finally {
+      setLoadingUploads(false);
+    }
+  }, []);
+
+  const fetchRecords = useCallback(async (uploadId: string, page: number, search: string) => {
+    setLoadingRecords(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(page),
+        pageSize: "20",
+        ...(search ? { search } : {}),
+      });
+      const response = await fetch(`/api/loan-product-eligibility/uploads/${uploadId}/items?${params}`);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data?.error || "Failed to load records");
+      setRecordsData(data as ItemsPage);
+    } catch (e: unknown) {
+      toast.error(getErrorMessage(e, "Failed to load records"));
+    } finally {
+      setLoadingRecords(false);
+    }
+  }, []);
+
+  const openViewRecords = useCallback(
+    (upload: UploadRecord) => {
+      setViewUpload(upload);
+      setRecordsPage(1);
+      setRecordsSearch("");
+      setRecordsData(null);
+      void fetchRecords(upload.id, 1, "");
+    },
+    [fetchRecords]
+  );
+
+  const closeViewRecords = useCallback(() => {
+    setViewUpload(null);
+    setRecordsData(null);
+    setRecordsSearch("");
+    setRecordsPage(1);
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+  }, []);
+
+  const handleRecordsSearchChange = useCallback(
+    (value: string) => {
+      setRecordsSearch(value);
+      setRecordsPage(1);
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      if (!viewUpload) return;
+      searchDebounceRef.current = setTimeout(() => {
+        void fetchRecords(viewUpload.id, 1, value);
+      }, 350);
+    },
+    [fetchRecords, viewUpload]
+  );
+
+  const handleRecordsPageChange = useCallback(
+    (nextPage: number) => {
+      if (!viewUpload) return;
+      setRecordsPage(nextPage);
+      void fetchRecords(viewUpload.id, nextPage, recordsSearch);
+    },
+    [fetchRecords, recordsSearch, viewUpload]
+  );
+
+  useEffect(() => {
+    void fetchUploads();
+  }, [fetchUploads]);
+
+  useEffect(() => {
+    if (isUploadModalOpen && products.length === 0 && !loadingProducts) {
+      void fetchProducts();
+    }
+  }, [fetchProducts, isUploadModalOpen, loadingProducts, products.length]);
+
+  // Poll while any upload is actively syncing
+  useEffect(() => {
+    const hasSyncing = uploads.some((u) => u.status === "SYNCING");
+    if (!hasSyncing) return;
+    const timer = setInterval(() => void fetchUploads(), 4000);
+    return () => clearInterval(timer);
+  }, [uploads, fetchUploads]);
+
+  const parseFile = useCallback((nextFile: File) => {
+    setValidationErrors([]);
+    setParsedItems([]);
+    setError(null);
+    setMessage(null);
+
+    Papa.parse(nextFile, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (results) => {
+        const headers = (results.meta.fields || []).map((h) => String(h));
+        const headerMap = new Map<string, string>();
+        for (const header of headers) {
+          headerMap.set(normalizeHeader(header), header);
+        }
+
+        const missing = REQUIRED_HEADERS.filter((required) => !headerMap.has(required));
+        if (missing.length > 0) {
+          setValidationErrors([
+            `Missing required column(s): ${missing.join(", ")}. Expected headers: name, NRC, phone`,
+          ]);
+          return;
+        }
+
+        const resolvedHeaders = {
+          name: headerMap.get("name")!,
+          nrc: headerMap.get("nrc")!,
+          phone: headerMap.get("phone")!,
+        };
+
+        const data = results.data as Record<string, string>[];
+        const items: ParsedItem[] = [];
+        const errors: string[] = [];
+
+        data.forEach((row, index) => {
+          const rowNumber = index + 1;
+          const name = (row[resolvedHeaders.name] || "").trim();
+          const nrc = (row[resolvedHeaders.nrc] || "").trim();
+          const phone = (row[resolvedHeaders.phone] || "").trim();
+
+          if (!name || !nrc || !phone) {
+            errors.push(`Row ${rowNumber}: name, NRC and phone are all required.`);
+            return;
+          }
+
+          items.push({ rowNumber, name, nrc, phone });
+        });
+
+        if (errors.length > 0) {
+          setValidationErrors(errors.slice(0, 20));
+          return;
+        }
+
+        if (items.length === 0) {
+          setValidationErrors(["No valid rows found in file."]);
+          return;
+        }
+
+        setParsedItems(items);
+      },
+      error: () => {
+        setValidationErrors(["Could not parse CSV file."]);
+      },
+    });
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextFile = event.target.files?.[0] || null;
+      setFile(nextFile);
+      setParsedItems([]);
+      setValidationErrors([]);
+      setMessage(null);
+      setError(null);
+      if (nextFile) {
+        parseFile(nextFile);
+      }
+    },
+    [parseFile]
+  );
+
+  const syncUpload = useCallback(
+    async (uploadId: string) => {
+      setSyncingUploadId(uploadId);
+      setError(null);
+      setMessage(null);
+      try {
+        const response = await fetch(`/api/loan-product-eligibility/uploads/${uploadId}/sync`, {
+          method: "POST",
+        });
+        const result = await response.json();
+        if (!response.ok) {
+          throw new Error(result?.error || "Sync failed");
+        }
+        setMessage(`Upload synced successfully (${result.syncedRows} rows).`);
+        await fetchUploads();
+      } catch (e: unknown) {
+        setError(getErrorMessage(e, "Sync failed"));
+        await fetchUploads();
+      } finally {
+        setSyncingUploadId(null);
+      }
+    },
+    [fetchUploads]
+  );
+
+  const handleUploadAndSync = useCallback(async () => {
+    if (!selectedProduct || !file || parsedItems.length === 0) return;
+
+    setUploading(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const createResponse = await fetch("/api/loan-product-eligibility/uploads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileName: file.name,
+          productExternalId: String(selectedProduct.id),
+          productName: selectedProduct.name,
+          items: parsedItems,
+        }),
+      });
+
+      const createResult = await createResponse.json();
+      if (!createResponse.ok) {
+        throw new Error(createResult?.error || "Upload failed");
+      }
+
+      setFile(null);
+      setParsedItems([]);
+      setValidationErrors([]);
+      setIsPreviewModalOpen(false);
+      setIsUploadModalOpen(false);
+      toast.success("Upload saved — syncing to USSD in the background.");
+      await fetchUploads();
+    } catch (e: unknown) {
+      setError(getErrorMessage(e, "Upload failed"));
+    } finally {
+      setUploading(false);
+    }
+  }, [fetchUploads, file, parsedItems, selectedProduct]);
+
+  const openUploadModal = useCallback(() => {
+    setError(null);
+    setMessage(null);
+    setIsPreviewModalOpen(false);
+    setIsUploadModalOpen(true);
+  }, []);
+
+  const resetUploadForm = useCallback(() => {
+    setFile(null);
+    setParsedItems([]);
+    setValidationErrors([]);
+  }, []);
+
+  const closeUploadFlow = useCallback(() => {
+    setIsPreviewModalOpen(false);
+    setIsUploadModalOpen(false);
+    resetUploadForm();
+  }, [resetUploadForm]);
+
+  const handlePreview = useCallback(() => {
+    if (!selectedProduct) {
+      setError("Please select a loan product.");
+      return;
+    }
+    if (!file) {
+      setError("Please choose a CSV file.");
+      return;
+    }
+    if (validationErrors.length > 0 || parsedItems.length === 0) {
+      setError("Please fix CSV validation errors before preview.");
+      return;
+    }
+    setError(null);
+    setIsUploadModalOpen(false);
+    setIsPreviewModalOpen(true);
+  }, [file, parsedItems.length, selectedProduct, validationErrors.length]);
+
+  const previewRows = parsedItems.slice(0, 5);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <CardTitle>Loan Product Eligibility Uploads</CardTitle>
+              <CardDescription>
+                Upload CSV with mandatory columns: <strong>name</strong>, <strong>NRC</strong>,{" "}
+                <strong>phone</strong>. New synced upload replaces previous whitelist for that product in USSD.
+              </CardDescription>
+            </div>
+            <Button onClick={openUploadModal}>
+              <Upload className="mr-2 h-4 w-4" />
+              New Upload
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Dialog
+        open={isUploadModalOpen}
+        onOpenChange={(open) => {
+          setIsUploadModalOpen(open);
+          if (!open) {
+            setIsPreviewModalOpen(false);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Upload Eligibility CSV</DialogTitle>
+            <DialogDescription>
+              Select a loan product, upload your CSV, then preview before syncing.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Loan Product</label>
+              <Select value={selectedProductId} onValueChange={setSelectedProductId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={loadingProducts ? "Loading products..." : "Select product"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {products.map((product) => (
+                    <SelectItem key={product.id} value={String(product.id)}>
+                      {product.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                This product whitelist will be replaced by the uploaded file after sync.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">CSV File</label>
+              <Input className="w-full" type="file" accept=".csv,text/csv" onChange={handleFileChange} />
+              <p className="text-xs text-muted-foreground">
+                Required columns: <strong>name</strong>, <strong>NRC</strong>, <strong>phone</strong>.
+              </p>
+            </div>
+
+            {file && (
+              <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                File selected: <strong>{file.name}</strong>
+              </div>
+            )}
+
+            {validationErrors.length > 0 && (
+              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 space-y-1">
+                {validationErrors.map((item, index) => (
+                  <p key={`${item}-${index}`}>{item}</p>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                {parsedItems.length > 0 ? `${parsedItems.length} valid row(s) ready` : "No rows ready"}
+              </p>
+              <div className="flex w-full flex-col sm:w-auto sm:flex-row items-stretch sm:items-center gap-2">
+                <Button className="w-full sm:w-auto" variant="outline" onClick={closeUploadFlow}>
+                  Cancel
+                </Button>
+                <Button className="w-full sm:w-auto" onClick={handlePreview} disabled={!selectedProduct || parsedItems.length === 0}>
+                  Preview CSV
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isPreviewModalOpen} onOpenChange={setIsPreviewModalOpen}>
+        <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Preview Upload Data</DialogTitle>
+            <DialogDescription>
+              Review CSV rows before syncing whitelist to USSD.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="text-sm text-muted-foreground">
+              Product: <strong>{selectedProduct?.name || "-"}</strong>
+              {file ? (
+                <>
+                  {" "}
+                  | File: <strong>{file.name}</strong>
+                </>
+              ) : null}
+            </div>
+
+            {previewRows.length > 0 && (
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>#</TableHead>
+                      <TableHead>Name</TableHead>
+                      <TableHead>NRC</TableHead>
+                      <TableHead>Phone</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {previewRows.map((row) => (
+                      <TableRow key={row.rowNumber}>
+                        <TableCell>{row.rowNumber}</TableCell>
+                        <TableCell>{row.name}</TableCell>
+                        <TableCell>{row.nrc}</TableCell>
+                        <TableCell>{row.phone}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                {parsedItems.length} valid row(s) ready to upload and sync
+              </p>
+              <div className="flex w-full flex-col sm:w-auto sm:flex-row items-stretch sm:items-center gap-2">
+                <Button
+                  className="w-full sm:w-auto"
+                  variant="outline"
+                  onClick={() => {
+                    setIsPreviewModalOpen(false);
+                    setIsUploadModalOpen(true);
+                  }}
+                >
+                  Back
+                </Button>
+                <Button
+                  className="w-full sm:w-auto"
+                  onClick={handleUploadAndSync}
+                  disabled={!selectedProduct || parsedItems.length === 0 || uploading}
+                >
+                  {uploading ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Upload className="mr-2 h-4 w-4" />
+                  )}
+                  Upload
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!viewUpload} onOpenChange={(open) => { if (!open) closeViewRecords(); }}>
+        <DialogContent className="sm:max-w-4xl max-h-[90vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Upload Records</DialogTitle>
+            <DialogDescription>
+              {viewUpload ? (
+                <>
+                  <strong>{viewUpload.productName}</strong> &mdash; {viewUpload.fileName} &mdash; uploaded{" "}
+                  {format(new Date(viewUpload.createdAt), "dd MMM yyyy HH:mm")}
+                </>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="pl-8"
+              placeholder="Search by name, NRC or phone…"
+              value={recordsSearch}
+              onChange={(e) => handleRecordsSearchChange(e.target.value)}
+            />
+          </div>
+
+          <div className="flex-1 overflow-auto rounded-md border">
+            {loadingRecords ? (
+              <div className="space-y-3 p-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-full" />
+                ))}
+              </div>
+            ) : !recordsData || recordsData.items.length === 0 ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                {recordsSearch ? "No records match your search." : "No records found."}
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">#</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>NRC</TableHead>
+                    <TableHead>Phone</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {recordsData.items.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="text-muted-foreground">{item.rowNumber}</TableCell>
+                      <TableCell>{item.name}</TableCell>
+                      <TableCell>{item.nrc}</TableCell>
+                      <TableCell>{item.normalizedPhone || item.phone}</TableCell>
+                      <TableCell>
+                        <Badge className={cn("gap-1 text-xs", STATUS_STYLES[item.status] || "bg-slate-100 text-slate-800")}>
+                          {item.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+
+          {recordsData && recordsData.total > 0 && (
+            <div className="flex items-center justify-between gap-2 pt-1 text-sm text-muted-foreground">
+              <span>
+                {recordsData.total} record{recordsData.total !== 1 ? "s" : ""}
+                {recordsSearch ? " matching" : ""}
+                {" — page "}
+                {recordsData.page} of {Math.ceil(recordsData.total / recordsData.pageSize)}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-7 w-7"
+                  disabled={recordsPage <= 1 || loadingRecords}
+                  onClick={() => handleRecordsPageChange(recordsPage - 1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-7 w-7"
+                  disabled={recordsPage >= Math.ceil(recordsData.total / recordsData.pageSize) || loadingRecords}
+                  onClick={() => handleRecordsPageChange(recordsPage + 1)}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {message && (
+        <div className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">{message}</div>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <CardTitle>Upload History</CardTitle>
+              <CardDescription>Shows whether each upload has synced to USSD.</CardDescription>
+            </div>
+            <Button variant="outline" size="icon" onClick={() => void fetchUploads()} disabled={loadingUploads}>
+              <RefreshCw className={cn("h-4 w-4", loadingUploads && "animate-spin")} />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loadingUploads ? (
+            <div className="space-y-3 py-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : uploads.length === 0 ? (
+            <div className="py-8 text-sm text-muted-foreground">No uploads yet.</div>
+          ) : (
+            <div className="rounded-md border overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Uploaded At</TableHead>
+                    <TableHead>Product</TableHead>
+                    <TableHead>File</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Rows</TableHead>
+                    <TableHead>Uploaded By</TableHead>
+                    <TableHead>Sync Error</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {uploads.map((upload) => (
+                    <TableRow key={upload.id}>
+                      <TableCell>{format(new Date(upload.createdAt), "dd MMM yyyy HH:mm")}</TableCell>
+                      <TableCell>{upload.productName}</TableCell>
+                      <TableCell>{upload.fileName}</TableCell>
+                      <TableCell>
+                        <Badge className={cn("gap-1", STATUS_STYLES[upload.status] || "bg-slate-100 text-slate-800")}>
+                          {upload.status === "SYNCED" && <CheckCircle2 className="h-3 w-3" />}
+                          {upload.status === "FAILED" && <XCircle className="h-3 w-3" />}
+                          {upload.status === "SYNCING" && <Loader2 className="h-3 w-3 animate-spin" />}
+                          {upload.status === "STAGING" && <AlertCircle className="h-3 w-3" />}
+                          {upload.status === "PARTIAL" && <AlertCircle className="h-3 w-3" />}
+                          {upload.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {upload.syncedRows}/{upload.totalRows}
+                      </TableCell>
+                      <TableCell>{upload.uploadedBy}</TableCell>
+                      <TableCell className="max-w-[280px] truncate" title={upload.syncError || ""}>
+                        {upload.syncError || "-"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openViewRecords(upload)}
+                          >
+                            <Eye className="h-4 w-4" />
+                            <span className="ml-1">View</span>
+                          </Button>
+                          {syncEligibleIds.has(upload.id) && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => void syncUpload(upload.id)}
+                              disabled={syncingUploadId === upload.id || upload.status === "SYNCING"}
+                            >
+                              {syncingUploadId === upload.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                "Sync"
+                              )}
+                            </Button>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(application)/collections/loan-product-eligibility/page.tsx
+++ b/app/(application)/collections/loan-product-eligibility/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { LoanProductEligibilityManager } from "./components/loan-product-eligibility-manager";
+
+export const metadata: Metadata = {
+  title: "Loan Product Eligibility | KENAC Loan Matrix",
+  description: "Upload and sync product-specific user eligibility for USSD loan applications",
+};
+
+export default function LoanProductEligibilityPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Loan Product Eligibility</h2>
+        <p className="text-muted-foreground">
+          Upload CSV files with Name, NRC and Phone to control who can apply for selected loan products in USSD.
+        </p>
+      </div>
+      <LoanProductEligibilityManager />
+    </div>
+  );
+}

--- a/app/(application)/components/mobile-sidebar.tsx
+++ b/app/(application)/components/mobile-sidebar.tsx
@@ -272,6 +272,16 @@ export function MobileSidebar({ userProfileData, tenantLogoUrl }: MobileSidebarP
                   >
                     Bulk Receipting
                   </Link>
+                  <Link
+                    href="/collections/loan-product-eligibility"
+                    className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
+                      pathname === "/collections/loan-product-eligibility"
+                        ? iconColorActive
+                        : `${iconColor} hover:${textColor}`
+                    }`}
+                  >
+                    Loan Product Eligibility
+                  </Link>
                 </div>
               )}
             </div>

--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -74,6 +74,7 @@ export function SidebarNav() {
         subMenuItems={[
           { label: "Expected Payments", href: "/collections" },
           { label: "Bulk Receipting", href: "/collections/bulk-receipting" },
+          { label: "Loan Product Eligibility", href: "/collections/loan-product-eligibility" },
         ]}
       />
 

--- a/app/api/fineract/loanproducts/route.ts
+++ b/app/api/fineract/loanproducts/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { fetchFineractAPI } from "@/lib/api";
+
+type LoanProductsResponse = {
+  pageItems?: unknown[];
+  data?: unknown[];
+};
+
+export async function GET() {
+  try {
+    const data = (await fetchFineractAPI("/loanproducts")) as
+      | unknown[]
+      | LoanProductsResponse;
+
+    if (Array.isArray(data)) {
+      return NextResponse.json(data);
+    }
+
+    if (Array.isArray(data?.pageItems)) {
+      return NextResponse.json(data.pageItems);
+    }
+
+    if (Array.isArray(data?.data)) {
+      return NextResponse.json(data.data);
+    }
+
+    return NextResponse.json([]);
+  } catch (error: unknown) {
+    console.error("Error fetching loan products:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to fetch loan products";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/loan-product-eligibility/uploads/[id]/items/route.ts
+++ b/app/api/loan-product-eligibility/uploads/[id]/items/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { getSession } from "@/lib/auth";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const tenant = await getTenantFromHeaders();
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status")?.trim();
+    const search = searchParams.get("search")?.trim() || "";
+    const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+    const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+
+    const upload = await prisma.loanEligibilityUpload.findFirst({
+      where: { id, tenantId: tenant.id },
+      select: { id: true },
+    });
+    if (!upload) {
+      return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+    }
+
+    const where = {
+      uploadId: id,
+      ...(status ? { status } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: "insensitive" as const } },
+              { nrc: { contains: search, mode: "insensitive" as const } },
+              { normalizedPhone: { contains: search, mode: "insensitive" as const } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, items] = await Promise.all([
+      prisma.loanEligibilityUploadItem.count({ where }),
+      prisma.loanEligibilityUploadItem.findMany({
+        where,
+        orderBy: { rowNumber: "asc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+    ]);
+
+    return NextResponse.json({ items, total, page, pageSize });
+  } catch (error) {
+    console.error("Error fetching loan eligibility upload items:", error);
+    return NextResponse.json({ error: "Failed to fetch items" }, { status: 500 });
+  }
+}

--- a/app/api/loan-product-eligibility/uploads/[id]/sync/route.ts
+++ b/app/api/loan-product-eligibility/uploads/[id]/sync/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { getSession } from "@/lib/auth";
+import { performEligibilitySync } from "@/lib/loan-eligibility-sync";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  try {
+    const tenant = await getTenantFromHeaders();
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const upload = await prisma.loanEligibilityUpload.findFirst({
+      where: { id, tenantId: tenant.id },
+      select: { id: true, status: true },
+    });
+
+    if (!upload) {
+      return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+    }
+
+    if (upload.status === "SYNCING") {
+      return NextResponse.json({ error: "Sync already in progress" }, { status: 409 });
+    }
+
+    await performEligibilitySync(id);
+
+    const updated = await prisma.loanEligibilityUpload.findUnique({
+      where: { id },
+      select: { status: true, syncedRows: true, failedRows: true },
+    });
+
+    return NextResponse.json({ success: true, ...updated });
+  } catch (error: unknown) {
+    console.error("Error triggering loan eligibility sync:", error);
+    const message = error instanceof Error ? error.message : "Sync failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/loan-product-eligibility/uploads/route.ts
+++ b/app/api/loan-product-eligibility/uploads/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import prisma from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { getSession } from "@/lib/auth";
+import { performEligibilitySync } from "@/lib/loan-eligibility-sync";
+
+const itemSchema = z.object({
+  rowNumber: z.number().int().positive(),
+  name: z.string().trim().min(1),
+  nrc: z.string().trim().min(1),
+  phone: z.string().trim().min(1),
+});
+
+const createUploadSchema = z.object({
+  fileName: z.string().trim().min(1),
+  productExternalId: z.string().trim().min(1),
+  productName: z.string().trim().min(1),
+  items: z.array(itemSchema).min(1),
+});
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function normalizePhoneNumber(input: string): string {
+  const digits = (input || "").replace(/[^0-9]/g, "");
+  if (!digits) return "";
+  if (digits.startsWith("260")) return digits;
+  if (digits.length === 9) return `260${digits}`;
+  if (digits.startsWith("0") && digits.length >= 10) return `260${digits.slice(1)}`;
+  return digits;
+}
+
+export async function GET() {
+  try {
+    const tenant = await getTenantFromHeaders();
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const uploads = await prisma.loanEligibilityUpload.findMany({
+      where: { tenantId: tenant.id },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      include: {
+        _count: {
+          select: { items: true },
+        },
+      },
+    });
+
+    return NextResponse.json(uploads);
+  } catch (error: unknown) {
+    console.error("Error fetching loan eligibility uploads:", error);
+
+    // If local DB hasn't applied this migration yet, treat as empty history instead of hard-failing UI.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021"
+    ) {
+      return NextResponse.json([]);
+    }
+
+    return NextResponse.json({ error: "Failed to fetch uploads" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const tenant = await getTenantFromHeaders();
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const payload = createUploadSchema.parse(await request.json());
+
+    const duplicateMap = new Map<string, number[]>();
+    const normalizedRows = payload.items.map((row) => {
+      const normalizedPhone = normalizePhoneNumber(row.phone);
+      if (!normalizedPhone) {
+        throw new Error(`Invalid phone number at row ${row.rowNumber}`);
+      }
+      const current = duplicateMap.get(normalizedPhone) || [];
+      current.push(row.rowNumber);
+      duplicateMap.set(normalizedPhone, current);
+      return {
+        ...row,
+        normalizedPhone,
+      };
+    });
+
+    const duplicates = Array.from(duplicateMap.entries()).filter(([, rows]) => rows.length > 1);
+    if (duplicates.length > 0) {
+      const detail = duplicates
+        .map(([phone, rows]) => `${phone} (rows: ${rows.join(", ")})`)
+        .join("; ");
+      return NextResponse.json(
+        { error: `Duplicate phone numbers found: ${detail}` },
+        { status: 400 }
+      );
+    }
+
+    const uploadedBy =
+      session.user.name ||
+      session.user.email ||
+      String(session.user.userId ?? session.user.id ?? "unknown");
+
+    const upload = await prisma.loanEligibilityUpload.create({
+      data: {
+        tenantId: tenant.id,
+        fileName: payload.fileName,
+        productExternalId: payload.productExternalId,
+        productName: payload.productName,
+        uploadedBy,
+        status: "STAGING",
+        totalRows: normalizedRows.length,
+        items: {
+          create: normalizedRows.map((row) => ({
+            rowNumber: row.rowNumber,
+            name: row.name,
+            nrc: row.nrc,
+            phone: row.phone,
+            normalizedPhone: row.normalizedPhone,
+            status: "PENDING",
+          })),
+        },
+      },
+    });
+
+    // Fire background sync — don't await so the response returns immediately
+    void performEligibilitySync(upload.id).catch((e: unknown) => {
+      console.error("Background eligibility sync failed for upload", upload.id, e);
+    });
+
+    return NextResponse.json({ id: upload.id, totalRows: upload.totalRows }, { status: 201 });
+  } catch (error: unknown) {
+    console.error("Error creating loan eligibility upload:", error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues.map((issue) => issue.message).join(", ") },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({ error: getErrorMessage(error, "Failed to create upload") }, { status: 500 });
+  }
+}

--- a/env.example
+++ b/env.example
@@ -34,3 +34,7 @@ NODE_ENV=development
 # Notifications Service Configuration
 NOTIFICATION_SERVICE_URL=http://kenac-notification-service-dev.10.10.0.24.nip.io:31778
 TENANT_ID=goodfellow
+
+# USSD Loan Product Whitelist Sync Configuration
+USSD_BASE_URL=http://localhost:8080/api/v1
+USSD_LOAN_PRODUCT_SYNC_API_KEY=

--- a/lib/loan-eligibility-sync.ts
+++ b/lib/loan-eligibility-sync.ts
@@ -1,0 +1,161 @@
+import prisma from "@/lib/prisma";
+
+const BATCH_SIZE = 100;
+
+function ussdBaseUrl() {
+  return (process.env.USSD_BASE_URL ?? "").replace(/\/$/, "");
+}
+
+function syncApiKey() {
+  return process.env.USSD_LOAN_PRODUCT_SYNC_API_KEY ?? "";
+}
+
+type SyncEntry = { name: string; nrc: string; phone: string };
+type BatchEntryResult = { phone: string; success: boolean; errorMessage: string | null };
+type BatchResponse = { batchNumber: number; results: BatchEntryResult[] };
+
+async function pushBatch(params: {
+  productExternalId: string;
+  uploadId: string;
+  batchNumber: number;
+  isFirstBatch: boolean;
+  entries: SyncEntry[];
+}): Promise<BatchResponse> {
+  const base = ussdBaseUrl();
+  if (!base) throw new Error("USSD_LOAN_PRODUCTS_BASE_URL is not configured");
+
+  const url = `${base}/api/v1/loan-products/external/${encodeURIComponent(params.productExternalId)}/whitelist/batch`;
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const key = syncApiKey();
+  if (key) headers["X-Sync-Api-Key"] = key;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      uploadId: params.uploadId,
+      batchNumber: params.batchNumber,
+      firstBatch: params.isFirstBatch,
+      entries: params.entries,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`USSD batch ${params.batchNumber} failed (${response.status}): ${text || response.statusText}`);
+  }
+
+  return response.json() as Promise<BatchResponse>;
+}
+
+export async function performEligibilitySync(uploadId: string): Promise<void> {
+  const upload = await prisma.loanEligibilityUpload.findUnique({
+    where: { id: uploadId },
+    select: { id: true, productExternalId: true, syncedRows: true, status: true },
+  });
+
+  if (!upload || upload.status === "SYNCING") return;
+
+  const isFirstSync = upload.syncedRows === 0;
+
+  const items = await prisma.loanEligibilityUploadItem.findMany({
+    where: { uploadId, status: { in: ["PENDING", "FAILED"] } },
+    orderBy: { rowNumber: "asc" },
+    select: { id: true, name: true, nrc: true, normalizedPhone: true },
+  });
+
+  if (items.length === 0) {
+    // Nothing left to sync — recount and mark final status
+    await finaliseCounts(uploadId);
+    return;
+  }
+
+  await prisma.loanEligibilityUpload.update({
+    where: { id: uploadId },
+    data: { status: "SYNCING", syncError: null },
+  });
+
+  const chunks: typeof items[] = [];
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    chunks.push(items.slice(i, i + BATCH_SIZE));
+  }
+
+  let lastError: string | null = null;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const batch = chunks[i];
+    const isFirstBatch = isFirstSync && i === 0;
+
+    try {
+      const result = await pushBatch({
+        productExternalId: upload.productExternalId,
+        uploadId,
+        batchNumber: i + 1,
+        isFirstBatch,
+        entries: batch.map((item) => ({ name: item.name, nrc: item.nrc, phone: item.normalizedPhone })),
+      });
+
+      const resultMap = new Map(result.results.map((r) => [r.phone, r]));
+
+      await Promise.all(
+        batch.map((item) => {
+          const r = resultMap.get(item.normalizedPhone);
+          const success = r?.success ?? false;
+          return prisma.loanEligibilityUploadItem.update({
+            where: { id: item.id },
+            data: {
+              status: success ? "SYNCED" : "FAILED",
+              errorMessage: success ? null : (r?.errorMessage ?? "No result returned"),
+            },
+          });
+        })
+      );
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Sync failed";
+      lastError = message;
+
+      await prisma.loanEligibilityUploadItem.updateMany({
+        where: { id: { in: batch.map((item) => item.id) } },
+        data: { status: "FAILED", errorMessage: message },
+      });
+    }
+
+    // Update live counts after each batch so UI polling sees progress
+    await updateLiveCounts(uploadId);
+  }
+
+  await finaliseCounts(uploadId, lastError);
+}
+
+async function updateLiveCounts(uploadId: string) {
+  const [syncedRows, failedRows] = await Promise.all([
+    prisma.loanEligibilityUploadItem.count({ where: { uploadId, status: "SYNCED" } }),
+    prisma.loanEligibilityUploadItem.count({ where: { uploadId, status: "FAILED" } }),
+  ]);
+  await prisma.loanEligibilityUpload.update({
+    where: { id: uploadId },
+    data: { syncedRows, failedRows },
+  });
+}
+
+async function finaliseCounts(uploadId: string, lastError: string | null = null) {
+  const [syncedRows, failedRows] = await Promise.all([
+    prisma.loanEligibilityUploadItem.count({ where: { uploadId, status: "SYNCED" } }),
+    prisma.loanEligibilityUploadItem.count({ where: { uploadId, status: "FAILED" } }),
+  ]);
+
+  let status: string;
+  if (failedRows === 0) {
+    status = "SYNCED";
+  } else if (syncedRows === 0) {
+    status = "FAILED";
+  } else {
+    status = "PARTIAL";
+  }
+
+  await prisma.loanEligibilityUpload.update({
+    where: { id: uploadId },
+    data: { status, syncedRows, failedRows, syncError: lastError },
+  });
+}

--- a/prisma/migrations/20260525120000_add_loan_eligibility_uploads/migration.sql
+++ b/prisma/migrations/20260525120000_add_loan_eligibility_uploads/migration.sql
@@ -1,0 +1,55 @@
+-- Create table for product eligibility uploads (history)
+CREATE TABLE "LoanEligibilityUpload" (
+  "id" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "fileName" TEXT NOT NULL,
+  "productExternalId" TEXT NOT NULL,
+  "productName" TEXT NOT NULL,
+  "uploadedBy" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'STAGING',
+  "totalRows" INTEGER NOT NULL DEFAULT 0,
+  "syncedRows" INTEGER NOT NULL DEFAULT 0,
+  "failedRows" INTEGER NOT NULL DEFAULT 0,
+  "syncError" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "LoanEligibilityUpload_pkey" PRIMARY KEY ("id")
+);
+
+-- Create table for row-level upload items
+CREATE TABLE "LoanEligibilityUploadItem" (
+  "id" TEXT NOT NULL,
+  "uploadId" TEXT NOT NULL,
+  "rowNumber" INTEGER NOT NULL,
+  "name" TEXT NOT NULL,
+  "nrc" TEXT NOT NULL,
+  "phone" TEXT NOT NULL,
+  "normalizedPhone" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'PENDING',
+  "errorMessage" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "LoanEligibilityUploadItem_pkey" PRIMARY KEY ("id")
+);
+
+-- Foreign key
+ALTER TABLE "LoanEligibilityUploadItem"
+ADD CONSTRAINT "LoanEligibilityUploadItem_uploadId_fkey"
+FOREIGN KEY ("uploadId") REFERENCES "LoanEligibilityUpload"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Indexes
+CREATE INDEX "LoanEligibilityUpload_tenantId_createdAt_idx"
+ON "LoanEligibilityUpload"("tenantId", "createdAt");
+
+CREATE INDEX "LoanEligibilityUpload_tenantId_productExternalId_idx"
+ON "LoanEligibilityUpload"("tenantId", "productExternalId");
+
+CREATE INDEX "LoanEligibilityUpload_tenantId_status_idx"
+ON "LoanEligibilityUpload"("tenantId", "status");
+
+CREATE INDEX "LoanEligibilityUploadItem_uploadId_status_idx"
+ON "LoanEligibilityUploadItem"("uploadId", "status");
+
+CREATE INDEX "LoanEligibilityUploadItem_uploadId_normalizedPhone_idx"
+ON "LoanEligibilityUploadItem"("uploadId", "normalizedPhone");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -910,6 +910,45 @@ model BulkRepaymentItem {
   @@index([loanId])
 }
 
+model LoanEligibilityUpload {
+  id                String                    @id @default(cuid())
+  tenantId          String
+  fileName          String
+  productExternalId String
+  productName       String
+  uploadedBy        String
+  status            String                    @default("STAGING") // STAGING, SYNCING, SYNCED, FAILED
+  totalRows         Int                       @default(0)
+  syncedRows        Int                       @default(0)
+  failedRows        Int                       @default(0)
+  syncError         String?
+  createdAt         DateTime                  @default(now())
+  updatedAt         DateTime                  @updatedAt
+  items             LoanEligibilityUploadItem[]
+
+  @@index([tenantId, createdAt])
+  @@index([tenantId, productExternalId])
+  @@index([tenantId, status])
+}
+
+model LoanEligibilityUploadItem {
+  id              String              @id @default(cuid())
+  uploadId        String
+  upload          LoanEligibilityUpload @relation(fields: [uploadId], references: [id], onDelete: Cascade)
+  rowNumber       Int
+  name            String
+  nrc             String
+  phone           String
+  normalizedPhone String
+  status          String              @default("PENDING") // PENDING, SYNCED, FAILED
+  errorMessage    String?
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+
+  @@index([uploadId, status])
+  @@index([uploadId, normalizedPhone])
+}
+
 model ReceiptRange {
   id         String   @id @default(cuid())
   tenantId   String


### PR DESCRIPTION
## Summary

- New **Loan Product Eligibility** page (`/collections/loan-product-eligibility`) for uploading CSV whitelists (name, NRC, phone) per loan product
- Upload is saved to DB immediately; modal closes, then sync to USSD kicks off in background batches of 100
- USSD sync is row-by-row with per-entry status returned — Loan Matrix tracks which records actually synced vs failed
- On first sync, USSD deactivates the existing whitelist for that product before inserting new entries; retries only resend failed rows
- Upload history table: paginated **View Records** modal with debounced search (name/NRC/phone), **Sync** button shown only on the latest upload per product when failed rows exist
- Prisma models: `LoanEligibilityUpload` + `LoanEligibilityUploadItem` with migration
- `env.example` updated with `USSD_BASE_URL` and `USSD_LOAN_PRODUCT_SYNC_API_KEY`

## Test plan

- [ ] Upload a valid CSV for a whitelisted loan product and confirm modal closes immediately after save, sync runs in background
- [ ] Verify upload history shows row-level SYNCED/FAILED status after sync completes
- [ ] Confirm Sync button only appears on the latest upload per product when `failedRows > 0`
- [ ] Retry sync on a partially failed upload — confirm only FAILED rows are re-sent, SYNCED rows untouched
- [ ] View Records modal: search by name, NRC, and phone number; verify pagination works
- [ ] Upload a CSV with duplicate phone numbers — confirm validation error before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)