### PR TITLE
fix(build): add force-dynamic to parameterless GET routes

### DIFF
--- a/app/api/fineract/loanproducts/route.ts
+++ b/app/api/fineract/loanproducts/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
 

--- a/app/api/loan-product-eligibility/uploads/route.ts
+++ b/app/api/loan-product-eligibility/uploads/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { z } from "zod";


### PR DESCRIPTION
## Summary

- Adds export const dynamic to uploads/route.ts and fineract/loanproducts/route.ts
- Both have parameterless GET() handlers — Next.js treats them as static and executes them at build time, triggering the Prisma import chain which fails with MODULE_NOT_FOUND in pnpm isolated node_modules

## Test plan

- [ ] CI Docker build passes without MODULE_NOT_FOUND error on /api/loan-product-eligibility/uploads

Generated with Claude Code