### PR TITLE
fix(build): import Prisma from generated path instead of @prisma/client

### DIFF
--- a/app/api/loan-product-eligibility/uploads/route.ts
+++ b/app/api/loan-product-eligibility/uploads/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@/app/generated/prisma";
 import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";


### PR DESCRIPTION
## Summary

- Fixes CI Docker build failure caused by direct import of @prisma/client in uploads/route.ts
- @prisma/client tries to load .prisma/client/default which does not exist in pnpm isolated node_modules when a custom output path is configured
- Changed to import Prisma from @/app/generated/prisma (the custom output path) to match how the rest of the codebase resolves it

## Test plan

- [ ] CI Docker build passes

Generated with Claude Code