### PR TITLE
fix(leads): restrict Configuration menu to SUPER_ADMIN only

### DIFF
--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -42,7 +42,8 @@ export function SidebarNav() {
   // Only add Configuration for admins/super admins AND if feature is enabled
   if (
     !rolesLoading &&
-    hasAnyRole(["ADMIN", "SUPER_ADMIN", "BRANCH_MANAGER"]) &&
+    // hasAnyRole(["ADMIN", "SUPER_ADMIN", "BRANCH_MANAGER"]) &&
+    hasAnyRole(["SUPER_ADMIN"]) &&
     isEnabled("leadConfig")
   ) {
     leadsSubMenuItems.push({ label: "Configuration", href: "/leads/config" });


### PR DESCRIPTION
## Summary
- Removed `ADMIN` and `BRANCH_MANAGER` from the role check that controls visibility of the **Configuration** menu item under Leads in the sidebar
- Menu is now only visible to users with `SUPER_ADMIN` role
- Old role list is preserved as a comment for reference

## Test plan
- [ ] Log in as a `SUPER_ADMIN` user — Configuration menu should be visible under Leads
- [ ] Log in as an `ADMIN` or `BRANCH_MANAGER` user — Configuration menu should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)