### PR TITLE
Add loan document audit and download support

### DIFF
--- a/app/(application)/clients/[id]/components/client-documents.tsx
+++ b/app/(application)/clients/[id]/components/client-documents.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { downloadClientDocumentAttachment } from "@/app/actions/client-document-actions";
+import { formatDateDdMmYyyy } from "@/lib/date-format";
 
 interface FineractDocument {
   id: number;
@@ -331,6 +332,7 @@ export function ClientDocuments({ clientId }: ClientDocumentsProps) {
                   <TableHead>Type</TableHead>
                   <TableHead>Size</TableHead>
                   <TableHead>Uploaded By</TableHead>
+                  <TableHead>Uploaded On</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -362,6 +364,11 @@ export function ClientDocuments({ clientId }: ClientDocumentsProps) {
                     <TableCell>
                       <span className="text-sm">
                         {document.uploadedBy?.trim() || "---"}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-sm">
+                        {formatDateDdMmYyyy(document.uploadedAt || document.createdDate)}
                       </span>
                     </TableCell>
                     <TableCell className="text-right">

--- a/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
@@ -17,7 +17,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/use-toast";
-import { AlertCircle, Download, MoreVertical, X, ChevronsLeft, ChevronLeft, ChevronRight, ChevronsRight, Edit, Flag, Plus, Heart, Coins, RotateCcw, Calendar, ChevronRight as ChevronRightIcon, User, Building, Phone, Mail, CreditCard, TrendingUp, Clock, FileText, Shield, DollarSign, Percent, CalendarDays, Settings, Trash2, StickyNote } from "lucide-react";
+import { AlertCircle, Download, Loader2, MoreVertical, X, ChevronsLeft, ChevronLeft, ChevronRight, ChevronsRight, Edit, Flag, Plus, Heart, Coins, RotateCcw, Calendar, ChevronRight as ChevronRightIcon, User, Building, Phone, Mail, CreditCard, TrendingUp, Clock, FileText, Shield, DollarSign, Percent, CalendarDays, Settings, Trash2, StickyNote } from "lucide-react";
 import { ClientTransactions } from "../../../components/client-transactions";
 import { RepaymentModal } from "./repayment-modal";
 import { PaymentModal } from "./payment-modal";
@@ -39,12 +39,20 @@ import CreateGuarantorModal from "@/components/CreateGuarantorModal";
 import RecoverFromGuarantorModal from "@/components/RecoverFromGuarantorModal";
 import SellLoanModal from "@/components/SellLoanModal";
 import { TransactionsDataTable } from "./transactions-data-table";
+import { downloadLoanDocumentAttachment } from "@/app/actions/loan-document-actions";
+import { formatDateDdMmYyyy } from "@/lib/date-format";
 import { FineractClient, FineractLoan } from "@/shared/types";
 
 interface ClientLoanDetailsProps {
   clientId: number;
   loanId: number;
 }
+
+type LoanDocumentDownloadItem = {
+  id: number | string;
+  fileName?: string;
+  name?: string;
+};
 
 export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) {
   const router = useRouter();
@@ -70,6 +78,7 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
   const [submittingReschedule, setSubmittingReschedule] = useState(false);
   const [documents, setDocuments] = useState<any[]>([]);
   const [loadingDocuments, setLoadingDocuments] = useState(false);
+  const [downloadingDocumentId, setDownloadingDocumentId] = useState<number | string | null>(null);
   const [showUploadDocuments, setShowUploadDocuments] = useState(false);
   const [submittingDocument, setSubmittingDocument] = useState(false);
   const [documentForm, setDocumentForm] = useState({
@@ -1370,7 +1379,17 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
       const response = await fetch(`/api/fineract/loans/${loanId}/documents`);
       if (response.ok) {
         const data = await response.json();
-        setDocuments(Array.isArray(data) ? data : []);
+        if (Array.isArray(data)) {
+          setDocuments(data);
+        } else if (data?.pageItems && Array.isArray(data.pageItems)) {
+          setDocuments(data.pageItems);
+        } else if (data?.content && Array.isArray(data.content)) {
+          setDocuments(data.content);
+        } else if (data?.documents && Array.isArray(data.documents)) {
+          setDocuments(data.documents);
+        } else {
+          setDocuments([]);
+        }
       } else {
         let errorData;
         try {
@@ -1405,69 +1424,52 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
     }
   };
 
-  // Download document
-  const handleDownloadDocument = async (documentId: string, fileName: string) => {
+  // Download document through a server action so the browser only handles the file blob.
+  const handleDownloadDocument = async (doc: LoanDocumentDownloadItem) => {
+    setDownloadingDocumentId(doc.id);
+
     try {
-      const response = await fetch(`/api/fineract/loans/${loanId}/documents/${documentId}/attachment`);
-      
-      if (response.ok) {
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = fileName;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-        
-        toast({
-          title: "Success",
-          description: "Document downloaded successfully!",
-          variant: "success",
-        });
-      } else {
-        // Try to parse as JSON, but handle cases where it's not JSON
-        let errorData: any = {};
-        let errorMessage = "Failed to download document";
-        
-        try {
-          const contentType = response.headers.get('content-type') || '';
-          if (contentType.includes('application/json')) {
-            errorData = await response.json();
-            console.error("Failed to download document:", errorData);
-            
-            if (errorData.defaultUserMessage) {
-              errorMessage = errorData.defaultUserMessage;
-            } else if (errorData.errors && errorData.errors.length > 0 && errorData.errors[0].defaultUserMessage) {
-              errorMessage = errorData.errors[0].defaultUserMessage;
-            } else if (errorData.error) {
-              errorMessage = errorData.error;
-            }
-          } else {
-            // Not JSON response, use status text
-            const responseText = await response.text();
-            console.error("Failed to download document (non-JSON):", response.status, response.statusText, responseText);
-            errorMessage = `Download failed: ${response.status} ${response.statusText}`;
-          }
-        } catch (parseError) {
-          console.error("Error parsing download response:", parseError);
-          errorMessage = `Download failed: ${response.status} ${response.statusText}`;
-        }
-        
-        toast({
-          title: "Error",
-          description: errorMessage,
-          variant: "destructive",
-        });
+      const result = await downloadLoanDocumentAttachment(loanId, doc.id);
+
+      if (!result.success || !result.fileBuffer) {
+        throw new Error(result.error || "Failed to download document");
       }
+
+      const blob = new Blob([result.fileBuffer], {
+        type: result.contentType || "application/octet-stream",
+      });
+      const url = window.URL.createObjectURL(blob);
+      const link = window.document.createElement("a");
+      link.href = url;
+      link.download =
+        result.fileName ||
+        doc.fileName ||
+        doc.name ||
+        `document-${doc.id}`;
+      window.document.body.appendChild(link);
+      link.click();
+      window.document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+
+      toast({
+        title: "Success",
+        description: "Document downloaded successfully!",
+        variant: "success",
+      });
     } catch (error) {
       console.error("Error downloading document:", error);
       toast({
         title: "Error",
-        description: "An unexpected error occurred while downloading the document",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while downloading the document",
         variant: "destructive",
       });
+    } finally {
+      setDownloadingDocumentId((currentId) =>
+        currentId === doc.id ? null : currentId
+      );
     }
   };
 
@@ -3690,6 +3692,8 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
                       <TableHead>File Name</TableHead>
                         <TableHead>Size</TableHead>
                         <TableHead>Type</TableHead>
+                      <TableHead>Uploaded By</TableHead>
+                      <TableHead>Uploaded On</TableHead>
                       <TableHead>Actions</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -3699,28 +3703,70 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
                           <TableRow key={document.id || index}>
                           <TableCell className="font-medium">{document.name}</TableCell>
                             <TableCell>{document.description || "N/A"}</TableCell>
-                          <TableCell>{document.fileName}</TableCell>
+                            <TableCell>{document.fileName}</TableCell>
                             <TableCell>{document.size ? `${(document.size / 1024).toFixed(1)} KB` : "N/A"}</TableCell>
                             <TableCell>{document.type || "N/A"}</TableCell>
-                          <TableCell>
-                            <div className="flex space-x-1">
-                                <Button 
-                                  variant="outline" 
-                                  size="sm" 
-                                  className="h-8 w-8 p-0 bg-blue-500 text-white hover:bg-blue-600"
-                                  onClick={() => handleDownloadDocument(document.id, document.fileName)}
-                                  title="Download"
-                                >
-                                <Download className="h-4 w-4" />
+                            <TableCell>
+                              <span className="text-sm">
+                                {document.uploadedBy?.trim() || "---"}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              <span className="text-sm">
+                                {formatDateDdMmYyyy(
+                                  document.uploadedAt || document.createdDate
+                                )}
+                              </span>
+                            </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="gap-2"
+                                onClick={() => handleDownloadDocument(document)}
+                                disabled={downloadingDocumentId === document.id}
+                                title={
+                                  downloadingDocumentId === document.id
+                                    ? "Downloading document"
+                                    : "Download document"
+                                }
+                                aria-label={
+                                  downloadingDocumentId === document.id
+                                    ? `Downloading ${
+                                        document.name ||
+                                        document.fileName ||
+                                        `document ${document.id}`
+                                      }`
+                                    : `Download ${
+                                        document.name ||
+                                        document.fileName ||
+                                        `document ${document.id}`
+                                      }`
+                                }
+                              >
+                                {downloadingDocumentId === document.id ? (
+                                  <>
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                    <span>Downloading...</span>
+                                  </>
+                                ) : (
+                                  <>
+                                    <Download className="h-4 w-4" />
+                                    <span>Download</span>
+                                  </>
+                                )}
                               </Button>
-                                <Button 
-                                  variant="outline" 
-                                  size="sm" 
-                                  className="h-8 w-8 p-0 bg-red-500 text-white hover:bg-red-600"
-                                  onClick={() => handleDeleteDocument(document.id, document.fileName)}
-                                  title="Delete"
-                                >
-                                  <Trash2 className="h-4 w-4" />
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-8 w-8 p-0 bg-red-500 text-white hover:bg-red-600"
+                                onClick={() => handleDeleteDocument(document.id, document.fileName)}
+                                title="Delete"
+                              >
+                                <Trash2 className="h-4 w-4" />
                               </Button>
                             </div>
                           </TableCell>
@@ -3728,7 +3774,7 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
                       ))
                     ) : (
                       <TableRow>
-                          <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                          <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
                             <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
                             <p>No documents found for this loan</p>
                             <p className="text-sm mt-2">Click "+ Add" to upload documents</p>

--- a/app/actions/loan-document-actions.ts
+++ b/app/actions/loan-document-actions.ts
@@ -1,0 +1,126 @@
+"use server";
+
+import * as https from "https";
+import { getAccessToken, getFineractTenantId } from "@/lib/api";
+
+export interface DownloadLoanDocumentResult {
+  success: boolean;
+  fileName?: string;
+  contentType?: string;
+  fileBuffer?: ArrayBuffer;
+  error?: string;
+}
+
+function getFileNameFromContentDisposition(
+  contentDisposition: string | null
+): string | undefined {
+  if (!contentDisposition) return undefined;
+
+  const encodedMatch = contentDisposition.match(
+    /filename\*=UTF-8''([^;]+)/i
+  );
+  if (encodedMatch?.[1]) {
+    try {
+      return decodeURIComponent(encodedMatch[1]);
+    } catch {
+      return encodedMatch[1];
+    }
+  }
+
+  const plainMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return plainMatch?.[1];
+}
+
+export async function downloadLoanDocumentAttachment(
+  loanId: number | string,
+  documentId: number | string
+): Promise<DownloadLoanDocumentResult> {
+  try {
+    const accessToken = await getAccessToken();
+    const fineractTenantId = await getFineractTenantId();
+    const baseUrl =
+      process.env.FINERACT_BASE_URL || "http://10.10.0.143:8443";
+    const url = `${baseUrl.replace(
+      /\/$/,
+      ""
+    )}/fineract-provider/api/v1/loans/${loanId}/documents/${documentId}/attachment`;
+
+    const headers = {
+      Authorization: `Basic ${accessToken}`,
+      "Fineract-Platform-TenantId": fineractTenantId,
+      Accept: "application/json, text/plain, */*",
+    };
+
+    let response: Response;
+
+    if (baseUrl.startsWith("http://")) {
+      response = await fetch(url, {
+        method: "GET",
+        headers,
+        cache: "no-store",
+      });
+    } else {
+      const agent = new https.Agent({ rejectUnauthorized: false });
+
+      response = await fetch(url, {
+        method: "GET",
+        headers,
+        cache: "no-store",
+        // @ts-expect-error - Node fetch accepts `agent` for HTTPS requests
+        agent,
+      });
+    }
+
+    if (!response.ok) {
+      let errorMessage = "Failed to download document";
+
+      try {
+        const contentType = response.headers.get("content-type") || "";
+
+        if (contentType.includes("application/json")) {
+          const errorData = await response.json();
+          errorMessage =
+            errorData.defaultUserMessage ||
+            errorData.developerMessage ||
+            errorData.error ||
+            errorMessage;
+        } else {
+          const errorText = await response.text();
+          if (errorText.trim()) {
+            errorMessage = errorText;
+          }
+        }
+      } catch {
+        // Keep the default error message when the response body is not readable.
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+
+    const fileBuffer = await response.arrayBuffer();
+    const contentType =
+      response.headers.get("content-type") || "application/octet-stream";
+    const contentDisposition = response.headers.get("content-disposition");
+
+    return {
+      success: true,
+      fileBuffer,
+      contentType,
+      fileName:
+        getFileNameFromContentDisposition(contentDisposition) ||
+        `document-${documentId}`,
+    };
+  } catch (error) {
+    console.error("Error downloading loan document:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to download document",
+    };
+  }
+}

--- a/app/api/fineract/loans/[id]/documents/route.ts
+++ b/app/api/fineract/loans/[id]/documents/route.ts
@@ -1,5 +1,42 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { getSession } from "@/lib/auth";
+import {
+  extractTenantSlugFromRequest,
+  getTenantBySlug,
+} from "@/lib/tenant-service";
+import {
+  getFineractDocumentUploadRecords,
+  recordFineractDocumentUpload,
+} from "@/lib/fineract-document-upload-audit";
+
+type FineractDocumentWithUpload = {
+  id: number;
+  parentEntityType?: string;
+  parentEntityId?: number | string;
+  uploadedBy?: string;
+  uploadedAt?: string;
+  [key: string]: unknown;
+};
+
+function enrichDocuments(
+  documents: FineractDocumentWithUpload[],
+  uploadRecords: Map<number, { username: string; documentSavedAt: Date }>
+) {
+  return documents.map((document) => {
+    const uploadRecord = uploadRecords.get(Number(document.id));
+
+    if (!uploadRecord) {
+      return document;
+    }
+
+    return {
+      ...document,
+      uploadedBy: uploadRecord.username,
+      uploadedAt: uploadRecord.documentSavedAt.toISOString(),
+    };
+  });
+}
 
 export async function GET(
   request: NextRequest,
@@ -7,21 +44,67 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/documents`);
-    return NextResponse.json(data);
-  } catch (error: any) {
-    console.error("Error fetching loan documents:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
+    const numericLoanId = Number(loanId);
+
+    if (!Number.isFinite(numericLoanId)) {
       return NextResponse.json(
-        error.errorData,
-        { status: error.status }
+        { error: "Invalid loan ID" },
+        { status: 400 }
       );
     }
-    
+
+    const tenantSlug = extractTenantSlugFromRequest(request);
+    const tenant = await getTenantBySlug(tenantSlug);
+    const uploadRecords = tenant
+      ? await getFineractDocumentUploadRecords(tenant.id, "loans", numericLoanId)
+      : [];
+    const uploadRecordMap = new Map(
+      uploadRecords.map((record) => [record.documentId, record])
+    );
+
+    const data = await fetchFineractAPI(`/loans/${loanId}/documents`);
+
+    if (data && Array.isArray(data)) {
+      return NextResponse.json(
+        enrichDocuments(data as FineractDocumentWithUpload[], uploadRecordMap)
+      );
+    }
+
+    if (data?.pageItems && Array.isArray(data.pageItems)) {
+      data.pageItems = enrichDocuments(
+        data.pageItems as FineractDocumentWithUpload[],
+        uploadRecordMap
+      );
+    } else if (data?.content && Array.isArray(data.content)) {
+      data.content = enrichDocuments(
+        data.content as FineractDocumentWithUpload[],
+        uploadRecordMap
+      );
+    } else if (data?.documents && Array.isArray(data.documents)) {
+      data.documents = enrichDocuments(
+        data.documents as FineractDocumentWithUpload[],
+        uploadRecordMap
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching loan documents:", error);
+
+    const fineractError = error as {
+      status?: number;
+      errorData?: unknown;
+    };
+
+    if (fineractError.status && fineractError.errorData) {
+      return NextResponse.json(fineractError.errorData, {
+        status: fineractError.status,
+      });
+    }
+
+    const message = error instanceof Error ? error.message : "Failed to fetch loan documents";
     return NextResponse.json(
-      { error: error.message || "Failed to fetch loan documents" },
+      { error: message },
       { status: 500 }
     );
   }
@@ -33,52 +116,110 @@ export async function POST(
 ) {
   try {
     const { id: loanId } = await params;
-    
-    // Handle multipart form data for file upload
+    const numericLoanId = Number(loanId);
+
+    if (!Number.isFinite(numericLoanId)) {
+      return NextResponse.json(
+        { error: "Invalid loan ID" },
+        { status: 400 }
+      );
+    }
+
+    const session = await getSession();
+    const tenantSlug = extractTenantSlugFromRequest(request);
+    const tenant = await getTenantBySlug(tenantSlug);
+
     const formData = await request.formData();
-    
-    // Create FormData for the Fineract API call
     const fineractFormData = new FormData();
-    
-    // Get the form fields
-    const name = formData.get('name') as string;
-    const description = formData.get('description') as string;
-    const file = formData.get('file') as File;
-    
+
+    const name = formData.get("name") as string;
+    const description = formData.get("description") as string;
+    const file = formData.get("file") as File;
+
     if (!name || !file) {
       return NextResponse.json(
         { error: "Name and file are required" },
         { status: 400 }
       );
     }
-    
-    // Add fields to FormData for Fineract API
-    fineractFormData.append('name', name);
-    fineractFormData.append('file', file);
+
+    fineractFormData.append("name", name);
+    fineractFormData.append("file", file);
     if (description) {
-      fineractFormData.append('description', description);
+      fineractFormData.append("description", description);
     }
-    
-    // Use the existing fetchFineractAPI helper (now handles FormData correctly)
+
     const data = await fetchFineractAPI(`/loans/${loanId}/documents`, {
       method: "POST",
       body: fineractFormData,
     });
-    
-    return NextResponse.json(data);
-  } catch (error: any) {
-    console.error("Error uploading document:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
+
+    const uploadedDocumentId = Number(
+      data?.resourceId ?? data?.resourceIdentifier ?? data?.id
+    );
+
+    if (
+      tenant?.id &&
+      Number.isFinite(uploadedDocumentId) &&
+      session?.user?.userId &&
+      session.user.name
+    ) {
+      try {
+        const auditRecord = await recordFineractDocumentUpload({
+          tenantId: tenant.id,
+          entityType: "loans",
+          entityId: numericLoanId,
+          documentId: uploadedDocumentId,
+          fineractUserId: session.user.userId,
+          username: session.user.name,
+        });
+
+        console.log("Fineract document upload audit saved", {
+          tenantId: tenant.id,
+          entityType: "loans",
+          entityId: numericLoanId,
+          documentId: uploadedDocumentId,
+          fineractUserId: session.user.userId,
+          username: session.user.name,
+          documentSavedAt: auditRecord?.documentSavedAt?.toISOString?.(),
+        });
+      } catch (auditError) {
+        console.error(
+          "Document upload audit save failed, but Fineract upload succeeded:",
+          auditError
+        );
+      }
+    } else {
+      console.warn(
+        "Skipping document upload audit because tenant, document id, or session user data was unavailable",
+        {
+          tenantId: tenant?.id,
+          loanId: numericLoanId,
+          uploadedDocumentId,
+          fineractUserId: session?.user?.userId,
+          username: session?.user?.name,
+        }
       );
     }
-    
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error uploading loan document:", error);
+
+    const fineractError = error as {
+      status?: number;
+      errorData?: unknown;
+    };
+
+    if (fineractError.status && fineractError.errorData) {
+      return NextResponse.json(fineractError.errorData, {
+        status: fineractError.status,
+      });
+    }
+
+    const message = error instanceof Error ? error.message : "Failed to upload loan document";
     return NextResponse.json(
-      { error: error.message || "Failed to upload document" },
+      { error: message },
       { status: 500 }
     );
   }

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,0 +1,44 @@
+export function formatDateDdMmYyyy(
+  dateValue?: string | number | Date | null
+): string {
+  if (dateValue === null || dateValue === undefined || dateValue === "") {
+    return "---";
+  }
+
+  if (typeof dateValue === "string") {
+    const trimmed = dateValue.trim();
+
+    const matchedDate = trimmed.match(/^(\d{2})[/-](\d{2})[/-](\d{4})$/);
+    if (matchedDate) {
+      return `${matchedDate[1]}-${matchedDate[2]}-${matchedDate[3]}`;
+    }
+
+    const parsedStringDate = new Date(trimmed);
+    if (!Number.isNaN(parsedStringDate.getTime())) {
+      return new Intl.DateTimeFormat("en-GB", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+      })
+        .format(parsedStringDate)
+        .replace(/\//g, "-");
+    }
+
+    return "---";
+  }
+
+  const parsedDate =
+    dateValue instanceof Date ? dateValue : new Date(dateValue);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "---";
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  })
+    .format(parsedDate)
+    .replace(/\//g, "-");
+}


### PR DESCRIPTION
## Summary\n- add server-side loan document download handling\n- share date formatting for document tables\n- enrich document rows with audit metadata in client and loan details\n- backfill Fineract document upload audit records in Prisma\n\n## Notes\n- branch: parten-main\n- target: main