### PR TITLE
fix(accordion): replace radix-ui meta-package with @radix-ui/react-accordion

### DIFF
--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { ChevronDownIcon } from "lucide-react"
-import { Accordion as AccordionPrimitive } from "radix-ui"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
 
 import { cn } from "@/lib/utils"
 


### PR DESCRIPTION
## Summary
- Fixes Docker build failure caused by unresolvable `radix-ui` meta-package import in `components/ui/accordion.tsx`
- Replaced `import { Accordion as AccordionPrimitive } from "radix-ui"` with `import * as AccordionPrimitive from "@radix-ui/react-accordion"` which is already installed

## Test plan
- [ ] Verify Docker build completes successfully
- [ ] Confirm accordion component renders correctly in the loan products page

🤖 Generated with [Claude Code](https://claude.com/claude-code)