### PR TITLE
Fix report parameter loading

### DIFF
--- a/app/(application)/reports/[reportName]/page.tsx
+++ b/app/(application)/reports/[reportName]/page.tsx
@@ -182,6 +182,11 @@ export default function ReportDetailPage() {
     const fallbackValue = getInitialParameterValue(parentParam);
     if (fallbackValue) {
       fetchParams[parentParam.parameter_variable] = fallbackValue;
+      return;
+    }
+
+    if (parentParam.parameter_variable === "officeId") {
+      fetchParams[parentParam.parameter_variable] = "1";
     }
   };
   useEffect(() => {
@@ -284,7 +289,10 @@ export default function ReportDetailPage() {
     }
   };
 
-  const loadParameterOptions = async (params: ReportParameter[]) => {
+  const loadParameterOptions = async (
+    params: ReportParameter[],
+    currentParamValues: Record<string, string> = {}
+  ) => {
     const options: Record<string, ParameterOption[]> = {};
 
     for (const param of params) {
@@ -295,16 +303,11 @@ export default function ReportDetailPage() {
           const fetchParams: Record<string, string> = normalizeParameterValues(
             currentParamValues
           );
-          if (param.parentparametername) {
-            const parentParam = params.find(
-              (p) => p.parameter_name === param.parentparametername
-            );
-            if (parentParam && !fetchParams[parentParam.parameter_variable]) {
-              // Fallback: officeId=1 when parent Office has no selection yet
-              fetchParams[parentParam.parameter_variable] =
-                parentParam.parameter_variable === "officeId" ? "1" : "";
-            }
-          }
+          applyParentParameterFallback(
+            fetchParams,
+            params,
+            param.parentparametername
+          );
 
           const searchParams = new URLSearchParams({
             action: "parameterOptions",
@@ -312,9 +315,7 @@ export default function ReportDetailPage() {
             ...fetchParams,
           });
           const response = await fetch(
-            `/api/fineract/reports?action=parameterOptions&parameterName=${encodeURIComponent(
-              param.parameter_name
-            )}`
+            `/api/fineract/reports?${searchParams.toString()}`
           );
           if (response.ok) {
             const optionData = await response.json();
@@ -499,15 +500,11 @@ export default function ReportDetailPage() {
           const fetchParams: Record<string, string> = normalizeParameterValues(
             newParams
           );
-          if (param.parentparametername) {
-            const parent = reportParameters.find(
-              (p) => p.parameter_name === param.parentparametername
-            );
-            if (parent && !fetchParams[parent.parameter_variable]) {
-              fetchParams[parent.parameter_variable] =
-                parent.parameter_variable === "officeId" ? "1" : "";
-            }
-          }
+          applyParentParameterFallback(
+            fetchParams,
+            reportParameters,
+            param.parentparametername
+          );
           const searchParams = new URLSearchParams({
             action: "parameterOptions",
             parameterName: param.parameter_name,

--- a/app/(application)/reports/page.tsx
+++ b/app/(application)/reports/page.tsx
@@ -181,6 +181,39 @@ export default function ReportsPage() {
         option.tc?.trim().toLowerCase() === "all"
     );
 
+  const getInitialParameterValue = (param: ReportParameter): string => {
+    if (param.parameter_displayType === "none" && param.parameter_default) {
+      return param.parameter_default;
+    }
+    if (param.parameter_default && param.parameter_default !== "0") {
+      return param.parameter_default;
+    }
+    return "";
+  };
+
+  const applyParentParameterFallback = (
+    fetchParams: Record<string, string>,
+    params: ReportParameter[],
+    parentParameterName?: string
+  ) => {
+    if (!parentParameterName) return;
+
+    const parentParam = params.find(
+      (candidate) => candidate.parameter_name === parentParameterName
+    );
+    if (!parentParam || fetchParams[parentParam.parameter_variable]) return;
+
+    const fallbackValue = getInitialParameterValue(parentParam);
+    if (fallbackValue) {
+      fetchParams[parentParam.parameter_variable] = fallbackValue;
+      return;
+    }
+
+    if (parentParam.parameter_variable === "officeId") {
+      fetchParams[parentParam.parameter_variable] = "1";
+    }
+  };
+
   // Load available reports on component mount
   useEffect(() => {
     fetchAvailableReports();
@@ -283,8 +316,9 @@ export default function ReportsPage() {
         // Initialize parameters with default values
         const defaultParams: Record<string, string> = {};
         params.forEach((param) => {
-          if (param.parameter_default && param.parameter_default !== "0") {
-            defaultParams[param.parameter_variable] = param.parameter_default;
+          const initialValue = getInitialParameterValue(param);
+          if (initialValue) {
+            defaultParams[param.parameter_variable] = initialValue;
           }
         });
 
@@ -316,7 +350,10 @@ export default function ReportsPage() {
     }
   };
 
-  const loadParameterOptions = async (params: ReportParameter[]) => {
+  const loadParameterOptions = async (
+    params: ReportParameter[],
+    currentParamValues: Record<string, string> = {}
+  ) => {
     const options: Record<string, ParameterOption[]> = {};
 
     for (const param of params) {
@@ -327,15 +364,11 @@ export default function ReportsPage() {
           const fetchParams: Record<string, string> = normalizeParameterValues(
             currentParamValues
           );
-          if (param.parentparametername) {
-            const parentParam = params.find(
-              (p) => p.parameter_name === param.parentparametername
-            );
-            if (parentParam && !fetchParams[parentParam.parameter_variable]) {
-              fetchParams[parentParam.parameter_variable] =
-                parentParam.parameter_variable === "officeId" ? "1" : "";
-            }
-          }
+          applyParentParameterFallback(
+            fetchParams,
+            params,
+            param.parentparametername
+          );
 
           const searchParams = new URLSearchParams({
             action: "parameterOptions",
@@ -343,9 +376,7 @@ export default function ReportsPage() {
             ...fetchParams,
           });
           const response = await fetch(
-            `/api/fineract/reports?action=parameterOptions&parameterName=${encodeURIComponent(
-              param.parameter_name
-            )}`
+            `/api/fineract/reports?${searchParams.toString()}`
           );
           if (response.ok) {
             const optionData = await response.json();
@@ -483,15 +514,11 @@ export default function ReportsPage() {
           const fetchParams: Record<string, string> = normalizeParameterValues(
             newParams
           );
-          if (param.parentparametername) {
-            const parent = reportParameters.find(
-              (p) => p.parameter_name === param.parentparametername
-            );
-            if (parent && !fetchParams[parent.parameter_variable]) {
-              fetchParams[parent.parameter_variable] =
-                parent.parameter_variable === "officeId" ? "1" : "";
-            }
-          }
+          applyParentParameterFallback(
+            fetchParams,
+            reportParameters,
+            param.parentparametername
+          );
           const searchParams = new URLSearchParams({
             action: "parameterOptions",
             parameterName: param.parameter_name,

--- a/app/api/fineract/reports/route.ts
+++ b/app/api/fineract/reports/route.ts
@@ -97,7 +97,8 @@ export async function GET(request: NextRequest) {
       });
       try {
         const options = await fineractService.getParameterOptions(
-          parameterName
+          parameterName,
+          optionParams
         );
         return NextResponse.json(options);
       } catch (error: any) {


### PR DESCRIPTION
## Summary
- fix report parameter option loading on both reports screens
- pass current and dependent parameter values through the frontend requests
- forward dependent option parameters from the API route to Fineract

## Testing
- not run