### PR TITLE
feat: MFA authentication, user login service, and user management enhancements

### DIFF
--- a/app/(application)/organization/users/[id]/page.tsx
+++ b/app/(application)/organization/users/[id]/page.tsx
@@ -3,24 +3,15 @@ import { notFound } from "next/navigation";
 import {
   AlertCircle,
   ArrowLeft,
-  PenLine,
-  ShieldCheck,
-  UserRound,
 } from "lucide-react";
 import { getUserAction } from "@/app/actions/user-management-actions";
 import { getUserSignatureAction } from "@/app/actions/user-signature-actions";
 import { UserDetailActions } from "../components/user-detail-actions";
+import { UserDetailTabs } from "../components/user-detail-tabs";
 import { UserAccessDenied } from "../components/user-access-denied";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { hasPermissionServer } from "@/lib/authorization";
 import { SpecificPermission } from "@/shared/types/auth";
 
@@ -29,18 +20,6 @@ type UserDetailPageProps = {
     id: string;
   }>;
 };
-
-function DetailField({
-  label,
-  value,
-}: Readonly<{ label: string; value: string }>) {
-  return (
-    <div className="space-y-1 rounded-lg border p-4">
-      <p className="text-sm font-medium text-muted-foreground">{label}</p>
-      <p className="font-medium">{value || "-"}</p>
-    </div>
-  );
-}
 
 export default async function UserDetailPage({
   params,
@@ -71,7 +50,12 @@ export default async function UserDetailPage({
       <div className="mx-auto max-w-5xl space-y-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h1 className="text-3xl font-bold">{user.displayName}</h1>
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl font-bold">{user.displayName}</h1>
+              <Badge variant={user.isBlocked ? "destructive" : "secondary"}>
+                {user.isBlocked ? "Blocked" : "Active"}
+              </Badge>
+            </div>
             <p className="mt-1 text-muted-foreground">
               View user profile, assigned roles, and administration actions.
             </p>
@@ -90,94 +74,7 @@ export default async function UserDetailPage({
           canUpdate={canUpdate}
         />
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <UserRound className="h-5 w-5" />
-              User Information
-            </CardTitle>
-            <CardDescription>
-              Core user details from the Mifos user profile.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <DetailField label="Login Name" value={user.username} />
-            <DetailField label="First Name" value={user.firstname} />
-            <DetailField label="Last Name" value={user.lastname} />
-            <DetailField label="Email" value={user.email || "Not set"} />
-            <DetailField label="Office" value={user.officeName || "-"} />
-            <DetailField
-              label="Staff"
-              value={user.staff?.displayName || "Unassigned"}
-            />
-            <DetailField
-              label="Password Never Expires"
-              value={user.passwordNeverExpires ? "Yes" : "No"}
-            />
-            <DetailField
-              label="Self Service User"
-              value={user.isSelfServiceUser ? "Yes" : "No"}
-            />
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <PenLine className="h-5 w-5" />
-              User Signature
-            </CardTitle>
-            <CardDescription>
-              Saved signature used for this user&apos;s loan contract workflows.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {signatureData ? (
-              <div className="rounded-xl border-2 border-dashed p-6 text-center">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={signatureData}
-                  alt={`${user.displayName} signature`}
-                  className="mx-auto max-h-32 rounded border bg-white p-2"
-                />
-              </div>
-            ) : (
-              <div className="rounded-xl border-2 border-dashed p-6 text-center">
-                <PenLine className="mx-auto h-10 w-10 text-muted-foreground" />
-                <p className="mt-2 text-sm text-muted-foreground">
-                  No signature has been saved for this user.
-                </p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShieldCheck className="h-5 w-5" />
-              Assigned Roles
-            </CardTitle>
-            <CardDescription>
-              Roles currently attached to this user in Fineract.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {user.selectedRoles.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No roles assigned to this user.
-              </p>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {user.selectedRoles.map((role) => (
-                  <Badge key={role.id} variant="secondary">
-                    {role.name}
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <UserDetailTabs user={user} signatureData={signatureData} />
       </div>
     );
   } catch (error) {

--- a/app/(application)/organization/users/components/user-detail-actions.tsx
+++ b/app/(application)/organization/users/components/user-detail-actions.tsx
@@ -2,8 +2,12 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, Pencil, Shield } from "lucide-react";
-import { changeUserPasswordAction } from "@/app/actions/user-management-actions";
+import { Ban, Loader2, LockOpen, Pencil, Shield } from "lucide-react";
+import {
+  blockUserAccountAction,
+  changeUserPasswordAction,
+  unblockUserAccountAction,
+} from "@/app/actions/user-management-actions";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -16,6 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/use-toast";
 import type { UserDetail } from "@/shared/types/user-management";
 
@@ -34,6 +39,11 @@ export function UserDetailActions({
   const [repeatPassword, setRepeatPassword] = useState("");
   const [showPasswords, setShowPasswords] = useState(false);
   const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [accountAction, setAccountAction] = useState<"block" | "unblock" | null>(
+    null
+  );
+  const [accountNote, setAccountNote] = useState("");
+  const [accountError, setAccountError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const handlePasswordChange = () => {
@@ -71,6 +81,49 @@ export function UserDetailActions({
     });
   };
 
+  const handleAccountAction = () => {
+    const nextAction = accountAction;
+
+    if (!nextAction) {
+      return;
+    }
+
+    setAccountError(null);
+
+    startTransition(async () => {
+      const result =
+        nextAction === "block"
+          ? await blockUserAccountAction({
+              userId: user.id,
+              note: accountNote,
+            })
+          : await unblockUserAccountAction({
+              userId: user.id,
+              note: accountNote,
+            });
+
+      if (!result.success) {
+        setAccountError(result.fieldErrors?.note?.[0] || result.error || "Unable to update account status");
+        return;
+      }
+
+      toast({
+        title:
+          nextAction === "block" ? "Account blocked" : "Account unblocked",
+        description:
+          result.message ||
+          `${user.displayName} has been ${nextAction === "block" ? "blocked" : "unblocked"}.`,
+        variant: "success",
+      });
+      setAccountNote("");
+      setAccountError(null);
+      setAccountAction(null);
+      router.refresh();
+    });
+  };
+
+  const isBlockAction = accountAction === "block";
+
   return (
     <>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -88,6 +141,29 @@ export function UserDetailActions({
           <Button variant="secondary" onClick={() => setIsPasswordOpen(true)}>
             <Shield className="h-4 w-4" />
             Change Password
+          </Button>
+        )}
+
+        {canUpdate && (
+          <Button
+            variant={user.isBlocked ? "secondary" : "destructive"}
+            className={
+              user.isBlocked
+                ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                : undefined
+            }
+            onClick={() => {
+              setAccountNote("");
+              setAccountError(null);
+              setAccountAction(user.isBlocked ? "unblock" : "block");
+            }}
+          >
+            {user.isBlocked ? (
+              <LockOpen className="h-4 w-4" />
+            ) : (
+              <Ban className="h-4 w-4" />
+            )}
+            {user.isBlocked ? "Unblock Account" : "Block Account"}
           </Button>
         )}
       </div>
@@ -152,6 +228,80 @@ export function UserDetailActions({
             <Button onClick={handlePasswordChange} disabled={isPending}>
               {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
               Save Password
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={accountAction !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAccountAction(null);
+            setAccountNote("");
+            setAccountError(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {isBlockAction ? "Block User Account" : "Unblock User Account"}
+            </DialogTitle>
+            <DialogDescription>
+              {isBlockAction
+                ? `Block ${user.displayName} from receiving MFA codes and completing sign-in.`
+                : `Restore MFA access for ${user.displayName}.`}
+              {" "}
+              A note is required for the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="account-note">Note</Label>
+              <Textarea
+                id="account-note"
+                value={accountNote}
+                onChange={(event) => setAccountNote(event.target.value)}
+                placeholder={
+                  isBlockAction
+                    ? "Explain why this account is being blocked"
+                    : "Explain why this account is being unblocked"
+                }
+                rows={4}
+              />
+            </div>
+
+            {accountError && (
+              <p className="text-sm text-destructive">{accountError}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setAccountAction(null);
+                setAccountNote("");
+                setAccountError(null);
+              }}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={isBlockAction ? "destructive" : "default"}
+              className={
+                isBlockAction
+                  ? undefined
+                  : "bg-emerald-600 text-white hover:bg-emerald-700"
+              }
+              onClick={handleAccountAction}
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              {isBlockAction ? "Block Account" : "Unblock Account"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/(application)/organization/users/components/user-detail-tabs.tsx
+++ b/app/(application)/organization/users/components/user-detail-tabs.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Ban, PenLine, ShieldCheck, UserRound } from "lucide-react";
+import { getUserBlockHistoryAction } from "@/app/actions/user-management-actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatPhoneWithCountryCode } from "@/lib/phone-utils";
+import type {
+  UserBlockHistoryPage,
+  UserDetail,
+  UserLoginBlockEvent,
+} from "@/shared/types/user-management";
+
+interface UserDetailTabsProps {
+  user: UserDetail;
+  signatureData: string | null;
+}
+
+function DetailField({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="space-y-1 rounded-lg border p-4">
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <p className="font-medium">{value || "-"}</p>
+    </div>
+  );
+}
+
+function formatAuditTimestamp(value?: string | null) {
+  if (!value) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function getBlockSourceLabel(event: UserLoginBlockEvent | { source?: string | null }) {
+  return event.source === "SYSTEM_MFA_MAX_ATTEMPTS"
+    ? "System: MFA attempts"
+    : "Manual admin action";
+}
+
+function BlockHistorySkeleton() {
+  return (
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-4 w-80 max-w-full" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={`block-history-skeleton-${index}`}
+            className="rounded-lg border p-4"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <Skeleton className="h-6 w-20" />
+                  <Skeleton className="h-6 w-36" />
+                </div>
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+            </div>
+            <Skeleton className="mt-3 h-4 w-full" />
+            <Skeleton className="mt-2 h-4 w-4/5" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BlockHistoryContent({
+  username,
+  historyPage,
+  onPageChange,
+  isLoading,
+}: Readonly<{
+  username: string;
+  historyPage: UserBlockHistoryPage;
+  onPageChange: (page: number) => void;
+  isLoading: boolean;
+}>) {
+  const startItem =
+    historyPage.total === 0
+      ? 0
+      : (historyPage.page - 1) * historyPage.pageSize + 1;
+  const endItem =
+    historyPage.total === 0
+      ? 0
+      : Math.min(historyPage.page * historyPage.pageSize, historyPage.total);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Block History</CardTitle>
+        <CardDescription>
+          Audit trail for account block and unblock actions on @{username}.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {historyPage.items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No block or unblock events have been recorded for this user.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {historyPage.items.map((event) => (
+              <div
+                key={event.id}
+                className="rounded-lg border p-4"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge
+                        variant={
+                          event.action === "BLOCK"
+                            ? "destructive"
+                            : "secondary"
+                        }
+                      >
+                        {event.action === "BLOCK" ? "Blocked" : "Unblocked"}
+                      </Badge>
+                      <Badge variant="outline">
+                        {getBlockSourceLabel(event)}
+                      </Badge>
+                    </div>
+                    <p className="text-sm font-medium">
+                      {event.actorName || "System"}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {formatAuditTimestamp(event.createdAt)}
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm">{event.note}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {historyPage.total > 0 && (
+          <div className="mt-6 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Showing {startItem}-{endItem} of {historyPage.total}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(historyPage.page - 1)}
+                disabled={historyPage.page <= 1 || isLoading}
+              >
+                Previous
+              </Button>
+              <p className="min-w-24 text-center text-sm text-muted-foreground">
+                Page {historyPage.page} of {historyPage.totalPages}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(historyPage.page + 1)}
+                disabled={historyPage.page >= historyPage.totalPages || isLoading}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function UserDetailTabs({
+  user,
+  signatureData,
+}: Readonly<UserDetailTabsProps>) {
+  const [activeTab, setActiveTab] = useState("details");
+  const [blockHistoryPage, setBlockHistoryPage] = useState<UserBlockHistoryPage | null>(
+    null
+  );
+  const [blockHistoryError, setBlockHistoryError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const phoneDisplay =
+    formatPhoneWithCountryCode(user.phone, user.countryCode) || "Not set";
+
+  const loadBlockHistoryPage = (page: number) => {
+    if (
+      page < 1 ||
+      isPending ||
+      (blockHistoryPage !== null && page === blockHistoryPage.page)
+    ) {
+      return;
+    }
+
+    setBlockHistoryError(null);
+    startTransition(async () => {
+      try {
+        const historyPage = await getUserBlockHistoryAction({
+          userId: user.id,
+          page,
+        });
+        setBlockHistoryPage(historyPage);
+      } catch (error) {
+        setBlockHistoryError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load block history"
+        );
+      }
+    });
+  };
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+
+    if (value !== "mfa" || blockHistoryPage !== null || isPending) {
+      return;
+    }
+
+    loadBlockHistoryPage(1);
+  };
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={handleTabChange}
+      className="space-y-4"
+    >
+      <TabsList className="grid w-full max-w-md grid-cols-2">
+        <TabsTrigger value="details">Details</TabsTrigger>
+        <TabsTrigger value="mfa">MFA</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="details" className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <UserRound className="h-5 w-5" />
+              User Information
+            </CardTitle>
+            <CardDescription>
+              Core user details from the Mifos user profile.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <DetailField label="Login Name" value={user.username} />
+            <DetailField label="First Name" value={user.firstname} />
+            <DetailField label="Last Name" value={user.lastname} />
+            <DetailField label="Email" value={user.email || "Not set"} />
+            <DetailField label="Phone" value={phoneDisplay} />
+            <DetailField label="Office" value={user.officeName || "-"} />
+            <DetailField
+              label="Staff"
+              value={user.staff?.displayName || "Unassigned"}
+            />
+            <DetailField
+              label="Password Never Expires"
+              value={user.passwordNeverExpires ? "Yes" : "No"}
+            />
+            <DetailField
+              label="Self Service User"
+              value={user.isSelfServiceUser ? "Yes" : "No"}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <PenLine className="h-5 w-5" />
+              User Signature
+            </CardTitle>
+            <CardDescription>
+              Saved signature used for this user&apos;s loan contract workflows.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {signatureData ? (
+              <div className="rounded-xl border-2 border-dashed p-6 text-center">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={signatureData}
+                  alt={`${user.displayName} signature`}
+                  className="mx-auto max-h-32 rounded border bg-white p-2"
+                />
+              </div>
+            ) : (
+              <div className="rounded-xl border-2 border-dashed p-6 text-center">
+                <PenLine className="mx-auto h-10 w-10 text-muted-foreground" />
+                <p className="mt-2 text-sm text-muted-foreground">
+                  No signature has been saved for this user.
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5" />
+              Assigned Roles
+            </CardTitle>
+            <CardDescription>
+              Roles currently attached to this user in Fineract.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {user.selectedRoles.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No roles assigned to this user.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {user.selectedRoles.map((role) => (
+                  <Badge key={role.id} variant="secondary">
+                    {role.name}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="mfa" className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Ban className="h-5 w-5" />
+              Account Access
+            </CardTitle>
+            <CardDescription>
+              MFA lock status and the latest block metadata for this account.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <DetailField
+              label="Account Status"
+              value={user.isBlocked ? "Blocked" : "Active"}
+            />
+            <DetailField
+              label="Blocked At"
+              value={formatAuditTimestamp(user.blockedAt)}
+            />
+            <DetailField
+              label="Block Source"
+              value={
+                user.isBlocked || user.blockedSource
+                  ? getBlockSourceLabel({ source: user.blockedSource })
+                  : "Not blocked"
+              }
+            />
+            <DetailField
+              label="Last Changed By"
+              value={user.blockedByActorName || (user.isBlocked ? "System" : "-")}
+            />
+            <div className="space-y-1 rounded-lg border p-4 md:col-span-2">
+              <p className="text-sm font-medium text-muted-foreground">
+                Latest Note
+              </p>
+              <p className="font-medium">{user.blockedNote || "No note recorded"}</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {isPending ? (
+          <BlockHistorySkeleton />
+        ) : blockHistoryError ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Block History</CardTitle>
+              <CardDescription>
+                Audit trail for account block and unblock actions on @{user.username}.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-destructive">{blockHistoryError}</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <BlockHistoryContent
+            username={user.username}
+            historyPage={
+              blockHistoryPage ?? {
+                items: [],
+                page: 1,
+                pageSize: 5,
+                total: 0,
+                totalPages: 1,
+              }
+            }
+            onPageChange={loadBlockHistoryPage}
+            isLoading={isPending}
+          />
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/app/(application)/organization/users/components/user-form.tsx
+++ b/app/(application)/organization/users/components/user-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { AlertCircle, Loader2, PenLine, Save, Trash2, Upload } from "lucide-react";
 import {
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SearchableSelect } from "@/components/searchable-select";
 import {
   Select,
   SelectContent,
@@ -26,6 +27,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
+import {
+  AFRICAN_COUNTRY_CODES,
+  getAfricanCountryDialCodeOrDefault,
+  getNumericPhoneValidationError,
+  USER_LOGIN_PHONE_MAX_LENGTH,
+} from "@/lib/phone-utils";
 import type {
   StaffOption,
   UserDetail,
@@ -46,6 +53,8 @@ type FieldErrors = Partial<Record<string, string[]>>;
 type FormState = {
   username: string;
   email: string;
+  phone: string;
+  countryCode: string;
   firstname: string;
   lastname: string;
   sendPasswordToEmail: boolean;
@@ -60,10 +69,15 @@ type FormState = {
 const validSignatureTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif"];
 const maxSignatureFileSize = 2 * 1024 * 1024;
 
-function buildInitialState(initialUser?: UserDetail): FormState {
+function buildInitialState(
+  initialUser: UserDetail | undefined,
+  defaultCountryCode: string
+): FormState {
   return {
     username: initialUser?.username ?? "",
     email: initialUser?.email ?? "",
+    phone: initialUser?.phone ?? "",
+    countryCode: initialUser?.countryCode ?? defaultCountryCode,
     firstname: initialUser?.firstname ?? "",
     lastname: initialUser?.lastname ?? "",
     sendPasswordToEmail: true,
@@ -118,11 +132,19 @@ export function UserForm({
   initialStaffOptions = [],
 }: Readonly<UserFormProps>) {
   const router = useRouter();
-  const [form, setForm] = useState<FormState>(() => buildInitialState(initialUser));
+  const [form, setForm] = useState<FormState>(() =>
+    buildInitialState(
+      initialUser,
+      getAfricanCountryDialCodeOrDefault(template.defaultCountryCode)
+    )
+  );
   const [staffOptions, setStaffOptions] =
     useState<StaffOption[]>(initialStaffOptions);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
+  const [phoneValidationError, setPhoneValidationError] = useState<string | null>(
+    null
+  );
   const [isLoadingStaff, setIsLoadingStaff] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [signatureData, setSignatureData] = useState<string | null>(null);
@@ -133,6 +155,14 @@ export function UserForm({
     mode === "edit" && Boolean(initialUser?.id)
   );
   const [signatureError, setSignatureError] = useState<string | null>(null);
+  const countryCodeOptions = useMemo(
+    () =>
+      AFRICAN_COUNTRY_CODES.map((entry) => ({
+        value: entry.code,
+        label: entry.label,
+      })),
+    []
+  );
 
   useEffect(() => {
     if (mode !== "edit" || !initialUser?.id) {
@@ -185,6 +215,33 @@ export function UserForm({
     }));
     setFormError(null);
   };
+
+  const handlePhoneChange = (value: string) => {
+    if (!value) {
+      setPhoneValidationError(null);
+      handleChange("phone", "");
+      return;
+    }
+
+    if (!/^\d+$/.test(value)) {
+      setPhoneValidationError("Phone number must contain only numbers");
+      return;
+    }
+
+    if (value.length > USER_LOGIN_PHONE_MAX_LENGTH) {
+      setPhoneValidationError(
+        `Phone number must not exceed ${USER_LOGIN_PHONE_MAX_LENGTH} digits`
+      );
+      return;
+    }
+
+    const nextError = getNumericPhoneValidationError(value);
+    setPhoneValidationError(nextError);
+    handleChange("phone", value);
+  };
+
+  const phoneFieldError = phoneValidationError || firstError(fieldErrors, "phone");
+  const countryCodeFieldError = firstError(fieldErrors, "countryCode");
 
   const handleOfficeChange = (value: string) => {
     const nextOfficeId = value === "__none__" ? "" : value;
@@ -248,10 +305,17 @@ export function UserForm({
     setFieldErrors({});
     setSignatureError(null);
 
+    if (phoneValidationError) {
+      setFormError("Please correct the phone number and try again.");
+      return;
+    }
+
     const payload: UserFormInput = {
       userId: initialUser?.id,
       username: form.username,
       email: form.email,
+      phone: form.phone,
+      countryCode: form.countryCode,
       firstname: form.firstname,
       lastname: form.lastname,
       sendPasswordToEmail: form.sendPasswordToEmail,
@@ -375,6 +439,44 @@ export function UserForm({
           {firstError(fieldErrors, "email") && (
             <p className="text-sm text-destructive">
               {firstError(fieldErrors, "email")}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="phone">Phone Number</Label>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <SearchableSelect
+              options={countryCodeOptions}
+              value={form.countryCode}
+              onValueChange={(value) =>
+                handleChange("countryCode", getAfricanCountryDialCodeOrDefault(value))
+              }
+              placeholder="Country code"
+              emptyMessage="No African country code found."
+              className="w-full sm:w-[220px]"
+            />
+            <Input
+              id="phone"
+              type="text"
+              inputMode="numeric"
+              autoComplete="tel-national"
+              pattern="[0-9]*"
+              maxLength={USER_LOGIN_PHONE_MAX_LENGTH}
+              value={form.phone}
+              onChange={(event) => handlePhoneChange(event.target.value)}
+              placeholder="Enter phone number for SMS MFA"
+              className="flex-1"
+            />
+          </div>
+          {countryCodeFieldError && (
+            <p className="text-sm text-destructive">{countryCodeFieldError}</p>
+          )}
+          {phoneFieldError ? (
+            <p className="text-sm text-destructive">{phoneFieldError}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Digits only, maximum {USER_LOGIN_PHONE_MAX_LENGTH} digits.
             </p>
           )}
         </div>
@@ -706,7 +808,10 @@ export function UserForm({
       </div>
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <Button type="submit" disabled={isPending || signatureLoading}>
+        <Button
+          type="submit"
+          disabled={isPending || signatureLoading || Boolean(phoneValidationError)}
+        >
           {isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (

--- a/app/(application)/organization/users/components/users-page-client.tsx
+++ b/app/(application)/organization/users/components/users-page-client.tsx
@@ -59,6 +59,17 @@ export function UsersPageClient({
         ),
     },
     {
+      id: "status",
+      header: "Status",
+      accessorKey: "isBlocked",
+      cell: ({ row }) => (
+        <Badge variant={row.original.isBlocked ? "destructive" : "secondary"}>
+          {row.original.isBlocked ? "Blocked" : "Active"}
+        </Badge>
+      ),
+      getExportValue: (item) => (item.isBlocked ? "Blocked" : "Active"),
+    },
+    {
       id: "officeName",
       header: "Office",
       accessorKey: "officeName",

--- a/app/actions/user-management-actions.ts
+++ b/app/actions/user-management-actions.ts
@@ -3,13 +3,33 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { fetchFineractAPI } from "@/lib/api";
+import { getSession } from "@/lib/auth";
 import { hasPermissionServer } from "@/lib/authorization";
+import {
+  DEFAULT_AFRICAN_COUNTRY_CODE,
+  getAfricanCountryDialCodeOrDefault,
+  getNumericPhoneValidationError,
+  isAfricanCountryDialCode,
+} from "@/lib/phone-utils";
+import { prisma } from "@/lib/prisma";
+import {
+  blockUserLogin,
+  deleteUserLogin,
+  getUserLoginByFineractUserId,
+  requireCurrentTenant,
+  unblockUserLogin,
+  upsertUserLogin,
+} from "@/lib/user-login-service";
 import { SpecificPermission } from "@/shared/types/auth";
 import type {
+  UserBlockHistoryInput,
+  UserBlockHistoryPage,
   OfficeOption,
   StaffOption,
   UserActionResult,
+  UserBlockAccountInput,
   UserDetail,
+  UserLoginBlockEvent,
   UserFormInput,
   UserPasswordChangeInput,
   UserRoleOption,
@@ -27,6 +47,8 @@ const createUserSchema = z
   .object({
     username: z.string().trim().min(1, "Username is required"),
     email: z.string().trim().optional().default(""),
+    phone: z.string().trim().optional().default(""),
+    countryCode: z.string().trim().optional().default(DEFAULT_AFRICAN_COUNTRY_CODE),
     firstname: z
       .string()
       .trim()
@@ -57,6 +79,26 @@ const createUserSchema = z
   })
   .superRefine((value, context) => {
     const email = value.email.trim();
+    const phone = value.phone.trim();
+    const countryCode = value.countryCode.trim();
+
+    const phoneError = getNumericPhoneValidationError(phone);
+
+    if (phoneError) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["phone"],
+        message: phoneError,
+      });
+    }
+
+    if (phone && !isAfricanCountryDialCode(countryCode)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["countryCode"],
+        message: "Select a valid African country code",
+      });
+    }
 
     if (value.sendPasswordToEmail) {
       if (!email) {
@@ -92,41 +134,63 @@ const createUserSchema = z
     );
   });
 
-const updateUserSchema = z.object({
-  userId: z.coerce.number().int().positive("User id is required"),
-  username: z.string().trim().min(1, "Username is required"),
-  email: z
-    .string()
-    .trim()
-    .min(1, "Email is required")
-    .refine((value) => z.string().email().safeParse(value).success, {
-      message: "Enter a valid email address",
-    }),
-  firstname: z
-    .string()
-    .trim()
-    .min(1, "First name is required")
-    .regex(
-      namePattern,
-      "First name cannot begin with a special character or number"
-    ),
-  lastname: z
-    .string()
-    .trim()
-    .min(1, "Last name is required")
-    .regex(
-      namePattern,
-      "Last name cannot begin with a special character or number"
-    ),
-  passwordNeverExpires: z.boolean().default(false),
-  officeId: z.coerce.number().int().positive("Office is required"),
-  staffId: z
-    .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
-    .transform((value) => (typeof value === "number" ? value : null)),
-  roles: z
-    .array(z.coerce.number().int().positive())
-    .min(1, "At least one role must be selected"),
-});
+const updateUserSchema = z
+  .object({
+    userId: z.coerce.number().int().positive("User id is required"),
+    username: z.string().trim().min(1, "Username is required"),
+    email: z
+      .string()
+      .trim()
+      .min(1, "Email is required")
+      .refine((value) => z.string().email().safeParse(value).success, {
+        message: "Enter a valid email address",
+      }),
+    phone: z.string().trim().optional().default(""),
+    countryCode: z.string().trim().optional().default(DEFAULT_AFRICAN_COUNTRY_CODE),
+    firstname: z
+      .string()
+      .trim()
+      .min(1, "First name is required")
+      .regex(
+        namePattern,
+        "First name cannot begin with a special character or number"
+      ),
+    lastname: z
+      .string()
+      .trim()
+      .min(1, "Last name is required")
+      .regex(
+        namePattern,
+        "Last name cannot begin with a special character or number"
+      ),
+    passwordNeverExpires: z.boolean().default(false),
+    officeId: z.coerce.number().int().positive("Office is required"),
+    staffId: z
+      .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
+      .transform((value) => (typeof value === "number" ? value : null)),
+    roles: z
+      .array(z.coerce.number().int().positive())
+      .min(1, "At least one role must be selected"),
+  })
+  .superRefine((value, context) => {
+    const phoneError = getNumericPhoneValidationError(value.phone);
+
+    if (phoneError) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["phone"],
+        message: phoneError,
+      });
+    }
+
+    if (value.phone && !isAfricanCountryDialCode(value.countryCode)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["countryCode"],
+        message: "Select a valid African country code",
+      });
+    }
+  });
 
 const deleteUserSchema = z.object({
   userId: z.coerce.number().int().positive("User id is required"),
@@ -148,6 +212,18 @@ const changePasswordSchema = z
       context
     );
   });
+
+const blockAccountSchema = z.object({
+  userId: z.coerce.number().int().positive("User id is required"),
+  note: z.string().trim().min(1, "Note is required"),
+});
+
+const blockHistorySchema = z.object({
+  userId: z.coerce.number().int().positive("User id is required"),
+  page: z.coerce.number().int().positive().default(1),
+});
+
+const userBlockHistoryPageSize = 5;
 
 function validatePasswordFields(
   value: { password?: string; repeatPassword?: string },
@@ -221,6 +297,12 @@ function asNumber(value: unknown): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function getTenantDefaultCountryCode(settings: unknown) {
+  const settingsRecord = asObject(settings);
+  const locale = asObject(settingsRecord.locale);
+  return getAfricanCountryDialCodeOrDefault(asString(locale.countryCode));
+}
+
 function mapRoleOption(role: unknown): UserRoleOption {
   const roleRecord = asObject(role);
   const roleId = asNumber(roleRecord.id) ?? 0;
@@ -282,11 +364,38 @@ function mapUserSummary(user: unknown): UserSummary {
     lastname,
     displayName,
     email: asString(userRecord.email),
+    phone: undefined,
+    countryCode: undefined,
+    isBlocked: false,
+    blockedAt: null,
     officeId: asNumber(userRecord.officeId),
     officeName: asString(userRecord.officeName) || asString(officeRecord.name),
     roles: selectedRoles
       .map((role) => asString(asObject(role).name))
       .filter(Boolean),
+  };
+}
+
+function mapUserLoginBlockEvent(event: {
+  id: string;
+  action: string;
+  source: string;
+  note: string;
+  actorUserId: number | null;
+  actorName: string | null;
+  createdAt: Date;
+}): UserLoginBlockEvent {
+  return {
+    id: event.id,
+    action: event.action === "UNBLOCK" ? "UNBLOCK" : "BLOCK",
+    source:
+      event.source === "SYSTEM_MFA_MAX_ATTEMPTS"
+        ? "SYSTEM_MFA_MAX_ATTEMPTS"
+        : "MANUAL",
+    note: event.note,
+    actorUserId: event.actorUserId,
+    actorName: event.actorName,
+    createdAt: event.createdAt.toISOString(),
   };
 }
 
@@ -309,15 +418,19 @@ function mapUserDetail(user: unknown): UserDetail {
     ...summary,
     passwordNeverExpires: Boolean(userRecord.passwordNeverExpires),
     isSelfServiceUser: Boolean(userRecord.isSelfServiceUser),
+    blockedSource: null,
+    blockedNote: null,
+    blockedByActorName: null,
     selectedRoles: selectedRoles.map(mapRoleOption),
     staff: staffSource ? mapStaffOption(staffSource) : null,
+    blockHistory: [],
   };
 }
 
-function toFieldErrorResult(
+function toFieldErrorResult<T = undefined>(
   error: z.ZodError,
   message = "Please correct the highlighted fields and try again"
-): UserActionResult {
+): UserActionResult<T> {
   return {
     success: false,
     error: message,
@@ -382,12 +495,42 @@ export async function listUsersAction(): Promise<UserSummary[]> {
     "You do not have permission to view users"
   );
 
-  const users = await fetchFineractAPI("/users");
+  const tenant = await requireCurrentTenant();
+  const [users, localLogins] = await Promise.all([
+    fetchFineractAPI("/users"),
+    prisma.userLogin.findMany({
+      where: {
+        tenantId: tenant.id,
+      },
+      select: {
+        fineractUserId: true,
+        email: true,
+        phone: true,
+        countryCode: true,
+        isBlocked: true,
+        blockedAt: true,
+      },
+    }),
+  ]);
+  const localLoginsByUserId = new Map(
+    localLogins.map((login) => [login.fineractUserId, login])
+  );
   const mappedUsers = Array.isArray(users) ? users.map(mapUserSummary) : [];
 
-  return mappedUsers.sort((left, right) =>
-    left.displayName.localeCompare(right.displayName)
-  );
+  return mappedUsers
+    .map((user) => {
+      const localLogin = localLoginsByUserId.get(user.id);
+
+      return {
+        ...user,
+        email: localLogin?.email || user.email,
+        phone: localLogin?.phone || undefined,
+        countryCode: localLogin?.countryCode || undefined,
+        isBlocked: localLogin?.isBlocked ?? false,
+        blockedAt: localLogin?.blockedAt?.toISOString() ?? null,
+      };
+    })
+    .sort((left, right) => left.displayName.localeCompare(right.displayName));
 }
 
 export async function getUserAction(userId: number): Promise<UserDetail> {
@@ -396,8 +539,95 @@ export async function getUserAction(userId: number): Promise<UserDetail> {
     "You do not have permission to view users"
   );
 
+  const tenant = await requireCurrentTenant();
   const user = await fetchFineractAPI(`/users/${userId}`);
-  return mapUserDetail(user);
+  const localLogin = await prisma.userLogin.findUnique({
+    where: {
+      tenantId_fineractUserId: {
+        tenantId: tenant.id,
+        fineractUserId: userId,
+      },
+    },
+    select: {
+      email: true,
+      phone: true,
+      countryCode: true,
+      isBlocked: true,
+      blockedAt: true,
+      blockedSource: true,
+      blockedNote: true,
+      blockedByActorName: true,
+    },
+  });
+  const mappedUser = mapUserDetail(user);
+
+  return {
+    ...mappedUser,
+    email: localLogin?.email || mappedUser.email,
+    phone: localLogin?.phone || undefined,
+    countryCode: localLogin?.countryCode || undefined,
+    isBlocked: localLogin?.isBlocked ?? false,
+    blockedAt: localLogin?.blockedAt?.toISOString() ?? null,
+    blockedSource:
+      localLogin?.blockedSource === "SYSTEM_MFA_MAX_ATTEMPTS"
+        ? "SYSTEM_MFA_MAX_ATTEMPTS"
+        : localLogin?.blockedSource === "MANUAL"
+          ? "MANUAL"
+          : null,
+    blockedNote: localLogin?.blockedNote ?? null,
+    blockedByActorName: localLogin?.blockedByActorName ?? null,
+    blockHistory: [],
+  };
+}
+
+export async function getUserBlockHistoryAction(
+  input: UserBlockHistoryInput
+): Promise<UserBlockHistoryPage> {
+  await ensurePermission(
+    SpecificPermission.READ_USER,
+    "You do not have permission to view users"
+  );
+
+  const parsed = blockHistorySchema.parse(input);
+  const tenant = await requireCurrentTenant();
+  const skip = (parsed.page - 1) * userBlockHistoryPageSize;
+  const [items, total] = await prisma.$transaction([
+    prisma.userLoginBlockEvent.findMany({
+      where: {
+        tenantId: tenant.id,
+        fineractUserId: parsed.userId,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+      skip,
+      take: userBlockHistoryPageSize,
+      select: {
+        id: true,
+        action: true,
+        source: true,
+        note: true,
+        actorUserId: true,
+        actorName: true,
+        createdAt: true,
+      },
+    }),
+    prisma.userLoginBlockEvent.count({
+      where: {
+        tenantId: tenant.id,
+        fineractUserId: parsed.userId,
+      },
+    }),
+  ]);
+  const totalPages = Math.max(1, Math.ceil(total / userBlockHistoryPageSize));
+
+  return {
+    items: items.map(mapUserLoginBlockEvent),
+    page: Math.min(parsed.page, totalPages),
+    pageSize: userBlockHistoryPageSize,
+    total,
+    totalPages,
+  };
 }
 
 export async function getUsersTemplateAction(): Promise<UsersTemplate> {
@@ -406,7 +636,10 @@ export async function getUsersTemplateAction(): Promise<UsersTemplate> {
     "You do not have permission to manage users"
   );
 
-  const template = await fetchFineractAPI("/users/template");
+  const [template, tenant] = await Promise.all([
+    fetchFineractAPI("/users/template"),
+    requireCurrentTenant(),
+  ]);
 
   return {
     allowedOffices: Array.isArray(template?.allowedOffices)
@@ -415,6 +648,7 @@ export async function getUsersTemplateAction(): Promise<UsersTemplate> {
     availableRoles: Array.isArray(template?.availableRoles)
       ? template.availableRoles.map(mapRoleOption)
       : [],
+    defaultCountryCode: getTenantDefaultCountryCode(tenant.settings),
   };
 }
 
@@ -466,6 +700,11 @@ export async function createUserAction(
     }
 
     const email = parsed.data.email.trim();
+    const phone = parsed.data.phone.trim();
+    const countryCode = phone
+      ? getAfricanCountryDialCodeOrDefault(parsed.data.countryCode)
+      : undefined;
+    const tenant = await requireCurrentTenant();
     const payload: Record<string, unknown> = {
       username: parsed.data.username,
       firstname: parsed.data.firstname,
@@ -498,6 +737,17 @@ export async function createUserAction(
       response?.resourceId ?? response?.subResourceId ?? response?.id
     );
 
+    if (Number.isFinite(userId)) {
+      await upsertUserLogin({
+        tenantId: tenant.id,
+        fineractUserId: userId,
+        username: parsed.data.username,
+        email,
+        phone,
+        countryCode,
+      });
+    }
+
     revalidateUserPaths(Number.isFinite(userId) ? userId : undefined);
 
     return {
@@ -529,6 +779,7 @@ export async function updateUserAction(
       return toFieldErrorResult(parsed.error);
     }
 
+    const tenant = await requireCurrentTenant();
     const payload = {
       username: parsed.data.username,
       email: parsed.data.email,
@@ -543,6 +794,17 @@ export async function updateUserAction(
     await fetchFineractAPI(`/users/${parsed.data.userId}`, {
       method: "PUT",
       body: JSON.stringify(payload),
+    });
+
+    await upsertUserLogin({
+      tenantId: tenant.id,
+      fineractUserId: parsed.data.userId,
+      username: parsed.data.username,
+      email: parsed.data.email,
+      phone: parsed.data.phone,
+      countryCode: parsed.data.phone
+        ? getAfricanCountryDialCodeOrDefault(parsed.data.countryCode)
+        : null,
     });
 
     revalidateUserPaths(parsed.data.userId);
@@ -576,8 +838,17 @@ export async function deleteUserAction(input: {
       return toFieldErrorResult(parsed.error, "User id is required");
     }
 
+    const tenant = await requireCurrentTenant();
     await fetchFineractAPI(`/users/${parsed.data.userId}`, {
       method: "DELETE",
+    });
+
+    await deleteUserLogin(tenant.id, parsed.data.userId);
+    await prisma.mfaChallenge.deleteMany({
+      where: {
+        tenantId: tenant.id,
+        fineractUserId: parsed.data.userId,
+      },
     });
 
     revalidateUserPaths(parsed.data.userId);
@@ -632,6 +903,132 @@ export async function changeUserPasswordAction(
     return {
       success: false,
       error: getErrorMessage(error, "Failed to change user password"),
+    };
+  }
+}
+
+async function getUserBlockActionContext(userId: number) {
+  const [tenant, session, user] = await Promise.all([
+    requireCurrentTenant(),
+    getSession(),
+    fetchFineractAPI(`/users/${userId}`),
+  ]);
+
+  if (!session?.user?.userId || !session.user.name) {
+    throw new Error("Your session could not be validated. Please sign in again.");
+  }
+
+  const mappedUser = mapUserDetail(user);
+  const existingLogin = await getUserLoginByFineractUserId(tenant.id, userId);
+
+  return {
+    tenant,
+    actorUserId: session.user.userId,
+    actorName: session.user.name,
+    mappedUser,
+    existingLogin,
+  };
+}
+
+export async function blockUserAccountAction(
+  input: UserBlockAccountInput
+): Promise<UserActionResult> {
+  try {
+    await ensurePermission(
+      SpecificPermission.UPDATE_USER,
+      "You do not have permission to block user accounts"
+    );
+
+    const parsed = blockAccountSchema.safeParse(input);
+    if (!parsed.success) {
+      return toFieldErrorResult(parsed.error, "A note is required to block this account");
+    }
+
+    const context = await getUserBlockActionContext(parsed.data.userId);
+
+    if (context.existingLogin?.isBlocked) {
+      return {
+        success: false,
+        error: `${context.mappedUser.displayName} is already blocked`,
+      };
+    }
+
+    await blockUserLogin({
+      tenantId: context.tenant.id,
+      fineractUserId: parsed.data.userId,
+      username: context.mappedUser.username,
+      email: context.existingLogin?.email || context.mappedUser.email,
+      phone: context.existingLogin?.phone,
+      countryCode: context.existingLogin?.countryCode,
+      note: parsed.data.note,
+      source: "MANUAL",
+      actorUserId: context.actorUserId,
+      actorName: context.actorName,
+    });
+
+    revalidateUserPaths(parsed.data.userId);
+
+    return {
+      success: true,
+      message: `${context.mappedUser.displayName} has been blocked`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: getErrorMessage(error, "Failed to block user account"),
+    };
+  }
+}
+
+export async function unblockUserAccountAction(
+  input: UserBlockAccountInput
+): Promise<UserActionResult> {
+  try {
+    await ensurePermission(
+      SpecificPermission.UPDATE_USER,
+      "You do not have permission to unblock user accounts"
+    );
+
+    const parsed = blockAccountSchema.safeParse(input);
+    if (!parsed.success) {
+      return toFieldErrorResult(
+        parsed.error,
+        "A note is required to unblock this account"
+      );
+    }
+
+    const context = await getUserBlockActionContext(parsed.data.userId);
+
+    if (!context.existingLogin?.isBlocked) {
+      return {
+        success: false,
+        error: `${context.mappedUser.displayName} is already active`,
+      };
+    }
+
+    await unblockUserLogin({
+      tenantId: context.tenant.id,
+      fineractUserId: parsed.data.userId,
+      username: context.mappedUser.username,
+      email: context.existingLogin.email,
+      phone: context.existingLogin.phone,
+      countryCode: context.existingLogin.countryCode,
+      note: parsed.data.note,
+      source: "MANUAL",
+      actorUserId: context.actorUserId,
+      actorName: context.actorName,
+    });
+
+    revalidateUserPaths(parsed.data.userId);
+
+    return {
+      success: true,
+      message: `${context.mappedUser.displayName} has been unblocked`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: getErrorMessage(error, "Failed to unblock user account"),
     };
   }
 }

--- a/app/actions/ussd-leads-actions.ts
+++ b/app/actions/ussd-leads-actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { Prisma } from "@/app/generated/prisma";
+import { sendSms } from "@/lib/notification-service";
 import { getTenantBySlug } from "@/lib/tenant-service";
 import prisma from "@/lib/prisma";
 import {
@@ -17,6 +19,7 @@ export interface UssdLeadsData {
 }
 
 // Dummy data for USSD applications
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const generateDummyUssdApplications = (): UssdLoanApplication[] => {
   const statuses: UssdLoanApplication["status"][] = [
     UssdLoanApplicationStatus.CREATED,
@@ -157,7 +160,7 @@ export async function getUssdLeadsData(
     }
 
     // Build where clause
-    const where: any = {
+    const where: Prisma.UssdLoanApplicationWhereInput = {
       tenantId: tenant.id,
     };
 
@@ -329,7 +332,7 @@ export async function updateUssdApplicationStatus(
     }
 
     // Prepare update payload
-    const updateData: any = {
+    const updateData: Prisma.UssdLoanApplicationUncheckedUpdateInput = {
       status,
       processedAt: new Date(),
       updatedAt: new Date(),
@@ -358,44 +361,21 @@ export async function updateUssdApplicationStatus(
     // On rejection, send SMS notification (best-effort, non-blocking for update)
     if (status === "REJECTED") {
       try {
-        const serviceBaseUrl = process.env.NOTIFICATION_SERVICE_URL;
-        const tenantId = process.env.TENANT_ID || "goodfellow";
-        if (!serviceBaseUrl) {
-          console.warn(
-            "NOTIFICATION_SERVICE_URL is not set; skipping SMS notification"
-          );
-        } else {
-          // Format amount as number with commas and 2 decimal places, then add ZMW prefix
-          const amountFormatted = application.principalAmount.toLocaleString(
-            "en-US",
-            {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            }
-          );
-          const reason =
-            notes || application.rejectionReason || "No reason provided";
-          const message = `Sorry ${application.userFullName}, your loan request of ZMW ${amountFormatted} was not approved. Reason: ${reason}. Contact us on +260957224792 /774 or visit our offices.`;
+        // Format amount as number with commas and 2 decimal places, then add ZMW prefix
+        const amountFormatted = application.principalAmount.toLocaleString(
+          "en-US",
+          {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }
+        );
+        const reason =
+          notes || application.rejectionReason || "No reason provided";
+        const message = `Sorry ${application.userFullName}, your loan request of ZMW ${amountFormatted} was not approved. Reason: ${reason}. Contact us on +260957224792 /774 or visit our offices.`;
 
-          const payload = {
-            tenantId,
-            phoneNumbers: [application.userPhoneNumber],
-            message,
-            messageId: (global as any).crypto?.randomUUID
-              ? (global as any).crypto.randomUUID()
-              : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-            configId: 0,
-          };
-
-          await fetch(
-            `${serviceBaseUrl.replace(/\/$/, "")}/api/v1/notifications/sms`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(payload),
-            }
-          );
-        }
+        await sendSms([application.userPhoneNumber], message, {
+          tenantId: application.tenantId,
+        });
       } catch (notifyError) {
         console.error(
           "Failed to send rejection SMS notification:",

--- a/app/api/auth/mfa/challenge/route.ts
+++ b/app/api/auth/mfa/challenge/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMfaChallengeSummary, MfaChallengeError } from "@/lib/mfa";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+export async function GET(request: NextRequest) {
+  try {
+    const challengeId = request.nextUrl.searchParams.get("challengeId")?.trim();
+
+    if (!challengeId) {
+      return NextResponse.json(
+        { success: false, error: "Challenge ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const challenge = await getMfaChallengeSummary(tenant.id, challengeId);
+
+    return NextResponse.json({
+      success: true,
+      challenge,
+    });
+  } catch (error) {
+    if (error instanceof MfaChallengeError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error fetching MFA challenge:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to fetch verification challenge" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/mfa/resend/route.ts
+++ b/app/api/auth/mfa/resend/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { MfaChallengeError, resendMfaChallenge } from "@/lib/mfa";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const challengeId =
+      typeof body.challengeId === "string" ? body.challengeId.trim() : "";
+
+    if (!challengeId) {
+      return NextResponse.json(
+        { success: false, error: "Challenge ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const challenge = await resendMfaChallenge(tenant.id, challengeId);
+
+    return NextResponse.json({
+      success: true,
+      challenge,
+    });
+  } catch (error) {
+    if (error instanceof MfaChallengeError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error resending MFA challenge:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to resend verification code" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/mfa/start/route.ts
+++ b/app/api/auth/mfa/start/route.ts
@@ -1,0 +1,267 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  authenticateWithFineractCredentials,
+  FineractAuthenticationError,
+  getPermissionValidationError,
+} from "@/lib/fineract-auth";
+import {
+  buildMissingMfaContactMessage,
+  createMfaChallengeRecord,
+  getAvailableMfaChannels,
+  getTenantMfaConfig,
+  invalidateActiveMfaChallenges,
+  maskMfaDestination,
+  resolveMfaDestinations,
+  sendMfaChallengeMessage,
+  serializeMfaAuthContext,
+} from "@/lib/mfa";
+import {
+  isUserLoginBlocked,
+  requireCurrentTenant,
+  USER_LOGIN_BLOCKED_MESSAGE,
+  upsertUserLogin,
+} from "@/lib/user-login-service";
+import type { MfaChannel } from "@/shared/types/tenant";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const username =
+      typeof body.username === "string" ? body.username.trim() : "";
+    const password =
+      typeof body.password === "string" ? body.password : "";
+    const requestedChannel =
+      body.channel === "email" || body.channel === "sms"
+        ? (body.channel as MfaChannel)
+        : undefined;
+
+    if (!username || !password) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Username and password are required",
+        },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const authUser = await authenticateWithFineractCredentials({
+      username,
+      password,
+    });
+
+    const validationError = getPermissionValidationError(authUser.rawPermissions);
+    if (validationError) {
+      return NextResponse.json(
+        { success: false, error: validationError },
+        { status: 403 }
+      );
+    }
+
+    const userLogin = await upsertUserLogin({
+      tenantId: tenant.id,
+      fineractUserId: authUser.userId,
+      username: authUser.username,
+      ...(authUser.fineractEmail
+        ? { email: authUser.fineractEmail }
+        : {}),
+    });
+
+    const tenantMfaConfig = getTenantMfaConfig(tenant.settings);
+    if (!tenantMfaConfig.usesMfa) {
+      return NextResponse.json({
+        success: true,
+        requiresMfa: false,
+      });
+    }
+
+    if (isUserLoginBlocked(userLogin)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: USER_LOGIN_BLOCKED_MESSAGE,
+        },
+        { status: 423 }
+      );
+    }
+
+    if (tenantMfaConfig.channels.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Multi-factor authentication is enabled for your tenant, but no channels are configured. Contact your system administrator for help.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const destinations = resolveMfaDestinations({
+      email: userLogin.email || authUser.fineractEmail,
+      phone: userLogin.phone,
+      countryCode: userLogin.countryCode,
+    });
+    const availableChannels = getAvailableMfaChannels(
+      tenantMfaConfig.channels,
+      destinations
+    );
+
+    if (requestedChannel && !tenantMfaConfig.channels.includes(requestedChannel)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "The selected MFA channel is not enabled for your tenant.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (
+      requestedChannel &&
+      !availableChannels.includes(requestedChannel)
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: buildMissingMfaContactMessage({
+            configuredChannels: tenantMfaConfig.channels,
+            destinations,
+            requestedChannel,
+          }),
+        },
+        { status: 400 }
+      );
+    }
+
+    if (availableChannels.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: buildMissingMfaContactMessage({
+            configuredChannels: tenantMfaConfig.channels,
+            destinations,
+          }),
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!requestedChannel && availableChannels.length > 1) {
+      return NextResponse.json({
+        success: true,
+        requiresMfa: true,
+        requiresChannelSelection: true,
+        availableChannels,
+        destinations: Object.fromEntries(
+          availableChannels.map((channel) => [
+            channel,
+            maskMfaDestination(
+              channel,
+              channel === "email"
+                ? destinations.email || ""
+                : destinations.sms || ""
+            ),
+          ])
+        ),
+      });
+    }
+
+    const chosenChannel = requestedChannel ?? availableChannels[0];
+    const destination = destinations[chosenChannel];
+
+    if (!destination) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: buildMissingMfaContactMessage({
+            configuredChannels: tenantMfaConfig.channels,
+            destinations,
+            requestedChannel: chosenChannel,
+          }),
+        },
+        { status: 400 }
+      );
+    }
+
+    await invalidateActiveMfaChallenges(tenant.id, authUser.userId);
+
+    const { challenge, code } = await createMfaChallengeRecord({
+      tenantId: tenant.id,
+      fineractUserId: authUser.userId,
+      username: authUser.username,
+      channel: chosenChannel,
+      destination,
+      authContext: serializeMfaAuthContext({
+        ...authUser,
+        tenantId: tenant.id,
+      }),
+      maxAttempts: tenantMfaConfig.maxAttempts,
+    });
+
+    const delivered = await sendMfaChallengeMessage({
+      tenantId: tenant.id,
+      username: authUser.username,
+      channel: chosenChannel,
+      destination,
+      code,
+    });
+
+    if (!delivered) {
+      await prisma.mfaChallenge.update({
+        where: { id: challenge.id },
+        data: {
+          invalidatedAt: new Date(),
+        },
+      });
+
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            chosenChannel === "email"
+              ? "We could not send a verification email. Contact your system administrator for help."
+              : "We could not send a verification SMS. Contact your system administrator for help.",
+        },
+        { status: 500 }
+      );
+    }
+
+    await upsertUserLogin({
+      tenantId: tenant.id,
+      fineractUserId: authUser.userId,
+      username: authUser.username,
+      email: userLogin.email || authUser.fineractEmail,
+      phone: userLogin.phone,
+      countryCode: userLogin.countryCode,
+      lastMfaChannel: chosenChannel,
+      lastMfaSentAt: new Date(),
+    });
+
+    return NextResponse.json({
+      success: true,
+      requiresMfa: true,
+      challengeId: challenge.id,
+      channel: chosenChannel,
+      maskedDestination: challenge.maskedDestination,
+      expiresAt: challenge.expiresAt,
+    });
+  } catch (error) {
+    if (error instanceof FineractAuthenticationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error starting MFA flow:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Unable to start multi-factor authentication",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/mfa/verify/route.ts
+++ b/app/api/auth/mfa/verify/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { MfaChallengeError, verifyMfaChallengeCode } from "@/lib/mfa";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+import { MFA_CODE_LENGTH, MFA_CODE_PATTERN } from "@/shared/constants/mfa";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const challengeId =
+      typeof body.challengeId === "string" ? body.challengeId.trim() : "";
+    const code = typeof body.code === "string" ? body.code.trim() : "";
+
+    if (!challengeId || !code) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Challenge ID and verification code are required",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!MFA_CODE_PATTERN.test(code)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Verification code must be exactly ${MFA_CODE_LENGTH} digits`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const verification = await verifyMfaChallengeCode({
+      tenantId: tenant.id,
+      challengeId,
+      code,
+    });
+
+    return NextResponse.json({
+      success: true,
+      ...verification,
+    });
+  } catch (error) {
+    if (error instanceof MfaChallengeError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: error.message,
+          ...(error.details ?? {}),
+        },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error verifying MFA challenge:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to verify the MFA code" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/validate/route.ts
+++ b/app/api/auth/validate/route.ts
@@ -1,153 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getFineractTenantId } from "@/lib/fineract-tenant-service";
-import https from "https";
-import fetch from "node-fetch";
+import {
+  authenticateWithFineractCredentials,
+  FineractAuthenticationError,
+  getPermissionValidationError,
+} from "@/lib/fineract-auth";
 
 export async function POST(request: NextRequest) {
   try {
     const { username, password } = await request.json();
 
-    if (!username || !password) {
+    const authUser = await authenticateWithFineractCredentials({
+      username,
+      password,
+    });
+
+    const validationError = getPermissionValidationError(authUser.rawPermissions);
+    if (validationError) {
       return NextResponse.json(
-        { success: false, error: "Username and password are required" },
-        { status: 400 }
-      );
-    }
-
-    const fineractTenantId = await getFineractTenantId();
-    const baseUrl =
-      process.env.FINERACT_BASE_URL || "https://demo.mifos.io";
-    const authUrl = `${baseUrl}/fineract-provider/api/v1/authentication`;
-
-    const body = JSON.stringify({ username, password });
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "Fineract-Platform-TenantId": fineractTenantId,
-    };
-
-    let response;
-
-    if (baseUrl.startsWith("http://")) {
-      const http = require("http");
-      const url = require("url");
-      const parsedUrl = url.parse(authUrl);
-
-      response = await new Promise<{
-        ok: boolean;
-        status: number;
-        json: () => Promise<any>;
-      }>((resolve, reject) => {
-        const req = http.request(
-          {
-            hostname: parsedUrl.hostname,
-            port: parsedUrl.port || 80,
-            path: parsedUrl.path,
-            method: "POST",
-            headers: {
-              ...headers,
-              "Content-Length": Buffer.byteLength(body),
-            },
-          },
-          (res: any) => {
-            let data = "";
-            res.on("data", (chunk: any) => {
-              data += chunk;
-            });
-            res.on("end", () => {
-              resolve({
-                ok: res.statusCode >= 200 && res.statusCode < 300,
-                status: res.statusCode,
-                json: async () => JSON.parse(data),
-              });
-            });
-          }
-        );
-        req.on("error", reject);
-        req.write(body);
-        req.end();
-      });
-    } else {
-      response = await fetch(authUrl, {
-        method: "POST",
-        headers,
-        body,
-        agent: new https.Agent({ rejectUnauthorized: false }),
-      });
-    }
-
-    if (!response.ok) {
-      let errorMessage = "Authentication failed";
-      try {
-        const errorData = await response.json();
-        if (errorData.defaultUserMessage) {
-          errorMessage = errorData.defaultUserMessage;
-        } else if (errorData.developerMessage) {
-          errorMessage = errorData.developerMessage;
-        } else if (
-          errorData.errors?.length > 0 &&
-          errorData.errors[0].defaultUserMessage
-        ) {
-          errorMessage = errorData.errors[0].defaultUserMessage;
-        }
-      } catch {
-        errorMessage = `Authentication failed (${response.status})`;
-      }
-      return NextResponse.json(
-        { success: false, error: errorMessage },
-        { status: 401 }
-      );
-    }
-
-    const data = await response.json();
-
-    if (!data.base64EncodedAuthenticationKey) {
-      return NextResponse.json(
-        { success: false, error: "Authentication failed. Please check your credentials." },
-        { status: 401 }
-      );
-    }
-
-    const userPermissions: string[] = data.permissions || [];
-
-    if (userPermissions.length === 0) {
-      return NextResponse.json(
-        {
-          success: false,
-          error:
-            "Your account does not have any permissions assigned. Please contact your administrator.",
-        },
+        { success: false, error: validationError },
         { status: 403 }
       );
     }
 
-    const hasAllFunctions =
-      userPermissions.includes("ALL_FUNCTIONS") ||
-      userPermissions.includes("ALL_FUNCTIONS_READ");
-
-    if (!hasAllFunctions) {
-      const requiredPermissions = [
-        "READ_USER",
-        "READ_CURRENCY",
-        "READ_REPORT",
-      ];
-      const missing = requiredPermissions.filter(
-        (p) => !userPermissions.includes(p)
-      );
-
-      if (missing.length > 0) {
-        return NextResponse.json(
-          {
-            success: false,
-            error: `Insufficient privileges. Your account is missing required permissions: ${missing.join(", ")}. Please contact your administrator.`,
-          },
-          { status: 403 }
-        );
-      }
-    }
-
     return NextResponse.json({ success: true });
   } catch (error) {
+    if (error instanceof FineractAuthenticationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
     console.error("Validation route error:", error);
     return NextResponse.json(
       {

--- a/app/api/tenant/route.ts
+++ b/app/api/tenant/route.ts
@@ -10,12 +10,43 @@ export async function GET() {
   if (!tenant) {
     return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
   }
+  const settings =
+    tenant.settings && typeof tenant.settings === "object"
+      ? ({ ...(tenant.settings as unknown as Record<string, unknown>) } as Record<
+          string,
+          unknown
+        >)
+      : null;
+
+  if (settings) {
+    delete settings.usesMFA;
+    delete settings.mfaChannels;
+    delete settings.mfaMaxAttempts;
+
+    const features =
+      settings.features &&
+      typeof settings.features === "object" &&
+      !Array.isArray(settings.features)
+        ? ({ ...(settings.features as Record<string, unknown>) } as Record<
+            string,
+            unknown
+          >)
+        : null;
+
+    if (features) {
+      delete features.usesMFA;
+      delete features.mfaChannels;
+      delete features.mfaMaxAttempts;
+      settings.features = features;
+    }
+  }
+
   return NextResponse.json({
     id: tenant.id,
     name: tenant.name,
     slug: tenant.slug,
     logoFileUrl: tenant.logoFileUrl ?? null,
     logoLinkId: tenant.logoLinkId ?? null,
-    settings: tenant.settings ?? null,
+    settings,
   });
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,10 +5,15 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { LockIcon, ShieldIcon, ServerIcon, AlertCircle } from "lucide-react";
-import { LoanSystemLogo } from "@/components/ui/loan-system-logo";
+import {
+  LockIcon,
+  ShieldIcon,
+  ServerIcon,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
 import { Globe } from "@/components/magicui/globe";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Particles } from "@/components/magicui/particles";
 import { BorderBeam } from "@/components/magicui/border-beam";
 import { Meteors } from "@/components/magicui/meteors";
@@ -16,12 +21,17 @@ import { useAuth } from "@/contexts/auth-context";
 import { useRouter } from "next/navigation";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
+import type { MfaChannel } from "@/shared/types/tenant";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const [availableChannels, setAvailableChannels] = useState<MfaChannel[]>([]);
+  const [channelDestinations, setChannelDestinations] = useState<
+    Partial<Record<MfaChannel, string | null>>
+  >({});
   const { login, status } = useAuth();
   const router = useRouter();
 
@@ -32,8 +42,7 @@ export default function LoginPage() {
     }
   }, [status, router]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submitLogin = async (channel?: MfaChannel) => {
     setError("");
 
     if (!username || !password) {
@@ -44,12 +53,30 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      const result = await login(username, password);
+      const result = await login(username, password, channel);
 
       if (result.success) {
         window.location.href = "/leads";
-      } else {
+        return;
+      }
+
+      if (result.requiresMfa) {
+        if ("requiresChannelSelection" in result && result.requiresChannelSelection) {
+          setAvailableChannels(result.availableChannels);
+          setChannelDestinations(result.destinations);
+          return;
+        }
+
+        if ("challengeId" in result) {
+          router.push(`/auth/mfa?challengeId=${encodeURIComponent(result.challengeId)}`);
+          return;
+        }
+      }
+
+      if ("error" in result) {
         setError(result.error || "Login failed");
+        setAvailableChannels([]);
+        setChannelDestinations({});
       }
     } catch (err) {
       setError("An error occurred during login");
@@ -57,6 +84,11 @@ export default function LoginPage() {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await submitLogin();
   };
   return (
     <div className="min-h-screen flex flex-col md:flex-row bg-background overflow-hidden relative">
@@ -84,7 +116,7 @@ export default function LoginPage() {
           <div className="space-y-8 max-w-md">
             <div className="space-y-2">
               <p className="text-blue-500 text-lg font-medium">
-                Let's put Security everywhere
+                Let&apos;s put Security everywhere
               </p>
               <p className="text-foreground text-lg">
                 Empowering Secure Lending, Everywhere.
@@ -179,6 +211,36 @@ export default function LoginPage() {
                   </div>
                 )}
 
+                {availableChannels.length > 0 && (
+                  <div className="rounded-md border border-blue-500/30 bg-blue-500/5 p-4 space-y-3">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-foreground">
+                        Choose where to receive your verification code
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Select one of the configured MFA channels for your account.
+                      </p>
+                    </div>
+                    <div className="grid gap-2">
+                      {availableChannels.map((channel) => (
+                        <Button
+                          key={channel}
+                          type="button"
+                          variant="outline"
+                          disabled={isLoading}
+                          onClick={() => submitLogin(channel)}
+                          className="justify-between"
+                        >
+                          <span className="uppercase">{channel}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {channelDestinations[channel] || ""}
+                          </span>
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 <div className="space-y-2">
                   <Label
                     htmlFor="username"
@@ -193,7 +255,11 @@ export default function LoginPage() {
                       placeholder="Enter your username"
                       className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       value={username}
-                      onChange={(e) => setUsername(e.target.value)}
+                      onChange={(e) => {
+                        setUsername(e.target.value);
+                        setAvailableChannels([]);
+                        setChannelDestinations({});
+                      }}
                       required
                     />
                     <svg
@@ -233,7 +299,11 @@ export default function LoginPage() {
                       type="password"
                       className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       value={password}
-                      onChange={(e) => setPassword(e.target.value)}
+                      onChange={(e) => {
+                        setPassword(e.target.value);
+                        setAvailableChannels([]);
+                        setChannelDestinations({});
+                      }}
                       required
                     />
                     <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-blue-500" />
@@ -257,7 +327,10 @@ export default function LoginPage() {
                   disabled={isLoading}
                 >
                   {isLoading ? (
-                    <span>SIGNING IN...</span>
+                    <>
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>SIGNING IN...</span>
+                    </>
                   ) : (
                     <>
                       <span>SIGN IN</span>

--- a/app/auth/mfa/page.tsx
+++ b/app/auth/mfa/page.tsx
@@ -1,0 +1,687 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { signIn, getSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  AlertCircle,
+  ArrowLeft,
+  Loader2,
+  LockIcon,
+  ShieldIcon,
+  ServerIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Globe } from "@/components/magicui/globe";
+import { Particles } from "@/components/magicui/particles";
+import { BorderBeam } from "@/components/magicui/border-beam";
+import { Meteors } from "@/components/magicui/meteors";
+import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
+import { MFA_CODE_LENGTH } from "@/shared/constants/mfa";
+import type { MfaChannel } from "@/shared/types/tenant";
+
+type ChallengeSummary = {
+  id: string;
+  username: string;
+  channel: MfaChannel;
+  maskedDestination: string;
+  expiresAt: string;
+  resendAvailableAt: string;
+  attemptsUsed: number;
+  maxAttempts: number;
+  remainingAttempts: number;
+};
+
+function emptyCodeDigits() {
+  return Array.from({ length: MFA_CODE_LENGTH }, () => "");
+}
+
+function formatCountdown(milliseconds: number) {
+  const totalSeconds = Math.max(0, Math.ceil(milliseconds / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+async function hasActiveSession(
+  attempts = 5,
+  delayMs = 120
+): Promise<boolean> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const currentSession = await getSession();
+    if (currentSession) {
+      return true;
+    }
+
+    if (attempt < attempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return false;
+}
+
+export default function MfaPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const challengeId = searchParams.get("challengeId") || "";
+  const digitRefs = useRef<Array<HTMLInputElement | null>>([]);
+
+  const [challenge, setChallenge] = useState<ChallengeSummary | null>(null);
+  const [codeDigits, setCodeDigits] = useState<string[]>(() => emptyCodeDigits());
+  const [loading, setLoading] = useState(true);
+  const [verifying, setVerifying] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [now, setNow] = useState(() => Date.now());
+
+  const code = useMemo(() => codeDigits.join(""), [codeDigits]);
+  const resendCountdown = challenge
+    ? Math.max(0, new Date(challenge.resendAvailableAt).getTime() - now)
+    : 0;
+  const expiresCountdown = challenge
+    ? Math.max(0, new Date(challenge.expiresAt).getTime() - now)
+    : 0;
+  const isResendLocked = resendCountdown > 0;
+  const showAttemptWarning = (challenge?.attemptsUsed ?? 0) > 0;
+
+  useEffect(() => {
+    if (!challengeId) {
+      setError("Verification challenge is missing. Please log in again.");
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadChallenge() {
+      try {
+        const response = await fetch(
+          `/api/auth/mfa/challenge?challengeId=${encodeURIComponent(challengeId)}`
+        );
+        const data = await response.json();
+
+        if (!response.ok || !data.success) {
+          throw new Error(data.error || "Unable to load verification challenge");
+        }
+
+        if (!cancelled) {
+          setChallenge(data.challenge);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Unable to load verification challenge"
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadChallenge();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [challengeId]);
+
+  useEffect(() => {
+    if (!challenge) {
+      return undefined;
+    }
+
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [challenge]);
+
+  useEffect(() => {
+    if (!loading && challenge) {
+      digitRefs.current[0]?.focus();
+    }
+  }, [loading, challenge]);
+
+  const focusDigit = (index: number) => {
+    const nextIndex = Math.max(0, Math.min(index, MFA_CODE_LENGTH - 1));
+    digitRefs.current[nextIndex]?.focus();
+    digitRefs.current[nextIndex]?.select();
+  };
+
+  const applyDigits = (startIndex: number, value: string) => {
+    const sanitized = value.replace(/\D/g, "").slice(0, MFA_CODE_LENGTH - startIndex);
+
+    if (!sanitized) {
+      setCodeDigits((current) => {
+        const next = [...current];
+        next[startIndex] = "";
+        return next;
+      });
+      return;
+    }
+
+    setCodeDigits((current) => {
+      const next = [...current];
+      sanitized.split("").forEach((digit, offset) => {
+        next[startIndex + offset] = digit;
+      });
+      return next;
+    });
+
+    const focusIndex = Math.min(
+      startIndex + sanitized.length,
+      MFA_CODE_LENGTH - 1
+    );
+    window.requestAnimationFrame(() => {
+      focusDigit(focusIndex);
+    });
+  };
+
+  const handleDigitChange = (index: number, value: string) => {
+    setError("");
+    setMessage("");
+    applyDigits(index, value);
+  };
+
+  const handleDigitKeyDown = (
+    index: number,
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusDigit(index - 1);
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusDigit(index + 1);
+      return;
+    }
+
+    if (event.key !== "Backspace") {
+      return;
+    }
+
+    event.preventDefault();
+    setError("");
+    setMessage("");
+
+    setCodeDigits((current) => {
+      const next = [...current];
+
+      if (next[index]) {
+        next[index] = "";
+        return next;
+      }
+
+      if (index > 0) {
+        next[index - 1] = "";
+        window.requestAnimationFrame(() => {
+          focusDigit(index - 1);
+        });
+      }
+
+      return next;
+    });
+  };
+
+  const handleDigitPaste = (
+    index: number,
+    event: React.ClipboardEvent<HTMLInputElement>
+  ) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+    applyDigits(index, event.clipboardData.getData("text"));
+  };
+
+  const handleVerify = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+
+    if (code.length !== MFA_CODE_LENGTH) {
+      setError(`Enter the ${MFA_CODE_LENGTH}-digit verification code to continue.`);
+      return;
+    }
+
+    setVerifying(true);
+
+    try {
+      const verifyResponse = await fetch("/api/auth/mfa/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          challengeId,
+          code,
+        }),
+      });
+      const verifyData = await verifyResponse.json();
+
+      if (!verifyResponse.ok || !verifyData.success) {
+        if (
+          challenge &&
+          typeof verifyData.attemptsUsed === "number" &&
+          typeof verifyData.maxAttempts === "number"
+        ) {
+          setChallenge({
+            ...challenge,
+            attemptsUsed: verifyData.attemptsUsed,
+            maxAttempts: verifyData.maxAttempts,
+            remainingAttempts:
+              typeof verifyData.remainingAttempts === "number"
+                ? verifyData.remainingAttempts
+                : Math.max(
+                    verifyData.maxAttempts - verifyData.attemptsUsed,
+                    0
+                  ),
+          });
+        }
+
+        setCodeDigits(emptyCodeDigits());
+        window.requestAnimationFrame(() => {
+          focusDigit(0);
+        });
+        setError(verifyData.error || "Verification failed");
+        return;
+      }
+
+      const signInResult = await signIn("credentials", {
+        challengeId,
+        verificationToken: verifyData.verificationToken,
+        redirect: false,
+        callbackUrl: "/leads",
+      });
+
+      if (signInResult?.error && !(await hasActiveSession())) {
+        throw new Error("Verification succeeded, but we could not complete sign-in.");
+      }
+
+      window.location.href = "/leads";
+    } catch (verifyError) {
+      setError(
+        verifyError instanceof Error
+          ? verifyError.message
+          : "Unable to verify the MFA code"
+      );
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setError("");
+    setMessage("");
+    setResending(true);
+
+    try {
+      const resendResponse = await fetch("/api/auth/mfa/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ challengeId }),
+      });
+      const resendData = await resendResponse.json();
+
+      if (!resendResponse.ok || !resendData.success) {
+        throw new Error(resendData.error || "Unable to resend the code");
+      }
+
+      setChallenge((current) =>
+        current
+          ? {
+              ...current,
+              ...resendData.challenge,
+            }
+          : current
+      );
+      setCodeDigits(emptyCodeDigits());
+      setMessage("A new verification code has been sent.");
+      window.requestAnimationFrame(() => {
+        focusDigit(0);
+      });
+    } catch (resendError) {
+      setError(
+        resendError instanceof Error
+          ? resendError.message
+          : "Unable to resend the code"
+      );
+    } finally {
+      setResending(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background px-6">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col md:flex-row bg-background overflow-hidden relative">
+      <div className="absolute top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
+
+      <div className="absolute inset-0 overflow-hidden pointer-events-none z-0 opacity-90">
+        <Meteors number={10} />
+        <Particles />
+        <div className="absolute inset-0 translate-x-[200px]">
+          <Globe />
+        </div>
+      </div>
+
+      <div className="hidden md:block md:w-1/2 relative z-10">
+        <div className="absolute inset-0 z-20 flex flex-col justify-between p-12 mx-auto max-w-4xl">
+          <div>
+            <ThemeAwareLogo width={150} height={150} />
+          </div>
+
+          <div className="space-y-8 max-w-md">
+            <div className="space-y-2">
+              <p className="text-blue-500 text-lg font-medium">
+                Let&apos;s put Security everywhere
+              </p>
+              <p className="text-foreground text-lg">
+                Empowering Secure Lending, Everywhere.
+              </p>
+            </div>
+
+            <h2 className="text-6xl font-bold text-foreground leading-tight">
+              LOAN
+              <br />
+              MATRIX
+            </h2>
+
+            <div className="relative translate-x-[200px]">
+              <div className="absolute -right-40 -top-20 w-80 h-80">
+                <div className="absolute inset-0 border-2 border-blue-500/30 rounded-full animate-[spin_30s_linear_infinite]"></div>
+                <div className="absolute inset-4 border border-blue-500/20 rounded-full animate-[spin_20s_linear_infinite_reverse]"></div>
+                <div className="absolute inset-10 border border-blue-500/10 rounded-full animate-[spin_25s_linear_infinite]"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="w-32 h-32 bg-card/50 backdrop-blur-sm rounded-lg flex items-center justify-center border border-border">
+                    <LockIcon className="h-16 w-16 text-blue-500" />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-6 pt-8">
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <ShieldIcon className="h-8 w-8 text-blue-500 mb-2" />
+                <span className="text-foreground text-sm font-medium text-center">
+                  Enterprise Security
+                </span>
+              </div>
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <ServerIcon className="h-8 w-8 text-blue-500 mb-2" />
+                <span className="text-foreground text-sm font-medium text-center">
+                  Advanced Analytics
+                </span>
+              </div>
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <svg
+                  className="h-8 w-8 text-blue-500 mb-2"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span className="text-foreground text-sm font-medium text-center">
+                  Compliance Ready
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-4">
+            <Button
+              variant="outline"
+              className="border-blue-500 text-foreground hover:bg-blue-500/20 transition-all duration-300"
+            >
+              LOAN MANAGEMENT
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col justify-center items-center p-6 md:p-12 lg:p-16 w-full md:w-1/2 relative z-10">
+        <div className="w-full max-w-md space-y-8 mx-auto">
+          <div className="md:hidden flex justify-center mb-8">
+            <ThemeAwareLogo width={120} height={40} className="h-12 w-auto" />
+          </div>
+
+          <Card className="w-full shadow-xl border-border overflow-hidden transition-all duration-300 hover:border-blue-500/40 bg-card/70 backdrop-blur-sm">
+            <CardContent className="p-8 space-y-6">
+              <div className="text-center space-y-2 mb-8">
+                <h1 className="text-3xl font-bold tracking-tight text-foreground">
+                  Multi-Factor Verification
+                </h1>
+                <p className="text-blue-500">
+                  Enter the code to continue signing in
+                </p>
+                {challenge && (
+                  <p className="text-sm text-muted-foreground">
+                    {challenge.channel.toUpperCase()} to {challenge.maskedDestination}
+                  </p>
+                )}
+              </div>
+
+              {error && (
+                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 flex items-start gap-2">
+                  <AlertCircle className="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" />
+                  <p className="text-sm text-red-500">{error}</p>
+                </div>
+              )}
+
+              {showAttemptWarning && challenge && (
+                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3">
+                  <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                    Attempt {challenge.attemptsUsed} of {challenge.maxAttempts}.
+                  </p>
+                  <p className="mt-1 text-sm text-amber-700/90 dark:text-amber-200">
+                    {challenge.remainingAttempts > 0
+                      ? `Your account will be blocked once ${challenge.maxAttempts} failed attempts are reached. ${challenge.remainingAttempts} attempt${challenge.remainingAttempts === 1 ? "" : "s"} remaining.`
+                      : `Your account will be blocked once ${challenge.maxAttempts} failed attempts are reached.`}
+                  </p>
+                </div>
+              )}
+
+              {message && (
+                <div className="rounded-md border border-green-500/30 bg-green-500/10 p-3">
+                  <p className="text-sm text-green-600">{message}</p>
+                </div>
+              )}
+
+              <form onSubmit={handleVerify} className="space-y-5">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-foreground">
+                      Verification Code
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Expires in {formatCountdown(expiresCountdown)}
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-6 gap-2">
+                    {codeDigits.map((digit, index) => (
+                      <input
+                        key={`mfa-digit-${index + 1}`}
+                        ref={(element) => {
+                          digitRefs.current[index] = element;
+                        }}
+                        type="text"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        autoComplete={index === 0 ? "one-time-code" : "off"}
+                        maxLength={1}
+                        value={digit}
+                        aria-label={`Verification code digit ${index + 1}`}
+                        onChange={(event) => handleDigitChange(index, event.target.value)}
+                        onKeyDown={(event) => handleDigitKeyDown(index, event)}
+                        onPaste={(event) => handleDigitPaste(index, event)}
+                        onFocus={(event) => event.currentTarget.select()}
+                        className={cn(
+                          "h-14 rounded-md border bg-background text-center text-xl font-semibold text-foreground outline-none transition-all duration-200",
+                          "border-border focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20",
+                          digit && "border-blue-500"
+                        )}
+                      />
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Type or paste your {MFA_CODE_LENGTH}-digit verification code.
+                  </p>
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
+                  disabled={verifying || !challengeId || code.length !== MFA_CODE_LENGTH}
+                >
+                  {verifying ? (
+                    <>
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>VERIFYING...</span>
+                    </>
+                  ) : (
+                    <>
+                      <span>VERIFY AND SIGN IN</span>
+                      <svg
+                        className="h-5 w-5"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M5 12h14M12 5l7 7-7 7" />
+                      </svg>
+                    </>
+                  )}
+                </Button>
+              </form>
+
+              <div className="space-y-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleResend}
+                  disabled={resending || !challengeId || isResendLocked}
+                >
+                  {resending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span>RESENDING...</span>
+                    </>
+                  ) : (
+                    <span>
+                      {isResendLocked
+                        ? `Resend available in ${formatCountdown(resendCountdown)}`
+                        : "Resend Code"}
+                    </span>
+                  )}
+                </Button>
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full"
+                  onClick={() => router.push("/auth/login")}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back to Login
+                </Button>
+
+                <div className="text-center">
+                  <Link
+                    href="/auth/login"
+                    className="text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    Start over with a different account
+                  </Link>
+                </div>
+              </div>
+            </CardContent>
+            <BorderBeam
+              duration={8}
+              size={100}
+              className="from-transparent via-blue-500 to-transparent"
+            />
+          </Card>
+
+          <div className="flex items-center justify-center space-x-2 pt-4">
+            <div className="p-2 rounded-full bg-card border border-border">
+              <svg
+                className="h-4 w-4 text-blue-500"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+              </svg>
+            </div>
+            <span className="text-sm text-blue-500">
+              Secure, encrypted connection
+            </span>
+          </div>
+
+          <div className="text-center text-sm text-muted-foreground pt-4">
+            © 2025 Enterprise Loan Management System. All rights reserved.
+            <div className="flex justify-center space-x-4 mt-2">
+              <Link
+                href="/terms"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Terms
+              </Link>
+              <Link
+                href="/privacy"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Privacy
+              </Link>
+              <Link
+                href="/support"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Support
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -2,8 +2,30 @@
 
 import React, { createContext, useContext } from "react";
 import { signIn, signOut, useSession, getSession } from "next-auth/react";
+import type { MfaChannel } from "@/shared/types/tenant";
 
-type LoginResult = { success: boolean; error?: string };
+type LoginResult =
+  | { success: true }
+  | {
+      success: false;
+      error: string;
+      requiresMfa?: false;
+      requiresChannelSelection?: false;
+    }
+  | {
+      success: false;
+      requiresMfa: true;
+      challengeId: string;
+      channel: MfaChannel;
+      maskedDestination: string;
+    }
+  | {
+      success: false;
+      requiresMfa: true;
+      requiresChannelSelection: true;
+      availableChannels: MfaChannel[];
+      destinations: Partial<Record<MfaChannel, string | null>>;
+    };
 
 type AuthContextType = {
   status: "loading" | "authenticated" | "unauthenticated";
@@ -13,15 +35,19 @@ type AuthContextType = {
     email?: string | null;
     image?: string | null;
   } | null;
-  login: (username: string, password: string) => Promise<LoginResult>;
-  logout: () => void;
+  login: (
+    username: string,
+    password: string,
+    channel?: MfaChannel
+  ) => Promise<LoginResult>;
+  logout: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextType>({
   status: "loading",
   user: null,
-  login: async () => ({ success: false }),
-  logout: () => {},
+  login: async () => ({ success: false, error: "Authentication unavailable" }),
+  logout: async () => {},
 });
 
 // Custom hook to use the auth context
@@ -49,11 +75,64 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return false;
   };
 
+  const waitForSessionToClear = async (
+    attempts = 10,
+    delayMs = 120
+  ): Promise<boolean> => {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const currentSession = await getSession();
+      if (!currentSession) {
+        return true;
+      }
+
+      if (attempt < attempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    return false;
+  };
+
   const login = async (
     username: string,
-    password: string
+    password: string,
+    channel?: MfaChannel
   ): Promise<LoginResult> => {
     try {
+      const mfaStartRes = await fetch("/api/auth/mfa/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password, channel }),
+      });
+      const mfaStartData = await mfaStartRes.json();
+
+      if (!mfaStartRes.ok || !mfaStartData.success) {
+        return {
+          success: false,
+          error: mfaStartData.error || "Login failed",
+        };
+      }
+
+      if (mfaStartData.requiresMfa) {
+        if (mfaStartData.requiresChannelSelection) {
+          return {
+            success: false,
+            requiresMfa: true,
+            requiresChannelSelection: true,
+            availableChannels: mfaStartData.availableChannels || [],
+            destinations: mfaStartData.destinations || {},
+          };
+        }
+
+        return {
+          success: false,
+          requiresMfa: true,
+          challengeId: mfaStartData.challengeId,
+          channel: mfaStartData.channel,
+          maskedDestination: mfaStartData.maskedDestination,
+        };
+      }
+
       const result = await signIn("credentials", {
         username,
         password,
@@ -69,25 +148,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         console.error("SignIn error:", result.error);
-
-        try {
-          const validateRes = await fetch("/api/auth/validate", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ username, password }),
-          });
-          const validateData = await validateRes.json();
-
-          if (!validateRes.ok || !validateData.success) {
-            return {
-              success: false,
-              error: validateData.error || "Invalid username or password",
-            };
-          }
-        } catch {
-          // validate endpoint unreachable, fall through to generic error
-        }
-
         return { success: false, error: "Invalid username or password" };
       }
 
@@ -97,25 +157,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           success: false,
           error: "Authentication is taking longer than expected. Please try again.",
         };
-      }
-
-      try {
-        const validateRes = await fetch("/api/auth/validate", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ username, password }),
-        });
-        const validateData = await validateRes.json();
-
-        if (!validateRes.ok || !validateData.success) {
-          await signOut({ redirect: false });
-          return {
-            success: false,
-            error: validateData.error || "Authentication failed",
-          };
-        }
-      } catch {
-        // validate endpoint unreachable — signIn already succeeded so allow login
       }
 
       return { success: true };
@@ -133,10 +174,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const logout = () => {
-    signOut({
-      callbackUrl: `${window.location.origin}/auth/login`,
+  const logout = async () => {
+    await signOut({
+      redirect: false,
     });
+
+    await waitForSessionToClear();
+    window.location.href = `${window.location.origin}/auth/login`;
   };
 
   // Map NextAuth session status to our auth context status

--- a/env.example
+++ b/env.example
@@ -34,6 +34,9 @@ NODE_ENV=development
 # Notifications Service Configuration
 NOTIFICATION_SERVICE_URL=http://kenac-notification-service-dev.10.10.0.24.nip.io:31778
 TENANT_ID=goodfellow
+EMAIL_NOTIFICATION_SERVICE_URL=
+EMAIL_NOTIFICATION_SERVICE_PATH=/api/v1/notifications/email
+MFA_EMAIL_FROM=
 
 # USSD Loan Product Whitelist Sync Configuration
 USSD_BASE_URL=http://localhost:8080/api/v1

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,9 +3,18 @@ import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import https from "https";
 import fetch from "node-fetch";
-import { SpecificPermission } from "@/shared/types/auth";
-import { mapApiPermissionsToSpecific } from "./authorization";
-import { getFineractTenantId } from "./fineract-tenant-service";
+import { Role, SpecificPermission } from "@/shared/types/auth";
+import {
+  authenticateWithFineractCredentials,
+  getPermissionValidationError,
+} from "@/lib/fineract-auth";
+import { consumeVerifiedMfaChallenge, getTenantMfaConfig } from "@/lib/mfa";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import {
+  getUserLoginByFineractUserId,
+  isUserLoginBlocked,
+  updateUserLoginLastLogin,
+} from "@/lib/user-login-service";
 
 // Define the NextAuth options
 export const authOptions: NextAuthOptions = {
@@ -17,239 +26,66 @@ export const authOptions: NextAuthOptions = {
       credentials: {
         username: { label: "Username", type: "text" },
         password: { label: "Password", type: "password" },
+        challengeId: { label: "Challenge ID", type: "text" },
+        verificationToken: { label: "Verification Token", type: "text" },
       },
       async authorize(credentials) {
-        if (!credentials?.username || !credentials?.password) {
-          return null;
-        }
-
         try {
-          // Get the Fineract tenant ID based on the current subdomain
-          const fineractTenantId = await getFineractTenantId();
+          if (credentials?.challengeId && credentials?.verificationToken) {
+            return await consumeVerifiedMfaChallenge({
+              challengeId: credentials.challengeId,
+              verificationToken: credentials.verificationToken,
+            });
+          }
 
-          const baseUrl =
-            process.env.FINERACT_BASE_URL || "https://demo.mifos.io";
-          const authUrl = `${baseUrl}/fineract-provider/api/v1/authentication`;
+          if (!credentials?.username || !credentials?.password) {
+            return null;
+          }
 
-          console.log("Auth Debug - baseUrl:", baseUrl);
-          console.log("Auth Debug - authUrl:", authUrl);
-          console.log("Auth Debug - fineractTenantId:", fineractTenantId);
-          console.log("Auth Debug - isHTTP:", baseUrl.startsWith("http://"));
-          console.log(
-            "Auth Debug - FINERACT_TENANT_ID:",
-            process.env.FINERACT_TENANT_ID
-          );
-          console.log("Auth Debug - All env vars:", {
-            FINERACT_BASE_URL: process.env.FINERACT_BASE_URL,
-            FINERACT_TENANT_ID: process.env.FINERACT_TENANT_ID,
-            FINERACT_USERNAME: process.env.FINERACT_USERNAME,
-            FINERACT_PASSWORD: process.env.FINERACT_PASSWORD,
+          const tenant = await getTenantFromHeaders();
+          if (!tenant) {
+            console.error(
+              "Blocking direct sign-in because tenant could not be resolved for credentials flow"
+            );
+            return null;
+          }
+
+          const authUser = await authenticateWithFineractCredentials({
+            username: credentials.username,
+            password: credentials.password,
           });
 
-          let response;
-
-          // Check if it's HTTP and use different approach
-          if (baseUrl.startsWith("http://")) {
-            console.log("Auth Debug - Using HTTP path");
-            // Use Node.js built-in http module for HTTP URLs
-            const http = require("http");
-            const url = require("url");
-
-            const parsedUrl = url.parse(authUrl);
-            const postData = JSON.stringify({
-              username: credentials.username,
-              password: credentials.password,
-            });
-
-            const options = {
-              hostname: parsedUrl.hostname,
-              port: parsedUrl.port || 80,
-              path: parsedUrl.path,
-              method: "POST",
-              headers: {
-                Accept: "application/json, text/plain, */*",
-                "Content-Type": "application/json",
-                "Fineract-Platform-TenantId": fineractTenantId,
-                "Content-Length": Buffer.byteLength(postData),
-              },
-            };
-
-            console.log("Auth Debug - HTTP request options:", options);
-            console.log("Auth Debug - POST data:", postData);
-
-            response = await new Promise<any>((resolve, reject) => {
-              const req = http.request(options, (res: any) => {
-                let data = "";
-                console.log(
-                  "Auth Debug - HTTP response status:",
-                  res.statusCode
-                );
-                res.on("data", (chunk: any) => {
-                  data += chunk;
-                });
-                res.on("end", () => {
-                  console.log("Auth Debug - HTTP response data:", data);
-                  resolve({
-                    ok: res.statusCode >= 200 && res.statusCode < 300,
-                    status: res.statusCode,
-                    statusText: res.statusMessage,
-                    json: async () => JSON.parse(data),
-                    text: async () => data,
-                  });
-                });
-              });
-
-              req.on("error", (error: Error) => {
-                console.error("Auth Debug - HTTP request error:", error);
-                reject(error);
-              });
-              req.write(postData);
-              req.end();
-            });
-          } else {
-            console.log("Auth Debug - Using HTTPS path");
-            // Use fetch for HTTPS URLs (original code)
-            response = await fetch(authUrl, {
-              method: "POST",
-              headers: {
-                Accept: "application/json, text/plain, */*",
-                "Content-Type": "application/json",
-                "Fineract-Platform-TenantId": fineractTenantId,
-              },
-              body: JSON.stringify({
-                username: credentials.username,
-                password: credentials.password,
-              }),
-              // Skip SSL verification for local development
-              agent: new https.Agent({
-                rejectUnauthorized: false,
-              }),
-            });
+          const validationError = getPermissionValidationError(
+            authUser.rawPermissions
+          );
+          if (validationError) {
+            console.error("Auth validation blocked session creation:", validationError);
+            return null;
           }
 
-          console.log(
-            "Auth Debug - Response status:",
-            response.status,
-            response.statusText
+          const userLogin = await getUserLoginByFineractUserId(
+            tenant.id,
+            authUser.userId
           );
 
-          if (!response.ok) {
-            console.error(
-              "Authentication failed:",
-              response.status,
-              response.statusText
+          if (isUserLoginBlocked(userLogin)) {
+            console.warn(
+              `Blocking direct sign-in because user ${authUser.username} is blocked for tenant ${tenant.slug || tenant.id}`
             );
-            const errorText = await response.text();
-            console.error("Error response body:", errorText);
             return null;
           }
 
-          const data = await response.json();
-          console.log("=== AUTH LOGIN ===", data.username, "roles:", JSON.stringify(data.roles));
-          console.log("Auth Debug - Response data keys:", Object.keys(data));
-          console.log(
-            "Auth Debug - base64EncodedAuthenticationKey from Fineract:",
-            data.base64EncodedAuthenticationKey
-          );
-
-          // Compute Basic auth token ourselves: base64(username:password)
-          const computedBasicAuth = Buffer.from(
-            `${credentials.username}:${credentials.password}`
-          ).toString("base64");
-          console.log(
-            "Auth Debug - Computed Basic auth token:",
-            computedBasicAuth
-          );
-
-          // Use our computed token instead of Fineract's response
-          const accessToken = computedBasicAuth;
-
-          if (!data.base64EncodedAuthenticationKey) {
-            // Auth failed if Fineract didn't return the key
+          const tenantMfaConfig = getTenantMfaConfig(tenant.settings);
+          if (tenantMfaConfig.usesMfa) {
+            console.warn(
+              `Blocking direct sign-in because MFA is enabled for tenant ${tenant.slug || authUser.tenantId}`
+            );
             return null;
           }
 
-          // Map API permissions to our specific permissions
-          const mappedPermissions = mapApiPermissionsToSpecific(
-            data.permissions
-          );
-
-          // If auth response has empty roles, fetch from user details endpoint as fallback
-          let userRoles = data.roles || [];
-          if (userRoles.length === 0 && data.userId) {
-            try {
-              console.log("Auth Debug - Roles empty from auth endpoint, fetching from /users/" + data.userId);
-              const userDetailUrl = `${baseUrl}/fineract-provider/api/v1/users/${data.userId}`;
-              let userDetailResponse;
-
-              if (baseUrl.startsWith("http://")) {
-                const http = require("http");
-                const url = require("url");
-                const parsedUrl = url.parse(userDetailUrl);
-                userDetailResponse = await new Promise<any>((resolve, reject) => {
-                  const req = http.request({
-                    hostname: parsedUrl.hostname,
-                    port: parsedUrl.port || 80,
-                    path: parsedUrl.path,
-                    method: "GET",
-                    headers: {
-                      Accept: "application/json",
-                      Authorization: `Basic ${computedBasicAuth}`,
-                      "Fineract-Platform-TenantId": fineractTenantId,
-                    },
-                  }, (res: any) => {
-                    let body = "";
-                    res.on("data", (chunk: any) => { body += chunk; });
-                    res.on("end", () => {
-                      resolve({
-                        ok: res.statusCode >= 200 && res.statusCode < 300,
-                        json: async () => JSON.parse(body),
-                      });
-                    });
-                  });
-                  req.on("error", reject);
-                  req.end();
-                });
-              } else {
-                userDetailResponse = await fetch(userDetailUrl, {
-                  method: "GET",
-                  headers: {
-                    Accept: "application/json",
-                    Authorization: `Basic ${computedBasicAuth}`,
-                    "Fineract-Platform-TenantId": fineractTenantId,
-                  },
-                  agent: new https.Agent({ rejectUnauthorized: false }),
-                });
-              }
-
-              if (userDetailResponse.ok) {
-                const userData = await userDetailResponse.json();
-                if (userData.selectedRoles && userData.selectedRoles.length > 0) {
-                  userRoles = userData.selectedRoles;
-                  console.log("Auth Debug - Fetched roles from user details:", userRoles.map((r: any) => r.name));
-                }
-              }
-            } catch (roleError) {
-              console.error("Auth Debug - Failed to fetch user roles fallback:", roleError);
-            }
-          }
-
-          // Return the user object with all the authentication data
           return {
-            id: data.userId.toString(),
-            userId: data.userId,
-            name: data.username,
-            email: data.username,
-            accessToken,
-            base64EncodedAuthenticationKey: computedBasicAuth,
-            officeId: data.officeId,
-            officeName: data.officeName,
-            roles: userRoles,
-            permissions: mappedPermissions,
-            rawPermissions: data.permissions,
-            shouldRenewPassword: data.shouldRenewPassword,
-            isTwoFactorAuthenticationRequired:
-              data.isTwoFactorAuthenticationRequired,
+            ...authUser,
+            tenantId: tenant.id,
           };
         } catch (error) {
           console.error("Authentication error:", error);
@@ -264,8 +100,11 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async redirect({ url, baseUrl }) {
-      // Allow relative URLs (they resolve against the browser's current origin)
-      if (url.startsWith("/")) return url;
+      // NextAuth client helpers may parse the returned URL with `new URL(...)`,
+      // so normalize relative callback paths to absolute URLs here.
+      if (url.startsWith("/")) {
+        return new URL(url, baseUrl).toString();
+      }
 
       try {
         const urlObj = new URL(url);
@@ -294,18 +133,37 @@ export const authOptions: NextAuthOptions = {
           token.name = user.name;
           token.email = user.email;
           token.accessToken = user.accessToken;
+          token.tenantId = user.tenantId;
           token.userId = user.userId;
           token.base64EncodedAuthenticationKey =
             user.base64EncodedAuthenticationKey;
           token.officeId = user.officeId;
           token.officeName = user.officeName;
-          // Only store role IDs and names to reduce token size
-          token.roles = user.roles?.map((r: any) => ({ id: r.id, name: r.name, disabled: r.disabled })) || [];
+          // Keep the role payload compact while preserving the shared Role type.
+          token.roles =
+            user.roles?.map((role) => ({
+              id: role.id,
+              name: role.name,
+              description: role.description ?? "",
+              disabled: Boolean(role.disabled),
+            })) || [];
           token.permissions = user.permissions;
           // Don't store rawPermissions - it can contain hundreds of items and causes 431 errors
           token.shouldRenewPassword = user.shouldRenewPassword;
           token.isTwoFactorAuthenticationRequired =
             user.isTwoFactorAuthenticationRequired;
+
+          if (user.tenantId && user.userId && user.name) {
+            await updateUserLoginLastLogin({
+              tenantId: user.tenantId,
+              fineractUserId: user.userId,
+              username: user.name,
+              email:
+                typeof user.email === "string" && user.email.includes("@")
+                  ? user.email
+                  : undefined,
+            });
+          }
         }
         return token;
       } catch (error) {
@@ -325,10 +183,11 @@ export const authOptions: NextAuthOptions = {
           session.user.id = token.sub ?? "";
           session.user.name = token.name as string;
           session.user.email = token.email as string;
+          session.user.tenantId = token.tenantId as string;
           session.user.userId = token.userId as number;
           session.user.officeId = token.officeId as number;
           session.user.officeName = token.officeName as string;
-          session.user.roles = token.roles as any[];
+          session.user.roles = token.roles as Role[];
           session.user.permissions = token.permissions as SpecificPermission[];
           // rawPermissions not stored in JWT to avoid 431 errors - use permissions instead
           session.user.rawPermissions = [];
@@ -381,7 +240,7 @@ export async function isAuthenticated() {
  * Get the current logged-in user details
  * @returns Promise with the user details
  */
-export async function getCurrentUserDetails(userId: String) {
+export async function getCurrentUserDetails(userId: string) {
   try {
     const { getFineractTenantId } = await import("./fineract-tenant-service");
     const fineractTenantId = await getFineractTenantId();
@@ -412,7 +271,6 @@ export async function getCurrentUserDetails(userId: String) {
       response = await fetch(url, {
         method: "GET",
         headers,
-        // @ts-ignore
         agent: httpsAgent,
       });
     }

--- a/lib/fineract-auth.ts
+++ b/lib/fineract-auth.ts
@@ -1,0 +1,313 @@
+import https from "https";
+import fetch from "node-fetch";
+import { Role, SpecificPermission } from "@/shared/types/auth";
+import { mapApiPermissionsToSpecific } from "@/lib/authorization";
+import { getFineractTenantId } from "@/lib/fineract-tenant-service";
+
+type JsonValue = Record<string, any>;
+
+export class FineractAuthenticationError extends Error {
+  status: number;
+
+  constructor(message: string, status = 401) {
+    super(message);
+    this.name = "FineractAuthenticationError";
+    this.status = status;
+  }
+}
+
+export type FineractAuthenticatedUser = {
+  id: string;
+  tenantId: string;
+  userId: number;
+  username: string;
+  name: string;
+  email: string;
+  fineractEmail: string | null;
+  accessToken: string;
+  base64EncodedAuthenticationKey: string;
+  officeId?: number;
+  officeName?: string;
+  roles: Role[];
+  permissions: SpecificPermission[];
+  rawPermissions: string[];
+  shouldRenewPassword?: boolean;
+  isTwoFactorAuthenticationRequired?: boolean;
+};
+
+function getFineractBaseUrl() {
+  return process.env.FINERACT_BASE_URL || "https://demo.mifos.io";
+}
+
+function createResponseShim(statusCode: number, statusText: string, body: string) {
+  return {
+    ok: statusCode >= 200 && statusCode < 300,
+    status: statusCode,
+    statusText,
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  };
+}
+
+async function requestFineract(
+  url: string,
+  options: {
+    method: "GET" | "POST";
+    headers: Record<string, string>;
+    body?: string;
+  }
+) {
+  if (url.startsWith("http://")) {
+    const http = require("http");
+    const parsedUrl = new URL(url);
+
+    return new Promise<ReturnType<typeof createResponseShim>>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: parsedUrl.hostname,
+          port: parsedUrl.port || 80,
+          path: `${parsedUrl.pathname}${parsedUrl.search}`,
+          method: options.method,
+          headers: options.body
+            ? {
+                ...options.headers,
+                "Content-Length": Buffer.byteLength(options.body),
+              }
+            : options.headers,
+        },
+        (res: any) => {
+          let data = "";
+          res.on("data", (chunk: any) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            resolve(
+              createResponseShim(
+                res.statusCode || 500,
+                res.statusMessage || "Request failed",
+                data
+              )
+            );
+          });
+        }
+      );
+
+      req.on("error", reject);
+
+      if (options.body) {
+        req.write(options.body);
+      }
+
+      req.end();
+    });
+  }
+
+  return fetch(url, {
+    method: options.method,
+    headers: options.headers,
+    body: options.body,
+    agent: new https.Agent({
+      rejectUnauthorized: false,
+    }),
+  });
+}
+
+async function readJsonSafe(response: {
+  json: () => Promise<any>;
+  text: () => Promise<string>;
+}) {
+  try {
+    return await response.json();
+  } catch {
+    try {
+      const text = await response.text();
+      return text ? JSON.parse(text) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export async function extractFineractErrorMessage(response: {
+  status: number;
+  statusText: string;
+  json: () => Promise<any>;
+  text: () => Promise<string>;
+}) {
+  const errorData = await readJsonSafe(response);
+
+  if (errorData?.defaultUserMessage) {
+    return errorData.defaultUserMessage as string;
+  }
+
+  if (errorData?.developerMessage) {
+    return errorData.developerMessage as string;
+  }
+
+  if (
+    Array.isArray(errorData?.errors) &&
+    errorData.errors.length > 0 &&
+    typeof errorData.errors[0]?.defaultUserMessage === "string"
+  ) {
+    return errorData.errors[0].defaultUserMessage as string;
+  }
+
+  return `Authentication failed (${response.status} ${response.statusText})`;
+}
+
+async function fetchFineractUserDetails(input: {
+  baseUrl: string;
+  fineractTenantId: string;
+  basicAuth: string;
+  userId: number;
+}) {
+  const { baseUrl, fineractTenantId, basicAuth, userId } = input;
+  const userDetailUrl = `${baseUrl}/fineract-provider/api/v1/users/${userId}`;
+
+  const response = await requestFineract(userDetailUrl, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Basic ${basicAuth}`,
+      "Fineract-Platform-TenantId": fineractTenantId,
+    },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return readJsonSafe(response);
+}
+
+export function getPermissionValidationError(userPermissions: string[]) {
+  if (!Array.isArray(userPermissions) || userPermissions.length === 0) {
+    return "Your account does not have any permissions assigned. Please contact your administrator.";
+  }
+
+  const hasAllFunctions =
+    userPermissions.includes("ALL_FUNCTIONS") ||
+    userPermissions.includes("ALL_FUNCTIONS_READ");
+
+  if (hasAllFunctions) {
+    return null;
+  }
+
+  const requiredPermissions = ["READ_USER", "READ_CURRENCY", "READ_REPORT"];
+  const missing = requiredPermissions.filter(
+    (permission) => !userPermissions.includes(permission)
+  );
+
+  if (missing.length === 0) {
+    return null;
+  }
+
+  return `Insufficient privileges. Your account is missing required permissions: ${missing.join(", ")}. Please contact your administrator.`;
+}
+
+export async function authenticateWithFineractCredentials(input: {
+  username: string;
+  password: string;
+}): Promise<FineractAuthenticatedUser> {
+  const username = input.username.trim();
+  const password = input.password;
+
+  if (!username || !password) {
+    throw new FineractAuthenticationError(
+      "Username and password are required",
+      400
+    );
+  }
+
+  const fineractTenantId = await getFineractTenantId();
+  const baseUrl = getFineractBaseUrl();
+  const authUrl = `${baseUrl}/fineract-provider/api/v1/authentication`;
+
+  const response = await requestFineract(authUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/json",
+      "Fineract-Platform-TenantId": fineractTenantId,
+    },
+    body: JSON.stringify({
+      username,
+      password,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new FineractAuthenticationError(
+      await extractFineractErrorMessage(response),
+      response.status
+    );
+  }
+
+  const data = (await readJsonSafe(response)) as JsonValue | null;
+
+  if (!data?.base64EncodedAuthenticationKey || !data?.userId) {
+    throw new FineractAuthenticationError(
+      "Authentication failed. Please check your credentials.",
+      401
+    );
+  }
+
+  const computedBasicAuth = Buffer.from(`${username}:${password}`).toString(
+    "base64"
+  );
+  const userDetails = await fetchFineractUserDetails({
+    baseUrl,
+    fineractTenantId,
+    basicAuth: computedBasicAuth,
+    userId: Number(data.userId),
+  });
+
+  const selectedRoles = Array.isArray(userDetails?.selectedRoles)
+    ? userDetails.selectedRoles
+    : Array.isArray(data.roles)
+      ? data.roles
+      : [];
+
+  const fineractEmail =
+    typeof userDetails?.email === "string" && userDetails.email.trim()
+      ? userDetails.email.trim()
+      : typeof data.email === "string" && data.email.trim()
+        ? data.email.trim()
+        : null;
+  const resolvedOfficeId =
+    typeof data.officeId === "number"
+      ? data.officeId
+      : Number.isFinite(Number(data.officeId))
+        ? Number(data.officeId)
+        : undefined;
+
+  return {
+    id: String(data.userId),
+    tenantId: fineractTenantId,
+    userId: Number(data.userId),
+    username: typeof data.username === "string" ? data.username : username,
+    name: typeof data.username === "string" ? data.username : username,
+    email: fineractEmail || username,
+    fineractEmail,
+    accessToken: computedBasicAuth,
+    base64EncodedAuthenticationKey: computedBasicAuth,
+    officeId: resolvedOfficeId,
+    officeName:
+      typeof data.officeName === "string" ? data.officeName : undefined,
+    roles: selectedRoles.map((role: JsonValue) => ({
+      id: Number(role.id),
+      name: typeof role.name === "string" ? role.name : "Unknown Role",
+      description:
+        typeof role.description === "string" ? role.description : "",
+      disabled: Boolean(role.disabled),
+    })),
+    permissions: mapApiPermissionsToSpecific(
+      Array.isArray(data.permissions) ? data.permissions : []
+    ),
+    rawPermissions: Array.isArray(data.permissions) ? data.permissions : [],
+    shouldRenewPassword: Boolean(data.shouldRenewPassword),
+    isTwoFactorAuthenticationRequired: Boolean(
+      data.isTwoFactorAuthenticationRequired
+    ),
+  };
+}

--- a/lib/mfa.ts
+++ b/lib/mfa.ts
@@ -1,0 +1,699 @@
+import { createHash, randomBytes, randomInt } from "crypto";
+import { Prisma } from "@/app/generated/prisma";
+import { prisma } from "@/lib/prisma";
+import { normalizeSmsPhoneNumber } from "@/lib/phone-utils";
+import { sendEmail, sendSms } from "@/lib/notification-service";
+import {
+  DEFAULT_MFA_MAX_ATTEMPTS,
+  MFA_CODE_LENGTH,
+  MFA_CODE_PATTERN,
+} from "@/shared/constants/mfa";
+import type { Role, SpecificPermission } from "@/shared/types/auth";
+import type { MfaChannel } from "@/shared/types/tenant";
+import type { FineractAuthenticatedUser } from "@/lib/fineract-auth";
+import {
+  blockUserLogin,
+  getUserLoginByFineractUserId,
+  isUserLoginBlocked,
+  USER_LOGIN_BLOCKED_MESSAGE,
+} from "@/lib/user-login-service";
+
+const MFA_EXPIRY_MINUTES = 10;
+const MFA_RESEND_COOLDOWN_SECONDS = 60;
+const MFA_MAX_RESENDS = 5;
+const MFA_ALLOWED_CHANNELS: MfaChannel[] = ["email", "sms"];
+
+type MfaDestinations = Record<MfaChannel, string | null>;
+
+type SerializedMfaAuthContext = {
+  id: string;
+  tenantId: string;
+  userId: number;
+  username: string;
+  name: string;
+  email: string;
+  accessToken: string;
+  base64EncodedAuthenticationKey: string;
+  officeId?: number;
+  officeName?: string;
+  roles: Role[];
+  permissions: SpecificPermission[];
+  rawPermissions: string[];
+  shouldRenewPassword?: boolean;
+  isTwoFactorAuthenticationRequired?: boolean;
+};
+
+type MfaAttemptState = {
+  attemptsUsed: number;
+  maxAttempts: number;
+  remainingAttempts: number;
+};
+
+type MfaChallengeErrorDetails = Partial<MfaAttemptState> & {
+  accountBlocked?: boolean;
+};
+
+export class MfaChallengeError extends Error {
+  status: number;
+  details?: MfaChallengeErrorDetails;
+
+  constructor(message: string, status = 400, details?: MfaChallengeErrorDetails) {
+    super(message);
+    this.name = "MfaChallengeError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function getMfaAttemptState(challenge: {
+  attempts: number;
+  maxAttempts: number;
+}): MfaAttemptState {
+  return {
+    attemptsUsed: challenge.attempts,
+    maxAttempts: challenge.maxAttempts,
+    remainingAttempts: Math.max(challenge.maxAttempts - challenge.attempts, 0),
+  };
+}
+
+export function getTenantMfaConfig(settings: unknown): {
+  usesMfa: boolean;
+  channels: MfaChannel[];
+  maxAttempts: number;
+} {
+  const config =
+    settings && typeof settings === "object"
+      ? (settings as Record<string, unknown>)
+      : {};
+  const featureConfig =
+    config.features && typeof config.features === "object"
+      ? (config.features as Record<string, unknown>)
+      : {};
+
+  const usesMfa = (featureConfig.usesMFA ?? config.usesMFA) === true;
+
+  const rawChannels = Array.isArray(featureConfig.mfaChannels)
+    ? featureConfig.mfaChannels
+    : Array.isArray(config.mfaChannels)
+      ? config.mfaChannels
+      : [];
+
+  const channels = rawChannels.filter((channel): channel is MfaChannel =>
+    MFA_ALLOWED_CHANNELS.includes(channel as MfaChannel)
+  );
+  const rawMaxAttempts = featureConfig.mfaMaxAttempts ?? config.mfaMaxAttempts;
+  const parsedMaxAttempts =
+    typeof rawMaxAttempts === "number"
+      ? rawMaxAttempts
+      : typeof rawMaxAttempts === "string"
+        ? Number(rawMaxAttempts)
+        : NaN;
+  const maxAttempts =
+    Number.isFinite(parsedMaxAttempts) && parsedMaxAttempts >= 1
+      ? Math.floor(parsedMaxAttempts)
+      : DEFAULT_MFA_MAX_ATTEMPTS;
+
+  return {
+    usesMfa,
+    channels,
+    maxAttempts,
+  };
+}
+
+export function resolveMfaDestinations(input: {
+  email?: string | null;
+  phone?: string | null;
+  countryCode?: string | null;
+}): MfaDestinations {
+  const email =
+    typeof input.email === "string" && input.email.trim()
+      ? input.email.trim()
+      : null;
+  const phone = normalizeSmsPhoneNumber(input.phone || "", input.countryCode);
+
+  return {
+    email,
+    sms: phone,
+  };
+}
+
+export function getAvailableMfaChannels(
+  configuredChannels: MfaChannel[],
+  destinations: MfaDestinations
+) {
+  return configuredChannels.filter((channel) => Boolean(destinations[channel]));
+}
+
+export function maskEmailAddress(email: string) {
+  const trimmed = email.trim();
+  const [localPart, domain] = trimmed.split("@");
+
+  if (!localPart || !domain) {
+    return "***";
+  }
+
+  const visibleLocal = localPart.slice(0, 1);
+  return `${visibleLocal}${"*".repeat(Math.max(localPart.length - 1, 2))}@${domain}`;
+}
+
+export function maskPhoneNumber(phone: string) {
+  const trimmed = phone.trim();
+  if (trimmed.length <= 4) {
+    return "*".repeat(trimmed.length || 3);
+  }
+
+  return `${trimmed.slice(0, 3)}${"*".repeat(
+    Math.max(trimmed.length - 5, 3)
+  )}${trimmed.slice(-2)}`;
+}
+
+export function maskMfaDestination(channel: MfaChannel, destination: string) {
+  return channel === "email"
+    ? maskEmailAddress(destination)
+    : maskPhoneNumber(destination);
+}
+
+export function buildMissingMfaContactMessage(input: {
+  configuredChannels: MfaChannel[];
+  destinations: MfaDestinations;
+  requestedChannel?: MfaChannel | null;
+}) {
+  const { configuredChannels, destinations, requestedChannel } = input;
+
+  if (requestedChannel === "sms" && !destinations.sms) {
+    return "Your phone number is not configured. Contact your system administrator for help.";
+  }
+
+  if (requestedChannel === "email" && !destinations.email) {
+    return "Your email address is not configured. Contact your system administrator for help.";
+  }
+
+  const needsEmail = configuredChannels.includes("email");
+  const needsSms = configuredChannels.includes("sms");
+  const hasEmail = Boolean(destinations.email);
+  const hasSms = Boolean(destinations.sms);
+
+  if (needsEmail && needsSms && !hasEmail && !hasSms) {
+    return "Your email address and phone number are not configured. Contact your system administrator for help.";
+  }
+
+  if (needsSms && !hasSms) {
+    return "Your phone number is not configured. Contact your system administrator for help.";
+  }
+
+  if (needsEmail && !hasEmail) {
+    return "Your email address is not configured. Contact your system administrator for help.";
+  }
+
+  return "Your multi-factor authentication details are not configured. Contact your system administrator for help.";
+}
+
+function getMfaHashSecret() {
+  return process.env.NEXTAUTH_SECRET || "loan-matrix-mfa-secret";
+}
+
+export function hashMfaCode(challengeId: string, code: string) {
+  return createHash("sha256")
+    .update(`${challengeId}:${code}:${getMfaHashSecret()}`)
+    .digest("hex");
+}
+
+export function hashMfaVerificationToken(
+  challengeId: string,
+  verificationToken: string
+) {
+  return createHash("sha256")
+    .update(`${challengeId}:${verificationToken}:${getMfaHashSecret()}`)
+    .digest("hex");
+}
+
+export function generateMfaCode() {
+  return randomInt(0, 10 ** MFA_CODE_LENGTH)
+    .toString()
+    .padStart(MFA_CODE_LENGTH, "0");
+}
+
+export function generateMfaVerificationToken() {
+  return randomBytes(24).toString("hex");
+}
+
+export function getMfaExpiryDate() {
+  return new Date(Date.now() + MFA_EXPIRY_MINUTES * 60 * 1000);
+}
+
+export function getMfaResendAvailableAt(lastSentAt: Date) {
+  return new Date(lastSentAt.getTime() + MFA_RESEND_COOLDOWN_SECONDS * 1000);
+}
+
+export function getMfaResendCooldownSeconds() {
+  return MFA_RESEND_COOLDOWN_SECONDS;
+}
+
+export function serializeMfaAuthContext(
+  user: FineractAuthenticatedUser
+): SerializedMfaAuthContext {
+  return {
+    id: user.id,
+    tenantId: user.tenantId,
+    userId: user.userId,
+    username: user.username,
+    name: user.name,
+    email: user.email,
+    accessToken: user.accessToken,
+    base64EncodedAuthenticationKey: user.base64EncodedAuthenticationKey,
+    officeId: user.officeId,
+    officeName: user.officeName,
+    roles: user.roles,
+    permissions: user.permissions,
+    rawPermissions: user.rawPermissions,
+    shouldRenewPassword: user.shouldRenewPassword,
+    isTwoFactorAuthenticationRequired: user.isTwoFactorAuthenticationRequired,
+  };
+}
+
+export function parseMfaAuthContext(
+  authContext: unknown
+): SerializedMfaAuthContext | null {
+  if (!authContext || typeof authContext !== "object") {
+    return null;
+  }
+
+  const data = authContext as Record<string, unknown>;
+
+  if (
+    typeof data.tenantId !== "string" ||
+    typeof data.id !== "string" ||
+    typeof data.userId !== "number" ||
+    typeof data.username !== "string" ||
+    typeof data.name !== "string" ||
+    typeof data.email !== "string" ||
+    typeof data.accessToken !== "string" ||
+    typeof data.base64EncodedAuthenticationKey !== "string" ||
+    !Array.isArray(data.roles) ||
+    !Array.isArray(data.permissions) ||
+    !Array.isArray(data.rawPermissions)
+  ) {
+    return null;
+  }
+
+  return {
+    id: data.id,
+    tenantId: data.tenantId,
+    userId: data.userId,
+    username: data.username,
+    name: data.name,
+    email: data.email,
+    accessToken: data.accessToken,
+    base64EncodedAuthenticationKey: data.base64EncodedAuthenticationKey,
+    officeId: typeof data.officeId === "number" ? data.officeId : undefined,
+    officeName:
+      typeof data.officeName === "string" ? data.officeName : undefined,
+    roles: data.roles,
+    permissions: data.permissions,
+    rawPermissions: data.rawPermissions,
+    shouldRenewPassword:
+      typeof data.shouldRenewPassword === "boolean"
+        ? data.shouldRenewPassword
+        : undefined,
+    isTwoFactorAuthenticationRequired:
+      typeof data.isTwoFactorAuthenticationRequired === "boolean"
+        ? data.isTwoFactorAuthenticationRequired
+        : undefined,
+  };
+}
+
+export async function sendMfaChallengeMessage(input: {
+  tenantId: string;
+  username: string;
+  channel: MfaChannel;
+  destination: string;
+  code: string;
+}) {
+  const { tenantId, username, channel, destination, code } = input;
+  const message = `Your Loan Matrix ${MFA_CODE_LENGTH}-digit verification code is ${code}. It expires in ${MFA_EXPIRY_MINUTES} minutes.`;
+
+  if (channel === "sms") {
+    return sendSms([destination], message, {
+      tenantId,
+      logLabel: "mfa-login-sms",
+    });
+  }
+
+  const subject = "Your Loan Matrix verification code";
+  const html = `<p>Hello ${username},</p><p>Your Loan Matrix ${MFA_CODE_LENGTH}-digit verification code is <strong>${code}</strong>.</p><p>This code expires in ${MFA_EXPIRY_MINUTES} minutes.</p>`;
+
+  return sendEmail([destination], subject, html, {
+    tenantId,
+    text: `Hello ${username},\n\n${message}`,
+    logLabel: "mfa-login-email",
+  });
+}
+
+export async function invalidateActiveMfaChallenges(
+  tenantId: string,
+  fineractUserId: number
+) {
+  await prisma.mfaChallenge.updateMany({
+    where: {
+      tenantId,
+      fineractUserId,
+      consumedAt: null,
+      invalidatedAt: null,
+    },
+    data: {
+      invalidatedAt: new Date(),
+    },
+  });
+}
+
+export async function createMfaChallengeRecord(input: {
+  tenantId: string;
+  fineractUserId: number;
+  username: string;
+  channel: MfaChannel;
+  destination: string;
+  authContext: SerializedMfaAuthContext;
+  maxAttempts: number;
+}) {
+  const code = generateMfaCode();
+  const expiresAt = getMfaExpiryDate();
+  const challenge = await prisma.mfaChallenge.create({
+    data: {
+      tenantId: input.tenantId,
+      fineractUserId: input.fineractUserId,
+      username: input.username,
+      channel: input.channel,
+      destination: input.destination,
+      maskedDestination: maskMfaDestination(input.channel, input.destination),
+      codeHash: "",
+      authContext: input.authContext as unknown as Prisma.InputJsonValue,
+      expiresAt,
+      maxAttempts: input.maxAttempts,
+    },
+  });
+
+  const codeHash = hashMfaCode(challenge.id, code);
+  const updatedChallenge = await prisma.mfaChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      codeHash,
+    },
+  });
+
+  return {
+    challenge: updatedChallenge,
+    code,
+  };
+}
+
+async function getTenantChallengeOrThrow(tenantId: string, challengeId: string) {
+  const challenge = await prisma.mfaChallenge.findFirst({
+    where: {
+      id: challengeId,
+      tenantId,
+    },
+  });
+
+  if (!challenge) {
+    throw new MfaChallengeError("Verification challenge not found.", 404);
+  }
+
+  return challenge;
+}
+
+export async function getMfaChallengeSummary(tenantId: string, challengeId: string) {
+  const challenge = await getTenantChallengeOrThrow(tenantId, challengeId);
+
+  if (challenge.invalidatedAt || challenge.consumedAt) {
+    throw new MfaChallengeError("Verification challenge is no longer active.", 410);
+  }
+
+  if (challenge.expiresAt.getTime() <= Date.now()) {
+    throw new MfaChallengeError("Verification challenge has expired. Please log in again.", 410);
+  }
+
+  return {
+    id: challenge.id,
+    username: challenge.username,
+    channel: challenge.channel as MfaChannel,
+    maskedDestination: challenge.maskedDestination,
+    expiresAt: challenge.expiresAt,
+    resendAvailableAt: getMfaResendAvailableAt(challenge.lastSentAt),
+    ...getMfaAttemptState(challenge),
+  };
+}
+
+export async function resendMfaChallenge(tenantId: string, challengeId: string) {
+  const challenge = await getTenantChallengeOrThrow(tenantId, challengeId);
+  const userLogin = await getUserLoginByFineractUserId(
+    tenantId,
+    challenge.fineractUserId
+  );
+
+  if (isUserLoginBlocked(userLogin)) {
+    await prisma.mfaChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        invalidatedAt: new Date(),
+      },
+    });
+
+    throw new MfaChallengeError(USER_LOGIN_BLOCKED_MESSAGE, 423);
+  }
+
+  if (challenge.invalidatedAt || challenge.consumedAt) {
+    throw new MfaChallengeError("Verification challenge is no longer active.", 410);
+  }
+
+  if (challenge.expiresAt.getTime() <= Date.now()) {
+    throw new MfaChallengeError("Verification challenge has expired. Please log in again.", 410);
+  }
+
+  if (challenge.resendCount >= MFA_MAX_RESENDS) {
+    throw new MfaChallengeError(
+      "Too many resend attempts. Please log in again.",
+      429
+    );
+  }
+
+  const resendAvailableAt = getMfaResendAvailableAt(challenge.lastSentAt);
+
+  if (resendAvailableAt.getTime() > Date.now()) {
+    throw new MfaChallengeError(
+      `Please wait ${Math.ceil(
+        (resendAvailableAt.getTime() - Date.now()) / 1000
+      )} seconds before requesting another code.`,
+      429
+    );
+  }
+
+  const code = generateMfaCode();
+  const expiresAt = getMfaExpiryDate();
+
+  const updatedChallenge = await prisma.mfaChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      codeHash: hashMfaCode(challenge.id, code),
+      verificationTokenHash: null,
+      verifiedAt: null,
+      attempts: 0,
+      resendCount: {
+        increment: 1,
+      },
+      lastSentAt: new Date(),
+      expiresAt,
+    },
+  });
+
+  const delivered = await sendMfaChallengeMessage({
+    tenantId,
+    username: updatedChallenge.username,
+    channel: updatedChallenge.channel as MfaChannel,
+    destination: updatedChallenge.destination,
+    code,
+  });
+
+  if (!delivered) {
+    await prisma.mfaChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        invalidatedAt: new Date(),
+      },
+    });
+
+    throw new MfaChallengeError(
+      "We could not resend the verification code. Please log in again or contact your system administrator for help.",
+      500
+    );
+  }
+
+  return {
+    id: updatedChallenge.id,
+    channel: updatedChallenge.channel as MfaChannel,
+    maskedDestination: updatedChallenge.maskedDestination,
+    expiresAt: updatedChallenge.expiresAt,
+    resendAvailableAt: getMfaResendAvailableAt(updatedChallenge.lastSentAt),
+    ...getMfaAttemptState(updatedChallenge),
+  };
+}
+
+export async function verifyMfaChallengeCode(input: {
+  tenantId: string;
+  challengeId: string;
+  code: string;
+}) {
+  const { tenantId, challengeId, code } = input;
+  const normalizedCode = code.trim();
+  const challenge = await getTenantChallengeOrThrow(tenantId, challengeId);
+  const userLogin = await getUserLoginByFineractUserId(
+    tenantId,
+    challenge.fineractUserId
+  );
+
+  if (isUserLoginBlocked(userLogin)) {
+    await prisma.mfaChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        invalidatedAt: new Date(),
+      },
+    });
+
+    throw new MfaChallengeError(USER_LOGIN_BLOCKED_MESSAGE, 423);
+  }
+
+  if (challenge.invalidatedAt || challenge.consumedAt) {
+    throw new MfaChallengeError("Verification challenge is no longer active.", 410);
+  }
+
+  if (challenge.expiresAt.getTime() <= Date.now()) {
+    throw new MfaChallengeError("Verification challenge has expired. Please log in again.", 410);
+  }
+
+  if (challenge.attempts >= challenge.maxAttempts) {
+    throw new MfaChallengeError(
+      "Too many incorrect verification attempts. Please log in again.",
+      429,
+      {
+        ...getMfaAttemptState(challenge),
+        accountBlocked: true,
+      }
+    );
+  }
+
+  if (!MFA_CODE_PATTERN.test(normalizedCode)) {
+    throw new MfaChallengeError(
+      `Enter the ${MFA_CODE_LENGTH}-digit verification code.`,
+      400
+    );
+  }
+
+  const incomingHash = hashMfaCode(challenge.id, normalizedCode);
+
+  if (incomingHash !== challenge.codeHash) {
+    const nextAttempts = challenge.attempts + 1;
+    const nextAttemptState = getMfaAttemptState({
+      attempts: nextAttempts,
+      maxAttempts: challenge.maxAttempts,
+    });
+    await prisma.mfaChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        attempts: nextAttempts,
+        ...(nextAttempts >= challenge.maxAttempts
+          ? { invalidatedAt: new Date() }
+          : {}),
+      },
+    });
+
+    if (nextAttempts >= challenge.maxAttempts) {
+      await blockUserLogin({
+        tenantId,
+        fineractUserId: challenge.fineractUserId,
+        username: challenge.username,
+        note: `Auto-blocked after ${challenge.maxAttempts} incorrect MFA verification attempt${challenge.maxAttempts === 1 ? "" : "s"}.`,
+        source: "SYSTEM_MFA_MAX_ATTEMPTS",
+      });
+
+      throw new MfaChallengeError(
+        "Too many incorrect verification attempts. Please log in again.",
+        429,
+        {
+          ...nextAttemptState,
+          accountBlocked: true,
+        }
+      );
+    }
+
+    throw new MfaChallengeError(
+      "The verification code you entered is incorrect.",
+      400,
+      nextAttemptState
+    );
+  }
+
+  const verificationToken = generateMfaVerificationToken();
+  await prisma.mfaChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      verificationTokenHash: hashMfaVerificationToken(
+        challenge.id,
+        verificationToken
+      ),
+      verifiedAt: new Date(),
+    },
+  });
+
+  return {
+    challengeId: challenge.id,
+    verificationToken,
+  };
+}
+
+export async function consumeVerifiedMfaChallenge(input: {
+  challengeId: string;
+  verificationToken: string;
+}) {
+  const challenge = await prisma.mfaChallenge.findUnique({
+    where: {
+      id: input.challengeId,
+    },
+  });
+
+  if (!challenge) {
+    return null;
+  }
+
+  if (
+    challenge.invalidatedAt ||
+    challenge.consumedAt ||
+    challenge.expiresAt.getTime() <= Date.now() ||
+    !challenge.verifiedAt ||
+    !challenge.verificationTokenHash
+  ) {
+    return null;
+  }
+
+  const expectedTokenHash = hashMfaVerificationToken(
+    challenge.id,
+    input.verificationToken
+  );
+
+  if (expectedTokenHash !== challenge.verificationTokenHash) {
+    return null;
+  }
+
+  const authContext = parseMfaAuthContext(challenge.authContext);
+  if (!authContext) {
+    return null;
+  }
+
+  await prisma.mfaChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      consumedAt: new Date(),
+      verificationTokenHash: null,
+    },
+  });
+
+  return authContext;
+}

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -3,9 +3,65 @@
  * Uses NOTIFICATION_SERVICE_URL and POST /api/v1/notifications/sms.
  */
 
+import { prisma } from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import {
+  normalizeCountryDialCode,
+  normalizeSmsPhoneNumber as normalizeSmsPhoneNumberFromUtils,
+} from "@/lib/phone-utils";
+
 const CONTACT_LINE = "For more info please contact us on +260957224792 /774 or visit our offices.";
 const DEFAULT_SMS_COUNTRY_CODE =
   process.env.SMS_DEFAULT_COUNTRY_CODE || "+260";
+const DEFAULT_EMAIL_NOTIFICATION_PATH =
+  process.env.EMAIL_NOTIFICATION_SERVICE_PATH || "/api/v1/notifications/email";
+
+async function resolveNotificationServiceTenantId(
+  tenantId?: string
+): Promise<string> {
+  let tenantRecord:
+    | { slug: string; notificationServiceTenantId: string | null }
+    | null = null;
+
+  if (tenantId) {
+    tenantRecord = await prisma.tenant.findFirst({
+      where: {
+        OR: [{ id: tenantId }, { slug: tenantId }],
+      },
+      select: {
+        slug: true,
+        notificationServiceTenantId: true,
+      },
+    });
+  } else {
+    try {
+      const tenant = await getTenantFromHeaders();
+      if (tenant?.id) {
+        tenantRecord = await prisma.tenant.findUnique({
+          where: { id: tenant.id },
+          select: {
+            slug: true,
+            notificationServiceTenantId: true,
+          },
+        });
+      }
+    } catch {
+      tenantRecord = null;
+    }
+  }
+
+  const configuredTenantId = tenantRecord?.notificationServiceTenantId?.trim();
+  if (configuredTenantId) {
+    return configuredTenantId;
+  }
+
+  const slugFallback = tenantRecord?.slug?.trim();
+  if (slugFallback) {
+    return slugFallback;
+  }
+
+  return "no-tenant";
+}
 
 function formatAmount(amount: number): string {
   return amount.toLocaleString("en-US", {
@@ -14,51 +70,14 @@ function formatAmount(amount: number): string {
   });
 }
 
-function normalizeCountryCode(countryCode?: string | null): string | null {
-  if (!countryCode) return null;
-  const digits = String(countryCode).replace(/\D/g, "");
-  return digits || null;
-}
-
 export function normalizeSmsPhoneNumber(
   phone: string,
   countryCode?: string | null
 ): string | null {
-  const raw = String(phone || "").trim();
-  if (!raw) return null;
-
-  const digits = raw.replace(/\D/g, "");
-  if (!digits) return null;
-
-  if (raw.startsWith("+")) {
-    return `+${digits}`;
-  }
-
-  if (raw.startsWith("00")) {
-    const internationalDigits = digits.slice(2);
-    return internationalDigits ? `+${internationalDigits}` : null;
-  }
-
-  const normalizedCountryCode =
-    normalizeCountryCode(countryCode) ||
-    normalizeCountryCode(DEFAULT_SMS_COUNTRY_CODE);
-
-  if (normalizedCountryCode) {
-    if (digits.startsWith(normalizedCountryCode)) {
-      return `+${digits}`;
-    }
-
-    const localDigits = digits.startsWith("0") ? digits.slice(1) : digits;
-    if (localDigits) {
-      return `+${normalizedCountryCode}${localDigits}`;
-    }
-  }
-
-  if (digits.length >= 11) {
-    return `+${digits}`;
-  }
-
-  return digits;
+  return normalizeSmsPhoneNumberFromUtils(
+    phone,
+    countryCode || normalizeCountryDialCode(DEFAULT_SMS_COUNTRY_CODE)
+  );
 }
 
 /**
@@ -68,10 +87,13 @@ export function normalizeSmsPhoneNumber(
 export async function sendSms(
   phoneNumbers: string[],
   message: string,
-  options?: { tenantId?: string; countryCode?: string | null }
+  options?: {
+    tenantId?: string;
+    countryCode?: string | null;
+    logLabel?: string;
+  }
 ): Promise<boolean> {
   const serviceBaseUrl = process.env.NOTIFICATION_SERVICE_URL;
-  const tenantId = options?.tenantId ?? process.env.TENANT_ID ?? "no-tenant";
 
   if (!serviceBaseUrl) {
     console.warn(
@@ -89,6 +111,7 @@ export async function sendSms(
   }
 
   try {
+    const tenantId = await resolveNotificationServiceTenantId(options?.tenantId);
     const payload = {
       tenantId,
       phoneNumbers: validPhones,
@@ -100,19 +123,36 @@ export async function sendSms(
       configId: 0,
     };
 
-    console.log("SENDING SMS TO NOTIFICATION SERVICE...");
     const url = `${serviceBaseUrl.replace(/\/$/, "")}/api/v1/notifications/sms`;
+    if (options?.logLabel) {
+      console.log(`[${options.logLabel}] Notification service SMS payload:`, {
+        url,
+        payload,
+      });
+    } else {
+      console.log("SENDING SMS TO NOTIFICATION SERVICE...");
+    }
+
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
+    const responseText = await res.text().catch(() => "");
+
+    if (options?.logLabel) {
+      console.log(`[${options.logLabel}] Notification service SMS response:`, {
+        status: res.status,
+        ok: res.ok,
+        body: responseText,
+      });
+    }
 
     if (!res.ok) {
       console.error(
         "Notification service SMS failed:",
         res.status,
-        await res.text().catch(() => "")
+        responseText
       );
       return false;
     }
@@ -121,6 +161,91 @@ export async function sendSms(
     return true;
   } catch (err) {
     console.error("Failed to send SMS notification:", err);
+    return false;
+  }
+}
+
+export async function sendEmail(
+  emailAddresses: string[],
+  subject: string,
+  html: string,
+  options?: {
+    tenantId?: string;
+    text?: string;
+    fromEmail?: string;
+    logLabel?: string;
+  }
+): Promise<boolean> {
+  const serviceBaseUrl =
+    process.env.EMAIL_NOTIFICATION_SERVICE_URL ||
+    process.env.NOTIFICATION_SERVICE_URL;
+  const validEmails = emailAddresses
+    .map((email) => String(email || "").trim())
+    .filter(Boolean);
+
+  if (!serviceBaseUrl) {
+    console.warn(
+      "No email notification service is configured; skipping email notification"
+    );
+    return false;
+  }
+
+  if (validEmails.length === 0) {
+    console.warn("No valid email addresses; skipping email notification");
+    return false;
+  }
+
+  try {
+    const tenantId = await resolveNotificationServiceTenantId(options?.tenantId);
+    const payload = {
+      tenantId,
+      emailAddresses: validEmails,
+      subject,
+      html,
+      text: options?.text,
+      fromEmail: options?.fromEmail || process.env.MFA_EMAIL_FROM,
+      messageId:
+        typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      configId: 0,
+    };
+
+    const url = `${serviceBaseUrl.replace(/\/$/, "")}${DEFAULT_EMAIL_NOTIFICATION_PATH}`;
+    if (options?.logLabel) {
+      console.log(`[${options.logLabel}] Notification service email payload:`, {
+        url,
+        payload,
+      });
+    }
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const responseText = await res.text().catch(() => "");
+
+    if (options?.logLabel) {
+      console.log(`[${options.logLabel}] Notification service email response:`, {
+        status: res.status,
+        ok: res.ok,
+        body: responseText,
+      });
+    }
+
+    if (!res.ok) {
+      console.error(
+        "Notification service email failed:",
+        res.status,
+        responseText
+      );
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("Failed to send email notification:", error);
     return false;
   }
 }

--- a/lib/phone-utils.ts
+++ b/lib/phone-utils.ts
@@ -1,0 +1,258 @@
+export const USER_LOGIN_PHONE_MAX_LENGTH = 15;
+export const DEFAULT_AFRICAN_COUNTRY_CODE = "+260";
+
+export type AfricanCountryCode = {
+  code: string;
+  country: string;
+  iso2: string;
+  label: string;
+};
+
+export const AFRICAN_COUNTRY_CODES: AfricanCountryCode[] = [
+  { code: "+213", country: "Algeria", iso2: "DZ", label: "Algeria (+213)" },
+  { code: "+244", country: "Angola", iso2: "AO", label: "Angola (+244)" },
+  { code: "+229", country: "Benin", iso2: "BJ", label: "Benin (+229)" },
+  { code: "+267", country: "Botswana", iso2: "BW", label: "Botswana (+267)" },
+  { code: "+226", country: "Burkina Faso", iso2: "BF", label: "Burkina Faso (+226)" },
+  { code: "+257", country: "Burundi", iso2: "BI", label: "Burundi (+257)" },
+  { code: "+238", country: "Cabo Verde", iso2: "CV", label: "Cabo Verde (+238)" },
+  { code: "+237", country: "Cameroon", iso2: "CM", label: "Cameroon (+237)" },
+  {
+    code: "+236",
+    country: "Central African Republic",
+    iso2: "CF",
+    label: "Central African Republic (+236)",
+  },
+  { code: "+235", country: "Chad", iso2: "TD", label: "Chad (+235)" },
+  { code: "+269", country: "Comoros", iso2: "KM", label: "Comoros (+269)" },
+  {
+    code: "+242",
+    country: "Congo (Brazzaville)",
+    iso2: "CG",
+    label: "Congo (Brazzaville) (+242)",
+  },
+  {
+    code: "+243",
+    country: "Congo (Kinshasa)",
+    iso2: "CD",
+    label: "Congo (Kinshasa) (+243)",
+  },
+  {
+    code: "+225",
+    country: "Cote d'Ivoire",
+    iso2: "CI",
+    label: "Cote d'Ivoire (+225)",
+  },
+  { code: "+253", country: "Djibouti", iso2: "DJ", label: "Djibouti (+253)" },
+  { code: "+20", country: "Egypt", iso2: "EG", label: "Egypt (+20)" },
+  {
+    code: "+240",
+    country: "Equatorial Guinea",
+    iso2: "GQ",
+    label: "Equatorial Guinea (+240)",
+  },
+  { code: "+291", country: "Eritrea", iso2: "ER", label: "Eritrea (+291)" },
+  { code: "+268", country: "Eswatini", iso2: "SZ", label: "Eswatini (+268)" },
+  { code: "+251", country: "Ethiopia", iso2: "ET", label: "Ethiopia (+251)" },
+  { code: "+241", country: "Gabon", iso2: "GA", label: "Gabon (+241)" },
+  { code: "+220", country: "Gambia", iso2: "GM", label: "Gambia (+220)" },
+  { code: "+233", country: "Ghana", iso2: "GH", label: "Ghana (+233)" },
+  { code: "+224", country: "Guinea", iso2: "GN", label: "Guinea (+224)" },
+  {
+    code: "+245",
+    country: "Guinea-Bissau",
+    iso2: "GW",
+    label: "Guinea-Bissau (+245)",
+  },
+  { code: "+254", country: "Kenya", iso2: "KE", label: "Kenya (+254)" },
+  { code: "+266", country: "Lesotho", iso2: "LS", label: "Lesotho (+266)" },
+  { code: "+231", country: "Liberia", iso2: "LR", label: "Liberia (+231)" },
+  { code: "+218", country: "Libya", iso2: "LY", label: "Libya (+218)" },
+  {
+    code: "+261",
+    country: "Madagascar",
+    iso2: "MG",
+    label: "Madagascar (+261)",
+  },
+  { code: "+265", country: "Malawi", iso2: "MW", label: "Malawi (+265)" },
+  { code: "+223", country: "Mali", iso2: "ML", label: "Mali (+223)" },
+  {
+    code: "+222",
+    country: "Mauritania",
+    iso2: "MR",
+    label: "Mauritania (+222)",
+  },
+  { code: "+230", country: "Mauritius", iso2: "MU", label: "Mauritius (+230)" },
+  { code: "+212", country: "Morocco", iso2: "MA", label: "Morocco (+212)" },
+  {
+    code: "+258",
+    country: "Mozambique",
+    iso2: "MZ",
+    label: "Mozambique (+258)",
+  },
+  { code: "+264", country: "Namibia", iso2: "NA", label: "Namibia (+264)" },
+  { code: "+227", country: "Niger", iso2: "NE", label: "Niger (+227)" },
+  { code: "+234", country: "Nigeria", iso2: "NG", label: "Nigeria (+234)" },
+  { code: "+250", country: "Rwanda", iso2: "RW", label: "Rwanda (+250)" },
+  {
+    code: "+239",
+    country: "Sao Tome and Principe",
+    iso2: "ST",
+    label: "Sao Tome and Principe (+239)",
+  },
+  { code: "+221", country: "Senegal", iso2: "SN", label: "Senegal (+221)" },
+  { code: "+248", country: "Seychelles", iso2: "SC", label: "Seychelles (+248)" },
+  {
+    code: "+232",
+    country: "Sierra Leone",
+    iso2: "SL",
+    label: "Sierra Leone (+232)",
+  },
+  { code: "+252", country: "Somalia", iso2: "SO", label: "Somalia (+252)" },
+  {
+    code: "+27",
+    country: "South Africa",
+    iso2: "ZA",
+    label: "South Africa (+27)",
+  },
+  {
+    code: "+211",
+    country: "South Sudan",
+    iso2: "SS",
+    label: "South Sudan (+211)",
+  },
+  { code: "+249", country: "Sudan", iso2: "SD", label: "Sudan (+249)" },
+  { code: "+255", country: "Tanzania", iso2: "TZ", label: "Tanzania (+255)" },
+  { code: "+228", country: "Togo", iso2: "TG", label: "Togo (+228)" },
+  { code: "+216", country: "Tunisia", iso2: "TN", label: "Tunisia (+216)" },
+  { code: "+256", country: "Uganda", iso2: "UG", label: "Uganda (+256)" },
+  { code: "+260", country: "Zambia", iso2: "ZM", label: "Zambia (+260)" },
+  { code: "+263", country: "Zimbabwe", iso2: "ZW", label: "Zimbabwe (+263)" },
+];
+
+const AFRICAN_COUNTRY_CODE_SET = new Set(
+  AFRICAN_COUNTRY_CODES.map((entry) => entry.code)
+);
+
+export function normalizeCountryDialCode(
+  countryCode?: string | null
+): string | null {
+  if (typeof countryCode !== "string") {
+    return null;
+  }
+
+  const digits = countryCode.replace(/\D/g, "");
+  return digits ? `+${digits}` : null;
+}
+
+export function isAfricanCountryDialCode(
+  countryCode?: string | null
+): boolean {
+  const normalizedCountryCode = normalizeCountryDialCode(countryCode);
+  return normalizedCountryCode
+    ? AFRICAN_COUNTRY_CODE_SET.has(normalizedCountryCode)
+    : false;
+}
+
+export function getAfricanCountryDialCodeOrDefault(
+  countryCode?: string | null,
+  fallback = DEFAULT_AFRICAN_COUNTRY_CODE
+): string {
+  return isAfricanCountryDialCode(countryCode)
+    ? (normalizeCountryDialCode(countryCode) as string)
+    : fallback;
+}
+
+export function normalizePhoneDigits(
+  phone?: string | null
+): string | null {
+  if (typeof phone !== "string") {
+    return null;
+  }
+
+  const trimmed = phone.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/\D/g, "") || null;
+}
+
+export function getNumericPhoneValidationError(
+  phone?: string | null,
+  maxLength = USER_LOGIN_PHONE_MAX_LENGTH
+): string | null {
+  if (typeof phone !== "string") {
+    return null;
+  }
+
+  const trimmed = phone.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return "Phone number must contain only numbers";
+  }
+
+  if (trimmed.length > maxLength) {
+    return `Phone number must not exceed ${maxLength} digits`;
+  }
+
+  return null;
+}
+
+export function normalizeSmsPhoneNumber(
+  phone: string,
+  countryCode?: string | null
+): string | null {
+  const raw = String(phone || "").trim();
+  if (!raw) return null;
+
+  const digits = raw.replace(/\D/g, "");
+  if (!digits) return null;
+
+  if (raw.startsWith("+")) {
+    return `+${digits}`;
+  }
+
+  if (raw.startsWith("00")) {
+    const internationalDigits = digits.slice(2);
+    return internationalDigits ? `+${internationalDigits}` : null;
+  }
+
+  const normalizedCountryCode = normalizeCountryDialCode(countryCode);
+
+  if (normalizedCountryCode) {
+    const countryDigits = normalizedCountryCode.slice(1);
+
+    if (digits.startsWith(countryDigits)) {
+      return `+${digits}`;
+    }
+
+    const localDigits = digits.startsWith("0") ? digits.slice(1) : digits;
+    return localDigits ? `${normalizedCountryCode}${localDigits}` : null;
+  }
+
+  if (digits.length >= 11) {
+    return `+${digits}`;
+  }
+
+  return digits;
+}
+
+export function formatPhoneWithCountryCode(
+  phone?: string | null,
+  countryCode?: string | null
+): string | null {
+  const normalizedPhone = normalizePhoneDigits(phone);
+
+  if (!normalizedPhone) {
+    return null;
+  }
+
+  const normalizedCountryCode = normalizeCountryDialCode(countryCode);
+  return normalizedCountryCode
+    ? `${normalizedCountryCode} ${normalizedPhone}`
+    : normalizedPhone;
+}

--- a/lib/tenant-service.ts
+++ b/lib/tenant-service.ts
@@ -126,6 +126,7 @@ export async function getTenantBySlug(
         slug: true,
         domain: true,
         settings: true,
+        notificationServiceTenantId: true,
         logoFileUrl: true,
         logoLinkId: true,
       },
@@ -173,11 +174,19 @@ export async function getOrCreateDefaultTenant(): Promise<TenantInfo> {
           slug: true,
           domain: true,
           settings: true,
+          notificationServiceTenantId: true,
         },
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const code =
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof error.code === "string"
+          ? error.code
+          : undefined;
       // If unique constraint fails, another request created it - just fetch it
-      if (error.code === "P2002") {
+      if (code === "P2002") {
         tenant = await getTenantBySlug("default");
       } else {
         throw error;
@@ -199,7 +208,7 @@ export async function createTenant(data: {
   name: string;
   slug: string;
   domain?: string;
-  settings?: any;
+  settings?: unknown;
 }): Promise<TenantInfo> {
   const tenant = await prisma.tenant.create({
     data: {
@@ -212,6 +221,7 @@ export async function createTenant(data: {
       slug: true,
       domain: true,
       settings: true,
+      notificationServiceTenantId: true,
     },
   });
 

--- a/lib/user-login-service.ts
+++ b/lib/user-login-service.ts
@@ -1,0 +1,384 @@
+import { Prisma } from "@/app/generated/prisma";
+import { prisma } from "@/lib/prisma";
+import {
+  getAfricanCountryDialCodeOrDefault,
+  isAfricanCountryDialCode,
+  normalizePhoneDigits,
+} from "@/lib/phone-utils";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import type { UserLoginBlockSource } from "@/shared/types/user-management";
+
+export const USER_LOGIN_BLOCKED_MESSAGE =
+  "Your account is blocked. Contact your system administrator for help.";
+
+export function normalizeUserLoginValue(
+  value: string | null | undefined
+): string | null {
+  if (typeof value !== "string") {
+    return value ?? null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export async function requireCurrentTenant() {
+  const tenant = await getTenantFromHeaders();
+
+  if (!tenant) {
+    throw new Error("Tenant not found");
+  }
+
+  return tenant;
+}
+
+export async function getUserLoginByFineractUserId(
+  tenantId: string,
+  fineractUserId: number
+) {
+  return prisma.userLogin.findUnique({
+    where: {
+      tenantId_fineractUserId: {
+        tenantId,
+        fineractUserId,
+      },
+    },
+  });
+}
+
+export async function getUserLoginByUsername(
+  tenantId: string,
+  username: string
+) {
+  return prisma.userLogin.findUnique({
+    where: {
+      tenantId_username: {
+        tenantId,
+        username,
+      },
+    },
+  });
+}
+
+export function isUserLoginBlocked(userLogin: { isBlocked: boolean } | null | undefined) {
+  return Boolean(userLogin?.isBlocked);
+}
+
+function getNormalizedUserLoginWriteData(input: {
+  username: string;
+  email?: string | null;
+  phone?: string | null;
+  countryCode?: string | null;
+  lastLoginAt?: Date | null;
+  lastMfaChannel?: string | null;
+  lastMfaSentAt?: Date | null;
+}) {
+  const normalizedEmail = normalizeUserLoginValue(input.email);
+  const normalizedPhone = normalizePhoneDigits(input.phone);
+  const normalizedCountryCode =
+    normalizedPhone && isAfricanCountryDialCode(input.countryCode)
+      ? getAfricanCountryDialCodeOrDefault(input.countryCode)
+      : null;
+  const normalizedUsername = input.username.trim();
+
+  return {
+    normalizedEmail,
+    normalizedPhone,
+    normalizedCountryCode,
+    normalizedUsername,
+  };
+}
+
+type UpsertUserLoginInput = {
+  tenantId: string;
+  fineractUserId: number;
+  username: string;
+  email?: string | null;
+  phone?: string | null;
+  countryCode?: string | null;
+  lastLoginAt?: Date | null;
+  lastMfaChannel?: string | null;
+  lastMfaSentAt?: Date | null;
+};
+
+export async function upsertUserLogin(input: UpsertUserLoginInput) {
+  const {
+    tenantId,
+    fineractUserId,
+    username,
+    email,
+    phone,
+    countryCode,
+    lastLoginAt,
+    lastMfaChannel,
+    lastMfaSentAt,
+  } = input;
+  const {
+    normalizedEmail,
+    normalizedPhone,
+    normalizedCountryCode,
+    normalizedUsername,
+  } = getNormalizedUserLoginWriteData({
+    username,
+    email,
+    phone,
+    countryCode,
+    lastLoginAt,
+    lastMfaChannel,
+    lastMfaSentAt,
+  });
+
+  const updateData: Record<string, unknown> = {
+    username: normalizedUsername,
+  };
+
+  if (email !== undefined) {
+    updateData.email = normalizedEmail;
+  }
+
+  if (phone !== undefined) {
+    updateData.phone = normalizedPhone;
+  }
+
+  if (countryCode !== undefined || phone !== undefined) {
+    updateData.countryCode = normalizedCountryCode;
+  }
+
+  if (lastLoginAt !== undefined) {
+    updateData.lastLoginAt = lastLoginAt;
+  }
+
+  if (lastMfaChannel !== undefined) {
+    updateData.lastMfaChannel = lastMfaChannel;
+  }
+
+  if (lastMfaSentAt !== undefined) {
+    updateData.lastMfaSentAt = lastMfaSentAt;
+  }
+
+  return prisma.userLogin.upsert({
+    where: {
+      tenantId_fineractUserId: {
+        tenantId,
+        fineractUserId,
+      },
+    },
+    update: updateData,
+    create: {
+      tenantId,
+      fineractUserId,
+      username: normalizedUsername,
+      email: normalizedEmail,
+      phone: normalizedPhone,
+      countryCode: normalizedCountryCode,
+      lastLoginAt: lastLoginAt ?? null,
+      lastMfaChannel: lastMfaChannel ?? null,
+      lastMfaSentAt: lastMfaSentAt ?? null,
+    },
+  });
+}
+
+export async function deleteUserLogin(
+  tenantId: string,
+  fineractUserId: number
+) {
+  await prisma.userLogin.deleteMany({
+    where: {
+      tenantId,
+      fineractUserId,
+    },
+  });
+}
+
+export async function updateUserLoginLastLogin(input: {
+  tenantId: string;
+  fineractUserId: number;
+  username: string;
+  email?: string | null;
+}) {
+  return upsertUserLogin({
+    ...input,
+    lastLoginAt: new Date(),
+  });
+}
+
+type UserLoginActor = {
+  actorUserId?: number | null;
+  actorName?: string | null;
+};
+
+type UserLoginBlockInput = UserLoginActor & {
+  tenantId: string;
+  fineractUserId: number;
+  username: string;
+  email?: string | null;
+  phone?: string | null;
+  countryCode?: string | null;
+  note: string;
+  source: UserLoginBlockSource;
+};
+
+async function ensureUserLoginRecord(
+  tx: Prisma.TransactionClient,
+  input: Omit<UserLoginBlockInput, "note" | "source" | "actorUserId" | "actorName">
+) {
+  const {
+    normalizedEmail,
+    normalizedPhone,
+    normalizedCountryCode,
+    normalizedUsername,
+  } = getNormalizedUserLoginWriteData(input);
+
+  return tx.userLogin.upsert({
+    where: {
+      tenantId_fineractUserId: {
+        tenantId: input.tenantId,
+        fineractUserId: input.fineractUserId,
+      },
+    },
+    update: {
+      username: normalizedUsername,
+      ...(input.email !== undefined ? { email: normalizedEmail } : {}),
+      ...(input.phone !== undefined ? { phone: normalizedPhone } : {}),
+      ...(input.phone !== undefined || input.countryCode !== undefined
+        ? { countryCode: normalizedCountryCode }
+        : {}),
+    },
+    create: {
+      tenantId: input.tenantId,
+      fineractUserId: input.fineractUserId,
+      username: normalizedUsername,
+      email: normalizedEmail,
+      phone: normalizedPhone,
+      countryCode: normalizedCountryCode,
+    },
+  });
+}
+
+export async function blockUserLogin(input: UserLoginBlockInput) {
+  const note = input.note.trim();
+
+  if (!note) {
+    throw new Error("A note is required to block this account.");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const userLogin = await ensureUserLoginRecord(tx, input);
+
+    if (userLogin.isBlocked) {
+      await tx.mfaChallenge.updateMany({
+        where: {
+          tenantId: input.tenantId,
+          fineractUserId: input.fineractUserId,
+          consumedAt: null,
+          invalidatedAt: null,
+        },
+        data: {
+          invalidatedAt: new Date(),
+        },
+      });
+
+      return {
+        changed: false,
+        userLogin,
+      };
+    }
+
+    const now = new Date();
+    const actorName = normalizeUserLoginValue(input.actorName);
+
+    const updatedUserLogin = await tx.userLogin.update({
+      where: { id: userLogin.id },
+      data: {
+        isBlocked: true,
+        blockedAt: now,
+        blockedSource: input.source,
+        blockedNote: note,
+        blockedByActorUserId: input.actorUserId ?? null,
+        blockedByActorName: actorName,
+      },
+    });
+
+    await tx.userLoginBlockEvent.create({
+      data: {
+        tenantId: input.tenantId,
+        userLoginId: userLogin.id,
+        fineractUserId: input.fineractUserId,
+        username: updatedUserLogin.username,
+        action: "BLOCK",
+        source: input.source,
+        note,
+        actorUserId: input.actorUserId ?? null,
+        actorName,
+      },
+    });
+
+    await tx.mfaChallenge.updateMany({
+      where: {
+        tenantId: input.tenantId,
+        fineractUserId: input.fineractUserId,
+        consumedAt: null,
+        invalidatedAt: null,
+      },
+      data: {
+        invalidatedAt: now,
+      },
+    });
+
+    return {
+      changed: true,
+      userLogin: updatedUserLogin,
+    };
+  });
+}
+
+export async function unblockUserLogin(input: UserLoginBlockInput) {
+  const note = input.note.trim();
+
+  if (!note) {
+    throw new Error("A note is required to unblock this account.");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const userLogin = await ensureUserLoginRecord(tx, input);
+
+    if (!userLogin.isBlocked) {
+      return {
+        changed: false,
+        userLogin,
+      };
+    }
+
+    const actorName = normalizeUserLoginValue(input.actorName);
+    const updatedUserLogin = await tx.userLogin.update({
+      where: { id: userLogin.id },
+      data: {
+        isBlocked: false,
+        blockedAt: null,
+        blockedSource: null,
+        blockedNote: null,
+        blockedByActorUserId: null,
+        blockedByActorName: null,
+      },
+    });
+
+    await tx.userLoginBlockEvent.create({
+      data: {
+        tenantId: input.tenantId,
+        userLoginId: userLogin.id,
+        fineractUserId: input.fineractUserId,
+        username: updatedUserLogin.username,
+        action: "UNBLOCK",
+        source: input.source,
+        note,
+        actorUserId: input.actorUserId ?? null,
+        actorName,
+      },
+    });
+
+    return {
+      changed: true,
+      userLogin: updatedUserLogin,
+    };
+  });
+}

--- a/prisma/migrations/20260603090000_add_user_login_and_mfa/migration.sql
+++ b/prisma/migrations/20260603090000_add_user_login_and_mfa/migration.sql
@@ -1,0 +1,75 @@
+-- CreateTable
+CREATE TABLE "UserLogin" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "fineractUserId" INTEGER NOT NULL,
+    "username" TEXT NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "lastLoginAt" TIMESTAMP(3),
+    "lastMfaChannel" TEXT,
+    "lastMfaSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserLogin_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MfaChallenge" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "fineractUserId" INTEGER NOT NULL,
+    "username" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "destination" TEXT NOT NULL,
+    "maskedDestination" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "verificationTokenHash" TEXT,
+    "authContext" JSONB NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "resendCount" INTEGER NOT NULL DEFAULT 0,
+    "lastSentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "verifiedAt" TIMESTAMP(3),
+    "consumedAt" TIMESTAMP(3),
+    "invalidatedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MfaChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserLogin_tenantId_fineractUserId_key" ON "UserLogin"("tenantId", "fineractUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserLogin_tenantId_username_key" ON "UserLogin"("tenantId", "username");
+
+-- CreateIndex
+CREATE INDEX "UserLogin_tenantId_email_idx" ON "UserLogin"("tenantId", "email");
+
+-- CreateIndex
+CREATE INDEX "UserLogin_tenantId_phone_idx" ON "UserLogin"("tenantId", "phone");
+
+-- CreateIndex
+CREATE INDEX "MfaChallenge_tenantId_username_idx" ON "MfaChallenge"("tenantId", "username");
+
+-- CreateIndex
+CREATE INDEX "MfaChallenge_tenantId_fineractUserId_idx" ON "MfaChallenge"("tenantId", "fineractUserId");
+
+-- CreateIndex
+CREATE INDEX "MfaChallenge_tenantId_expiresAt_idx" ON "MfaChallenge"("tenantId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "MfaChallenge_tenantId_consumedAt_idx" ON "MfaChallenge"("tenantId", "consumedAt");
+
+-- CreateIndex
+CREATE INDEX "MfaChallenge_tenantId_invalidatedAt_idx" ON "MfaChallenge"("tenantId", "invalidatedAt");
+
+-- AddForeignKey
+ALTER TABLE "UserLogin" ADD CONSTRAINT "UserLogin_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MfaChallenge" ADD CONSTRAINT "MfaChallenge_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260603132000_add_user_login_country_code/migration.sql
+++ b/prisma/migrations/20260603132000_add_user_login_country_code/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "UserLogin"
+ADD COLUMN IF NOT EXISTS "countryCode" TEXT;

--- a/prisma/migrations/20260603161500_add_tenant_notification_service_tenant_id/migration.sql
+++ b/prisma/migrations/20260603161500_add_tenant_notification_service_tenant_id/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Tenant"
+ADD COLUMN IF NOT EXISTS "notificationServiceTenantId" TEXT;

--- a/prisma/migrations/20260603184500_add_user_login_blocking_and_mfa_max_attempts/migration.sql
+++ b/prisma/migrations/20260603184500_add_user_login_blocking_and_mfa_max_attempts/migration.sql
@@ -1,0 +1,47 @@
+-- AlterTable
+ALTER TABLE "UserLogin"
+ADD COLUMN IF NOT EXISTS "isBlocked" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN IF NOT EXISTS "blockedAt" TIMESTAMP(3),
+ADD COLUMN IF NOT EXISTS "blockedSource" TEXT,
+ADD COLUMN IF NOT EXISTS "blockedNote" TEXT,
+ADD COLUMN IF NOT EXISTS "blockedByActorUserId" INTEGER,
+ADD COLUMN IF NOT EXISTS "blockedByActorName" TEXT;
+
+-- AlterTable
+ALTER TABLE "MfaChallenge"
+ALTER COLUMN "maxAttempts" SET DEFAULT 3;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "UserLoginBlockEvent" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "userLoginId" TEXT NOT NULL,
+    "fineractUserId" INTEGER NOT NULL,
+    "username" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "note" TEXT NOT NULL,
+    "actorUserId" INTEGER,
+    "actorName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserLoginBlockEvent_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "UserLoginBlockEvent_tenantId_fkey"
+      FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UserLoginBlockEvent_userLoginId_fkey"
+      FOREIGN KEY ("userLoginId") REFERENCES "UserLogin"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "UserLogin_tenantId_isBlocked_idx"
+ON "UserLogin"("tenantId", "isBlocked");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "UserLoginBlockEvent_tenantId_userLoginId_createdAt_idx"
+ON "UserLoginBlockEvent"("tenantId", "userLoginId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "UserLoginBlockEvent_tenantId_fineractUserId_createdAt_idx"
+ON "UserLoginBlockEvent"("tenantId", "fineractUserId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model Tenant {
   slug                   String                  @unique
   domain                 String?
   settings               Json?
+  notificationServiceTenantId String?
   logoLinkId             String?                 // Document service link ID (UUID) for logo
   logoFileUrl            String?                 // Document service file URL for display
   isActive               Boolean                 @default(true)
@@ -28,6 +29,9 @@ model Tenant {
   pipelineStages         PipelineStage[]
   slaConfigs             SLAConfig[]
   teams                  Team[]
+  userLogins             UserLogin[]
+  userLoginBlockEvents   UserLoginBlockEvent[]
+  mfaChallenges          MfaChallenge[]
   validationRules        ValidationRule[]
   receiptRanges          ReceiptRange[]
   repaymentCashLinks     RepaymentCashLink[]
@@ -1105,6 +1109,84 @@ model UserRole {
   @@index([tenantId, mifosUserId])
   @@index([tenantId, roleId])
   @@index([tenantId, isActive])
+}
+
+model UserLogin {
+  id                   String               @id @default(cuid())
+  tenantId             String
+  fineractUserId       Int
+  username             String
+  email                String?
+  phone                String?
+  countryCode          String?
+  isBlocked            Boolean              @default(false)
+  blockedAt            DateTime?
+  blockedSource        String?
+  blockedNote          String?
+  blockedByActorUserId Int?
+  blockedByActorName   String?
+  lastLoginAt          DateTime?
+  lastMfaChannel       String?
+  lastMfaSentAt        DateTime?
+  createdAt            DateTime             @default(now())
+  updatedAt            DateTime             @updatedAt
+  tenant               Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  blockEvents          UserLoginBlockEvent[]
+
+  @@unique([tenantId, fineractUserId])
+  @@unique([tenantId, username])
+  @@index([tenantId, email])
+  @@index([tenantId, phone])
+  @@index([tenantId, isBlocked])
+}
+
+model UserLoginBlockEvent {
+  id            String    @id @default(cuid())
+  tenantId      String
+  userLoginId   String
+  fineractUserId Int
+  username      String
+  action        String
+  source        String
+  note          String
+  actorUserId   Int?
+  actorName     String?
+  createdAt     DateTime  @default(now())
+  tenant        Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  userLogin     UserLogin @relation(fields: [userLoginId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, userLoginId, createdAt])
+  @@index([tenantId, fineractUserId, createdAt])
+}
+
+model MfaChallenge {
+  id                    String    @id @default(cuid())
+  tenantId              String
+  fineractUserId        Int
+  username              String
+  channel               String
+  destination           String
+  maskedDestination     String
+  codeHash              String
+  verificationTokenHash String?
+  authContext           Json
+  attempts              Int       @default(0)
+  maxAttempts           Int       @default(3)
+  resendCount           Int       @default(0)
+  lastSentAt            DateTime  @default(now())
+  verifiedAt            DateTime?
+  consumedAt            DateTime?
+  invalidatedAt         DateTime?
+  expiresAt             DateTime
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  tenant                Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, username])
+  @@index([tenantId, fineractUserId])
+  @@index([tenantId, expiresAt])
+  @@index([tenantId, consumedAt])
+  @@index([tenantId, invalidatedAt])
 }
 
 // User Alert - system alerts shown in notifications

--- a/shared/constants/mfa.ts
+++ b/shared/constants/mfa.ts
@@ -1,0 +1,3 @@
+export const MFA_CODE_LENGTH = 6;
+export const MFA_CODE_PATTERN = new RegExp(`^\\d{${MFA_CODE_LENGTH}}$`);
+export const DEFAULT_MFA_MAX_ATTEMPTS = 3;

--- a/shared/types/auth.ts
+++ b/shared/types/auth.ts
@@ -69,6 +69,7 @@ export enum Resource {
 
 export type UserDetails = {
   id: string;
+  tenantId?: string;
   userId: number;
   name: string;
   email: string;

--- a/shared/types/next-auth.d.ts
+++ b/shared/types/next-auth.d.ts
@@ -11,6 +11,7 @@ declare module "next-auth" {
     base64EncodedAuthenticationKey?: string;
     user: {
       id?: string;
+      tenantId?: string;
       userId?: number;
       officeId?: number;
       officeName?: string;
@@ -27,6 +28,7 @@ declare module "next-auth" {
    */
   interface User {
     accessToken?: string;
+    tenantId?: string;
     userId?: number;
     base64EncodedAuthenticationKey?: string;
     officeId?: number;
@@ -45,6 +47,7 @@ declare module "next-auth/jwt" {
    */
   interface JWT {
     accessToken?: string;
+    tenantId?: string;
     userId?: number;
     base64EncodedAuthenticationKey?: string;
     officeId?: number;

--- a/shared/types/tenant.ts
+++ b/shared/types/tenant.ts
@@ -32,6 +32,12 @@ export interface TenantFeatures {
   officeScopedAdminLeadsDashboard: boolean;
   /** When showing client active loans for topup, use the foreclosure settlement amount instead of total outstanding (excludes unrealized/future interest) */
   topupLoanBalanceExcludeUnrealizedInterests: boolean;
+  /** When true, MFA is required for tenant logins. Missing or false disables MFA. */
+  usesMFA?: boolean;
+  /** Enabled MFA delivery channels for the tenant. */
+  mfaChannels?: MfaChannel[];
+  /** Maximum incorrect MFA verification attempts before the account is blocked. */
+  mfaMaxAttempts?: number;
 }
 
 /**
@@ -45,6 +51,7 @@ export type FirstRepaymentDateStrategy =
   | "month-after-disbursement";
 
 export type InterestRateDisplayMode = "annual" | "monthly";
+export type MfaChannel = "email" | "sms";
 
 export interface FirstRepaymentDateConfig {
   strategy: FirstRepaymentDateStrategy;
@@ -104,6 +111,7 @@ export interface TenantInfo {
   slug: string;
   domain?: string | null;
   settings?: TenantSettings;
+  notificationServiceTenantId?: string | null;
   /** Document service file URL for org logo (when set) */
   logoFileUrl?: string | null;
   /** Document service link ID (UUID) for logo */

--- a/shared/types/user-management.ts
+++ b/shared/types/user-management.ts
@@ -22,27 +22,59 @@ export interface UserSummary {
   lastname: string;
   displayName: string;
   email?: string;
+  phone?: string;
+  countryCode?: string;
+  isBlocked: boolean;
+  blockedAt?: string | null;
   officeId?: number;
   officeName?: string;
   roles: string[];
 }
 
+export type UserLoginBlockAction = "BLOCK" | "UNBLOCK";
+export type UserLoginBlockSource = "MANUAL" | "SYSTEM_MFA_MAX_ATTEMPTS";
+
+export interface UserLoginBlockEvent {
+  id: string;
+  action: UserLoginBlockAction;
+  source: UserLoginBlockSource;
+  note: string;
+  actorUserId?: number | null;
+  actorName?: string | null;
+  createdAt: string;
+}
+
+export interface UserBlockHistoryPage {
+  items: UserLoginBlockEvent[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
 export interface UserDetail extends UserSummary {
   passwordNeverExpires: boolean;
   isSelfServiceUser: boolean;
+  blockedSource?: UserLoginBlockSource | null;
+  blockedNote?: string | null;
+  blockedByActorName?: string | null;
   selectedRoles: UserRoleOption[];
   staff?: StaffOption | null;
+  blockHistory: UserLoginBlockEvent[];
 }
 
 export interface UsersTemplate {
   allowedOffices: OfficeOption[];
   availableRoles: UserRoleOption[];
+  defaultCountryCode: string;
 }
 
 export interface UserFormInput {
   userId?: number | string;
   username: string;
   email?: string;
+  phone?: string;
+  countryCode?: string;
   firstname: string;
   lastname: string;
   sendPasswordToEmail?: boolean;
@@ -59,6 +91,16 @@ export interface UserPasswordChangeInput {
   firstname?: string;
   password: string;
   repeatPassword: string;
+}
+
+export interface UserBlockAccountInput {
+  userId: number | string;
+  note: string;
+}
+
+export interface UserBlockHistoryInput {
+  userId: number | string;
+  page?: number | string;
 }
 
 export interface UserActionResult<T = undefined> {


### PR DESCRIPTION
## Summary

- Adds OTP-based MFA flow with start/challenge/verify/resend API routes and a dedicated `/auth/mfa` UI page
- Introduces `UserLogin` service for tracking login attempts, account blocking, and Fineract auth integration
- Adds 4 Prisma migrations: `UserLogin` table, country code field, notification service tenant ID, and blocking/MFA max attempts columns
- Expands user management actions (role assignment, status management), notification service, and auth context to wire MFA end-to-end
- Adds phone utilities and `shared/constants/mfa.ts` for OTP config

## Test plan

- [ ] Login flow redirects to MFA challenge page after credentials validated
- [ ] OTP is sent via SMS and verified correctly
- [ ] Resend OTP works and respects rate limits
- [ ] Failed OTP attempts increment counter and block account after max attempts
- [ ] User management: role/status changes reflect correctly in the UI
- [ ] Existing login (non-MFA tenants) still works without regression
- [ ] Prisma migrations apply cleanly on a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)