### PR TITLE
fix: wrap MFA page useSearchParams in Suspense boundary

### DIFF
--- a/app/auth/mfa/page.tsx
+++ b/app/auth/mfa/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { signIn, getSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -67,6 +67,18 @@ async function hasActiveSession(
 }
 
 export default function MfaPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-background px-6">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    }>
+      <MfaPageContent />
+    </Suspense>
+  );
+}
+
+function MfaPageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const challengeId = searchParams.get("challengeId") || "";


### PR DESCRIPTION
## Summary

- Wraps `useSearchParams()` in the `/auth/mfa` page inside a `Suspense` boundary
- Fixes Docker build failure in CI — Next.js 15 requires `useSearchParams()` to be inside `Suspense` during static prerendering
- Extracted page body into `MfaPageContent` component; `MfaPage` now renders it wrapped in `Suspense` with a spinner fallback

## Test plan

- [x] `pnpm run build` completes successfully locally with no fatal errors
- [ ] GitHub Actions Docker build passes on push to UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)