### PR TITLE
feat: improve mandate preview and phone normalization

### DIFF
--- a/app/(application)/leads/new/components/loan-contracts.tsx
+++ b/app/(application)/leads/new/components/loan-contracts.tsx
@@ -97,11 +97,7 @@ export function LoanContracts({
   const { toast } = useToast();
   const router = useRouter();
   const mandateLogoUrl = useMemo(() => {
-    const fallbackLogoUrl =
-      typeof window !== "undefined"
-        ? new URL("/kenac_logo_light.png", window.location.origin).toString()
-        : null;
-    const candidate = tenantLogoUrl || fallbackLogoUrl;
+    const candidate = tenantLogoUrl;
 
     if (!candidate || typeof window === "undefined") {
       return candidate;
@@ -142,12 +138,26 @@ export function LoanContracts({
 
   useEffect(() => {
     let cancelled = false;
+    fetch("/api/tenant")
+      .then((res) => res.json())
+      .then((data: { logoFileUrl?: string | null }) => {
+        if (!cancelled) {
+          setTenantLogoUrl(data.logoFileUrl ?? null);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
     fetch("/api/tenant/contract-template?slug=full-loan")
       .then((res) => res.json())
-      .then((data: { html?: string | null; logoUrl?: string | null }) => {
+      .then((data: { html?: string | null }) => {
         if (!cancelled) {
           if (data.html) setTenantContractHtml(data.html);
-          if (data.logoUrl) setTenantLogoUrl(data.logoUrl);
         }
       })
       .catch(() => {});


### PR DESCRIPTION
## Summary
- normalize lead and client mobile numbers before saving/sending to Fineract
- add country code selection to client edit and improve searchable phone code labels
- update mandate preview to use the tenant logo source and show boxed service provider reference digits

## Testing
- not run in full because local branch has standing unrelated typecheck issues and the sandbox cannot validate the browser preview end-to-end
