### PR TITLE
chore: temporarily disable login permission gate

### DIFF
--- a/lib/fineract-auth.ts
+++ b/lib/fineract-auth.ts
@@ -181,28 +181,33 @@ async function fetchFineractUserDetails(input: {
 }
 
 export function getPermissionValidationError(userPermissions: string[]) {
-  if (!Array.isArray(userPermissions) || userPermissions.length === 0) {
-    return "Your account does not have any permissions assigned. Please contact your administrator.";
-  }
-
-  const hasAllFunctions =
-    userPermissions.includes("ALL_FUNCTIONS") ||
-    userPermissions.includes("ALL_FUNCTIONS_READ");
-
-  if (hasAllFunctions) {
-    return null;
-  }
-
-  const requiredPermissions = ["READ_USER", "READ_CURRENCY", "READ_REPORT"];
-  const missing = requiredPermissions.filter(
-    (permission) => !userPermissions.includes(permission)
-  );
-
-  if (missing.length === 0) {
-    return null;
-  }
-
-  return `Insufficient privileges. Your account is missing required permissions: ${missing.join(", ")}. Please contact your administrator.`;
+  // Login-time permission blocking is temporarily disabled so valid Fineract
+  // users can authenticate and rely on page/action authorization deeper in the app.
+  //
+  // if (!Array.isArray(userPermissions) || userPermissions.length === 0) {
+  //   return "Your account does not have any permissions assigned. Please contact your administrator.";
+  // }
+  //
+  // const hasAllFunctions =
+  //   userPermissions.includes("ALL_FUNCTIONS") ||
+  //   userPermissions.includes("ALL_FUNCTIONS_READ");
+  //
+  // if (hasAllFunctions) {
+  //   return null;
+  // }
+  //
+  // const requiredPermissions = ["READ_USER", "READ_CURRENCY", "READ_REPORT"];
+  // const missing = requiredPermissions.filter(
+  //   (permission) => !userPermissions.includes(permission)
+  // );
+  //
+  // if (missing.length === 0) {
+  //   return null;
+  // }
+  //
+  // return `Insufficient privileges. Your account is missing required permissions: ${missing.join(", ")}. Please contact your administrator.`;
+  void userPermissions;
+  return null;
 }
 
 export async function authenticateWithFineractCredentials(input: {

--- a/scripts/test-auth-permission-validation.ts
+++ b/scripts/test-auth-permission-validation.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { getPermissionValidationError } from "@/lib/fineract-auth";
+
+function main() {
+  assert.equal(
+    getPermissionValidationError([]),
+    null,
+    "users without mapped permissions should still be allowed to proceed through login"
+  );
+
+  assert.equal(
+    getPermissionValidationError(["READ_USER"]),
+    null,
+    "users missing READ_CURRENCY and READ_REPORT should still be allowed to proceed through login"
+  );
+
+  assert.equal(
+    getPermissionValidationError(["READ_CURRENCY", "READ_REPORT"]),
+    null,
+    "users missing READ_USER should still be allowed to proceed through login"
+  );
+
+  assert.equal(
+    getPermissionValidationError(["ALL_FUNCTIONS"]),
+    null,
+    "super users should continue to proceed through login"
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- temporarily comment out the Fineract login permission gate so valid users can sign in
- keep the previous gate logic in comments for quick restoration later
- add a focused auth validation script covering the temporary bypass

## Test Plan
- DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" ./node_modules/.bin/tsx scripts/test-auth-permission-validation.ts