### PR TITLE
Temporarily relax cash disbursement cashier restrictions

### DIFF
--- a/app/(application)/leads/[id]/components/state-transition-manager.tsx
+++ b/app/(application)/leads/[id]/components/state-transition-manager.tsx
@@ -57,6 +57,7 @@ import {
   getLocalIsoDate,
   isGoodfellowTenantHostname,
 } from "@/lib/goodfellow-tenant";
+import { shouldBypassCashierRestrictionsForLoanDisbursement } from "@/lib/loan-disbursement-cashier-policy";
 
 interface AvailableTransition {
   stageId: string;
@@ -228,6 +229,14 @@ export default function StateTransitionManager({
   const derivedDisbursementPayoutMethod = useMemo(
     () => inferPreferredPaymentMethodFromPaymentType(selectedPaymentType) || "",
     [selectedPaymentType]
+  );
+  const bypassCashierRestrictionsForDisbursement = useMemo(
+    () =>
+      shouldBypassCashierRestrictionsForLoanDisbursement({
+        transactionType: effectiveAction === "disburse" ? "DISBURSEMENT" : undefined,
+        payoutMethod: selectedPaymentTypeIsCash ? "CASH" : undefined,
+      }),
+    [effectiveAction, selectedPaymentTypeIsCash]
   );
   const resolvedPreferredPaymentType = useMemo(
     () =>
@@ -425,7 +434,8 @@ export default function StateTransitionManager({
           } else {
             const firstCash = list.find((p: { isCashPayment?: boolean }) => p.isCashPayment);
             const firstNonCash = list.find((p: { isCashPayment?: boolean }) => !p.isCashPayment);
-            const defaultPaymentType = currentCashierContext?.isCashier
+            const defaultPaymentType =
+              bypassCashierRestrictionsForDisbursement || currentCashierContext?.isCashier
               ? (firstCash || list[0])
               : (firstNonCash || list[0]);
             if (defaultPaymentType) {
@@ -435,7 +445,13 @@ export default function StateTransitionManager({
         })
         .catch(() => {});
     }
-  }, [currentCashierContext?.isCashier, effectiveAction, normalizedPreferredPaymentMethod, paymentTypes.length]);
+  }, [
+    bypassCashierRestrictionsForDisbursement,
+    currentCashierContext?.isCashier,
+    effectiveAction,
+    normalizedPreferredPaymentMethod,
+    paymentTypes.length,
+  ]);
 
   useEffect(() => {
     if (
@@ -542,6 +558,8 @@ export default function StateTransitionManager({
 
     if (normalizedPreferredPaymentMethod) return;
 
+    if (bypassCashierRestrictionsForDisbursement) return;
+
     if (!currentCashierContext?.isCashier && selectedPaymentTypeIsCash) {
       const firstNonCash = paymentTypes.find((paymentType) => !paymentType.isCashPayment);
       if (firstNonCash) {
@@ -549,6 +567,7 @@ export default function StateTransitionManager({
       }
     }
   }, [
+    bypassCashierRestrictionsForDisbursement,
     currentCashierContext?.isCashier,
     effectiveAction,
     normalizedPreferredPaymentMethod,
@@ -729,26 +748,28 @@ export default function StateTransitionManager({
           return;
         }
 
-        if (!currentCashierContext?.isCashier) {
-          toast({
-            title: "Cash Payout Not Allowed",
-            description:
-              currentCashierContext?.reason ||
-              "Only a logged-in cashier can choose cash for this disbursement.",
-            variant: "destructive",
-          });
-          return;
-        }
+        if (!bypassCashierRestrictionsForDisbursement) {
+          if (!currentCashierContext?.isCashier) {
+            toast({
+              title: "Cash Payout Not Allowed",
+              description:
+                currentCashierContext?.reason ||
+                "Only a logged-in cashier can choose cash for this disbursement.",
+              variant: "destructive",
+            });
+            return;
+          }
 
-        if (!currentCashierContext.hasActiveSession) {
-          toast({
-            title: "Cashier Session Required",
-            description:
-              currentCashierContext.reason ||
-              "Start an active cashier session before using cash.",
-            variant: "destructive",
-          });
-          return;
+          if (!currentCashierContext.hasActiveSession) {
+            toast({
+              title: "Cashier Session Required",
+              description:
+                currentCashierContext.reason ||
+                "Start an active cashier session before using cash.",
+              variant: "destructive",
+            });
+            return;
+          }
         }
       }
 
@@ -1451,14 +1472,15 @@ export default function StateTransitionManager({
                               <SelectItem
                                 key={p.id}
                                 value={String(p.id)}
-                                disabled={Boolean(p.isCashPayment && currentCashierContext && !currentCashierContext.isCashier)}
                               >
                                 {p.name}{p.isCashPayment ? " (Cash)" : ""}
                               </SelectItem>
                             ))}
                           </SelectContent>
                         </Select>
-                        {currentCashierContext && !currentCashierContext.isCashier && (
+                        {!bypassCashierRestrictionsForDisbursement &&
+                          currentCashierContext &&
+                          !currentCashierContext.isCashier && (
                           <p className="text-xs text-muted-foreground">
                             Cash payment types are disabled because the logged in user is not an assigned cashier.
                           </p>
@@ -1470,10 +1492,13 @@ export default function StateTransitionManager({
                   {loadingCurrentCashier && selectedPaymentTypeIsCash && (
                     <p className="text-xs text-muted-foreground flex items-center gap-1">
                       <Loader2 className="h-3 w-3 animate-spin" />
-                      Checking cashier access...
+                      Checking cashier info...
                     </p>
                   )}
-                  {currentCashierContext && !currentCashierContext.isCashier && selectedPaymentTypeIsCash && (
+                  {!bypassCashierRestrictionsForDisbursement &&
+                    currentCashierContext &&
+                    !currentCashierContext.isCashier &&
+                    selectedPaymentTypeIsCash && (
                     <p className="text-xs text-muted-foreground">
                       {currentCashierContext.reason || "Only cashiers can process cash payout."}
                     </p>
@@ -1484,7 +1509,9 @@ export default function StateTransitionManager({
                       <div className="flex items-center gap-2">
                         <Banknote className="h-4 w-4 text-green-600" />
                         <span className="text-sm font-medium text-green-800 dark:text-green-300">
-                          Cash payout will use the logged in cashier
+                          {currentCashierContext?.isCashier
+                            ? "Cash payout will use the logged in cashier"
+                            : "Cash payout is temporarily bypassing cashier linkage checks"}
                         </span>
                       </div>
                       {currentCashierContext?.isCashier ? (
@@ -1508,8 +1535,8 @@ export default function StateTransitionManager({
                           </div>
                         </>
                       ) : (
-                        <p className="text-sm text-red-600 dark:text-red-400">
-                          {currentCashierContext?.reason || "Only a cashier with an active session can use cash payout."}
+                        <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                          Cash disbursement is temporarily allowed even when the logged in user is not linked to an active cashier.
                         </p>
                       )}
                     </div>
@@ -1905,7 +1932,11 @@ export default function StateTransitionManager({
               (!selectedTransition?.isBackward && effectiveAction === "disburse" && !paymentTypeId) ||
               (!selectedTransition?.isBackward && effectiveAction === "disburse" && !!normalizedPreferredPaymentMethod && !resolvedPreferredPaymentType) ||
               (!selectedTransition?.isBackward && effectiveAction === "disburse" && !derivedDisbursementPayoutMethod) ||
-              (!selectedTransition?.isBackward && effectiveAction === "disburse" && selectedPaymentTypeIsCash && loadingCurrentCashier) ||
+              (!selectedTransition?.isBackward &&
+                effectiveAction === "disburse" &&
+                selectedPaymentTypeIsCash &&
+                loadingCurrentCashier &&
+                !bypassCashierRestrictionsForDisbursement) ||
               (!selectedTransition?.isBackward && effectiveAction === "payout" && !effectivePayoutMethod) ||
               (!selectedTransition?.isBackward && effectiveAction === "payout" && effectivePayoutMethod === "CASH" && (!selectedTeller || !selectedCashier)) ||
               (!selectedTransition?.isBackward && effectiveAction === "reject" && !reason?.trim())

--- a/app/api/tellers/[id]/cashiers/[cashierId]/settle/route.ts
+++ b/app/api/tellers/[id]/cashiers/[cashierId]/settle/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession } from "@/lib/auth";
 import { isPaymentTypeCash } from "@/lib/cash-repayment-teller";
+import { shouldSkipManualFineractCashierSettleForLoanDisbursement } from "@/lib/loan-disbursement-cashier-policy";
 import { sendLoanStatusSms } from "@/lib/notification-service";
 
 /**
@@ -479,58 +480,74 @@ export async function POST(
       }
     }
 
-    // Settle cash in Fineract (cash out transaction)
     let fineractSettlementId: number | null = null;
-    try {
-      const fineractService = await getFineractServiceWithSession();
-      console.log("Calling Fineract settleCashForCashier with:", {
-        tellerId: teller.fineractTellerId,
-        cashierId: fineractCashierId,
-        txnDate,
-        currencyCode: currency,
-        txnAmount: amount.toString(),
-        txnNote: fineractTxnNote,
-      });
-      const result = await fineractService.settleCashForCashier(
-        teller.fineractTellerId,
-        fineractCashierId,
+    if (
+      shouldSkipManualFineractCashierSettleForLoanDisbursement({
+        transactionType: txnType,
+      })
+    ) {
+      console.log(
+        "Skipping manual Fineract cashier settle for loan disbursement; Fineract disbursement already affects cashier summary.",
         {
+          tellerId: teller.fineractTellerId,
+          cashierId: fineractCashierId,
+          txnDate,
+          currencyCode: currency,
+          txnAmount: amount.toString(),
+        }
+      );
+    } else {
+      try {
+        const fineractService = await getFineractServiceWithSession();
+        console.log("Calling Fineract settleCashForCashier with:", {
+          tellerId: teller.fineractTellerId,
+          cashierId: fineractCashierId,
           txnDate,
           currencyCode: currency,
           txnAmount: amount.toString(),
           txnNote: fineractTxnNote,
-          dateFormat: "dd MMMM yyyy",
-          locale: "en",
-        }
-      );
-      fineractSettlementId = result.resourceId || result.id || null;
-      console.log("Fineract settle response:", result);
-    } catch (error: any) {
-      const errorDetails = {
-        message: error.message,
-        status: error.response?.status,
-        data: error.response?.data,
-      };
-      console.error("Error settling cash in Fineract:", errorDetails);
-      // Return full error details so user can see what went wrong
-      return NextResponse.json(
-        {
-          error: "Failed to settle cash in Fineract",
-          details:
-            error.response?.data?.defaultUserMessage ||
-            error.response?.data?.errors?.[0]?.defaultUserMessage ||
-            error.message,
-          fineractError: error.response?.data || null,
-          debugInfo: {
-            tellerId: teller.fineractTellerId,
-            cashierId: fineractCashierId,
+        });
+        const result = await fineractService.settleCashForCashier(
+          teller.fineractTellerId,
+          fineractCashierId,
+          {
             txnDate,
             currencyCode: currency,
             txnAmount: amount.toString(),
+            txnNote: fineractTxnNote,
+            dateFormat: "dd MMMM yyyy",
+            locale: "en",
+          }
+        );
+        fineractSettlementId = result.resourceId || result.id || null;
+        console.log("Fineract settle response:", result);
+      } catch (error: any) {
+        const errorDetails = {
+          message: error.message,
+          status: error.response?.status,
+          data: error.response?.data,
+        };
+        console.error("Error settling cash in Fineract:", errorDetails);
+        // Return full error details so user can see what went wrong
+        return NextResponse.json(
+          {
+            error: "Failed to settle cash in Fineract",
+            details:
+              error.response?.data?.defaultUserMessage ||
+              error.response?.data?.errors?.[0]?.defaultUserMessage ||
+              error.message,
+            fineractError: error.response?.data || null,
+            debugInfo: {
+              tellerId: teller.fineractTellerId,
+              cashierId: fineractCashierId,
+              txnDate,
+              currencyCode: currency,
+              txnAmount: amount.toString(),
+            },
           },
-        },
-        { status: error.response?.status || 500 }
-      );
+          { status: error.response?.status || 500 }
+        );
+      }
     }
 
     // Check if this fineract settlement already exists in our database

--- a/lib/loan-disbursement-cashier-policy.test.ts
+++ b/lib/loan-disbursement-cashier-policy.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import {
+  shouldBypassCashierRestrictionsForLoanDisbursement,
+  shouldSkipManualFineractCashierSettleForLoanDisbursement,
+} from "./loan-disbursement-cashier-policy";
+
+function run() {
+  assert.equal(
+    shouldSkipManualFineractCashierSettleForLoanDisbursement({
+      transactionType: "DISBURSEMENT",
+    }),
+    true
+  );
+
+  assert.equal(
+    shouldSkipManualFineractCashierSettleForLoanDisbursement({
+      payoutMethod: "CASH",
+    }),
+    true
+  );
+
+  assert.equal(
+    shouldSkipManualFineractCashierSettleForLoanDisbursement({
+      transactionType: "EXPENSE",
+    }),
+    false
+  );
+
+  assert.equal(
+    shouldBypassCashierRestrictionsForLoanDisbursement({
+      transactionType: "DISBURSEMENT",
+    }),
+    true
+  );
+
+  assert.equal(
+    shouldBypassCashierRestrictionsForLoanDisbursement({
+      payoutMethod: "CASH",
+    }),
+    true
+  );
+
+  assert.equal(
+    shouldBypassCashierRestrictionsForLoanDisbursement({
+      transactionType: "EXPENSE",
+    }),
+    false
+  );
+}
+
+run();

--- a/lib/loan-disbursement-cashier-policy.ts
+++ b/lib/loan-disbursement-cashier-policy.ts
@@ -1,0 +1,26 @@
+type LoanDisbursementCashierPolicyInput = {
+  payoutMethod?: "CASH" | "MOBILE_MONEY" | "BANK_TRANSFER";
+  transactionType?: string;
+};
+
+// Temporary production bypass while historical duplicate payout rows have spoiled cashier balances.
+const TEMPORARILY_BYPASS_CASHIER_RESTRICTIONS_FOR_LOAN_DISBURSEMENT = true;
+
+export function shouldSkipManualFineractCashierSettleForLoanDisbursement(
+  input: LoanDisbursementCashierPolicyInput
+): boolean {
+  return (
+    input.transactionType === "DISBURSEMENT" ||
+    input.payoutMethod === "CASH"
+  );
+}
+
+export function shouldBypassCashierRestrictionsForLoanDisbursement(
+  input: LoanDisbursementCashierPolicyInput
+): boolean {
+  return (
+    TEMPORARILY_BYPASS_CASHIER_RESTRICTIONS_FOR_LOAN_DISBURSEMENT &&
+    (input.transactionType === "DISBURSEMENT" ||
+      input.payoutMethod === "CASH")
+  );
+}

--- a/lib/team-state-machine-service.ts
+++ b/lib/team-state-machine-service.ts
@@ -4,6 +4,10 @@ import { applyTopupDisbursementCharges } from "./topup-disbursement-charge-servi
 import { getPaymentTypeInfo, isPaymentTypeCash } from "./cash-repayment-teller";
 import { resolveCurrentUserCashierContext } from "./current-user-cashier";
 import {
+  shouldBypassCashierRestrictionsForLoanDisbursement,
+  shouldSkipManualFineractCashierSettleForLoanDisbursement,
+} from "./loan-disbursement-cashier-policy";
+import {
   createSavingsAccount,
   approveSavingsAccount,
   activateSavingsAccount,
@@ -325,30 +329,44 @@ export class TeamAwareStateMachineService {
         throw new Error("Cash payout requires a cash disbursement payment type");
       }
 
-      // Resolve the logged-in cashier up front so we can block before disbursement.
       if (!overrides.tellerId || !overrides.cashierId) {
         const cashierContext = await resolveCurrentUserCashierContext(
           lead.tenantId,
           triggeredBy
         );
 
-        if (!cashierContext.isCashier) {
-          throw new Error(
-            cashierContext.reason || "Only an active cashier can process a cash payout"
-          );
+        if (
+          !shouldBypassCashierRestrictionsForLoanDisbursement({
+            payoutMethod: overrides.payoutMethod,
+          })
+        ) {
+          if (!cashierContext.isCashier) {
+            throw new Error(
+              cashierContext.reason || "Only an active cashier can process a cash payout"
+            );
+          }
+
+          if (!cashierContext.hasActiveSession) {
+            throw new Error(
+              cashierContext.reason || "Cashier must have an active session to process a cash payout"
+            );
+          }
         }
 
-        if (!cashierContext.hasActiveSession) {
-          throw new Error(
-            cashierContext.reason || "Cashier must have an active session to process a cash payout"
-          );
+        if (cashierContext.isCashier) {
+          return {
+            ...overrides,
+            tellerId:
+              cashierContext.fineractTellerId?.toString() ||
+              cashierContext.tellerId ||
+              undefined,
+            cashierId:
+              cashierContext.cashierId ||
+              cashierContext.fineractCashierId?.toString(),
+          };
         }
 
-        return {
-          ...overrides,
-          tellerId: cashierContext.fineractTellerId?.toString() || cashierContext.tellerId || undefined,
-          cashierId: cashierContext.cashierId || cashierContext.fineractCashierId?.toString(),
-        };
+        return overrides;
       }
 
       return overrides;
@@ -1693,78 +1711,135 @@ export class TeamAwareStateMachineService {
     const paidAt = Number.isNaN(payoutDate.getTime()) ? new Date() : payoutDate;
 
     if (overrides.payoutMethod === "CASH") {
+      const bypassCashierRestrictions =
+        shouldBypassCashierRestrictionsForLoanDisbursement({
+          payoutMethod: overrides.payoutMethod,
+        });
+
       if (!overrides.tellerId || !overrides.cashierId) {
         const cashierContext = await resolveCurrentUserCashierContext(
           lead.tenantId,
           triggeredBy
         );
 
-        if (!cashierContext.isCashier) {
-          throw new Error(
-            cashierContext.reason || "Only an active cashier can process a cash payout"
-          );
+        if (!bypassCashierRestrictions) {
+          if (!cashierContext.isCashier) {
+            throw new Error(
+              cashierContext.reason || "Only an active cashier can process a cash payout"
+            );
+          }
+
+          if (!cashierContext.hasActiveSession) {
+            throw new Error(
+              cashierContext.reason || "Cashier must have an active session to process a cash payout"
+            );
+          }
         }
 
-        if (!cashierContext.hasActiveSession) {
-          throw new Error(
-            cashierContext.reason || "Cashier must have an active session to process a cash payout"
-          );
-        }
-
-        overrides = {
-          ...overrides,
-          tellerId:
-            cashierContext.fineractTellerId?.toString() || cashierContext.tellerId || undefined,
-          cashierId:
-            cashierContext.cashierId || cashierContext.fineractCashierId?.toString(),
-        };
-      }
-
-      // Resolve teller — the UI sends Fineract teller IDs
-      const fineractTellerId = Number(overrides?.tellerId);
-      const teller = await prisma.teller.findFirst({
-        where: {
-          tenantId: lead.tenantId,
-          fineractTellerId,
-        },
-      });
-
-      if (!teller) {
-        throw new Error(`Teller not found for Fineract ID ${fineractTellerId}`);
-      }
-
-      // Resolve cashier — the UI sends DB cashier IDs (dbId) or Fineract IDs
-      const cashierIdStr = String(overrides?.cashierId);
-      let cashier = await prisma.cashier.findFirst({
-        where: { id: cashierIdStr, tellerId: teller.id, tenantId: lead.tenantId },
-      });
-      if (!cashier) {
-        const numId = Number(cashierIdStr);
-        if (!isNaN(numId)) {
-          cashier = await prisma.cashier.findFirst({
-            where: { fineractCashierId: numId, tellerId: teller.id, tenantId: lead.tenantId },
-          });
+        if (cashierContext.isCashier) {
+          overrides = {
+            ...overrides,
+            tellerId:
+              cashierContext.fineractTellerId?.toString() ||
+              cashierContext.tellerId ||
+              undefined,
+            cashierId:
+              cashierContext.cashierId ||
+              cashierContext.fineractCashierId?.toString(),
+          };
         }
       }
 
-      const fineractCashierId = cashier?.fineractCashierId || Number(cashierIdStr);
+      let teller:
+        | {
+            id: string;
+            fineractTellerId: number | null;
+          }
+        | null = null;
+      let cashier:
+        | {
+            id: string;
+            fineractCashierId: number | null;
+          }
+        | null = null;
+
+      if (overrides?.tellerId) {
+        const fineractTellerId = Number(overrides.tellerId);
+        teller = await prisma.teller.findFirst({
+          where: {
+            tenantId: lead.tenantId,
+            fineractTellerId,
+          },
+          select: {
+            id: true,
+            fineractTellerId: true,
+          },
+        });
+
+        if (!teller && !bypassCashierRestrictions) {
+          throw new Error(`Teller not found for Fineract ID ${fineractTellerId}`);
+        }
+      }
+
+      if (teller && overrides?.cashierId) {
+        const cashierIdStr = String(overrides.cashierId);
+        cashier = await prisma.cashier.findFirst({
+          where: { id: cashierIdStr, tellerId: teller.id, tenantId: lead.tenantId },
+          select: {
+            id: true,
+            fineractCashierId: true,
+          },
+        });
+        if (!cashier) {
+          const numId = Number(cashierIdStr);
+          if (!isNaN(numId)) {
+            cashier = await prisma.cashier.findFirst({
+              where: {
+                fineractCashierId: numId,
+                tellerId: teller.id,
+                tenantId: lead.tenantId,
+              },
+              select: {
+                id: true,
+                fineractCashierId: true,
+              },
+            });
+          }
+        }
+      }
+
+      const rawCashierId = overrides?.cashierId ? Number(overrides.cashierId) : NaN;
+      const fineractCashierId =
+        cashier?.fineractCashierId ??
+        (Number.isNaN(rawCashierId) ? null : rawCashierId);
 
       // Format date for Fineract
       const months = ["January","February","March","April","May","June","July","August","September","October","November","December"];
       const txnDate = `${paidAt.getDate()} ${months[paidAt.getMonth()]} ${paidAt.getFullYear()}`;
 
-      // Settle via Fineract teller/cashier
-      const fineract = await getFineractServiceWithSession();
-      await fineract.settleCashForCashier(
-        teller.fineractTellerId!,
-        fineractCashierId,
-        {
-          txnAmount: String(amount),
-          currencyCode,
-          txnNote: overrides.note || `Loan Disbursement Payout — ${clientName}`,
-          txnDate,
+      if (
+        !shouldSkipManualFineractCashierSettleForLoanDisbursement({
+          payoutMethod: overrides.payoutMethod,
+        })
+      ) {
+        if (!teller?.fineractTellerId || !fineractCashierId) {
+          throw new Error(
+            "Cash payout requires teller and cashier linkage when manual Fineract settle is enabled"
+          );
         }
-      );
+
+        const fineract = await getFineractServiceWithSession();
+        await fineract.settleCashForCashier(
+          teller.fineractTellerId!,
+          fineractCashierId,
+          {
+            txnAmount: String(amount),
+            currencyCode,
+            txnNote: overrides.note || `Loan Disbursement Payout — ${clientName}`,
+            txnDate,
+          }
+        );
+      }
 
       // Create / update payout record
       await prisma.loanPayout.upsert({
@@ -1781,20 +1856,26 @@ export class TeamAwareStateMachineService {
           currency: currencyCode,
           status: "PAID",
           paymentMethod: "CASH",
-          tellerId: teller.id,
+          tellerId: teller?.id || null,
           cashierId: cashier?.id || null,
           paidAt,
           paidBy: triggeredBy || "system",
-          notes: overrides.payoutNote || overrides.note || "Cash payout via teller",
+          notes:
+            overrides.payoutNote ||
+            overrides.note ||
+            (teller ? "Cash payout via teller" : "Cash payout via temporary cashier bypass"),
         },
         update: {
           status: "PAID",
           paymentMethod: "CASH",
-          tellerId: teller.id,
+          tellerId: teller?.id || null,
           cashierId: cashier?.id || null,
           paidAt,
           paidBy: triggeredBy || "system",
-          notes: overrides.payoutNote || overrides.note || "Cash payout via teller",
+          notes:
+            overrides.payoutNote ||
+            overrides.note ||
+            (teller ? "Cash payout via teller" : "Cash payout via temporary cashier bypass"),
         },
       });
 


### PR DESCRIPTION
## Summary
- temporarily bypass cashier linkage and active-session enforcement for cash loan disbursement
- keep cash disbursement payout recording working even when teller/cashier mapping is missing
- skip manual Fineract cashier settle for loan disbursement and cover the temporary policy with a focused test

## Test Plan
- node --import tsx lib/loan-disbursement-cashier-policy.test.ts
- DATABASE_URL=postgresql://user:pass@localhost:5432/db node --import tsx -e "import './lib/loan-disbursement-cashier-policy.ts'; import './lib/team-state-machine-service.ts'; import './app/api/tellers/[id]/cashiers/[cashierId]/settle/route.ts'; import './app/(application)/leads/[id]/components/state-transition-manager.tsx';"