### PR TITLE
feat: tighten loan details auth and branch gating

### DIFF
--- a/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
@@ -4,6 +4,7 @@ import { useCurrency } from "@/contexts/currency-context";
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +16,16 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Input } from "@/components/ui/input";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/use-toast";
 import { AlertCircle, Download, Loader2, MoreVertical, X, ChevronsLeft, ChevronLeft, ChevronRight, ChevronsRight, Edit, Flag, Plus, Heart, Coins, RotateCcw, Calendar, ChevronRight as ChevronRightIcon, User, Building, Phone, Mail, CreditCard, TrendingUp, Clock, FileText, Shield, DollarSign, Percent, CalendarDays, Settings, Trash2, StickyNote } from "lucide-react";
@@ -51,6 +62,11 @@ import {
 } from "@/lib/interest-rate-display";
 import { normalizeTenantSlug } from "@/lib/omama-tenant";
 import { FacilityBanner } from "@/components/credit-facility/facility-banner";
+import { getExistingClientTransferErrorMessage } from "@/lib/fineract-client-office-transfer";
+import {
+  getLoanDetailsOfficeTransferRequirement,
+  isLoanDetailsOfficeRestrictedAction,
+} from "@/lib/loan-details-office-gate";
 
 interface ClientLoanDetailsProps {
   clientId: number;
@@ -121,6 +137,7 @@ const formatLoanSequenceLabel = (position: number): string => {
 
 export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) {
   const router = useRouter();
+  const { data: session } = useSession();
   const { tenantSlug, features } = useFeatureFlags();
   const hasCreditFacility = !!features.hasCreditFacility;
   const [client, setClient] = useState<FineractClient | null>(null);
@@ -345,6 +362,25 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
 
   // Disburse Modal State
   const [showDisburseModal, setShowDisburseModal] = useState(false);
+
+  // Cross-branch action gate state
+  const [showLoanClientTransferModal, setShowLoanClientTransferModal] = useState(false);
+  const [loanClientTransferErrorMessage, setLoanClientTransferErrorMessage] =
+    useState<string | null>(null);
+  const [isTransferringLoanClient, setIsTransferringLoanClient] = useState(false);
+  const loanClientTransferRequirement = client
+    ? getLoanDetailsOfficeTransferRequirement({
+        clientId,
+        clientDisplayName: client.displayName || `${client.firstname} ${client.lastname}`,
+        clientOfficeId: (client as any)?.officeId,
+        clientOfficeName: client.officeName,
+        loanOfficeId: (loan as any)?.clientOfficeId ?? (loan as any)?.officeId,
+        loanOfficeName: undefined,
+        userOfficeId: session?.user?.officeId,
+        userOfficeName: session?.user?.officeName,
+      })
+    : null;
+  const hasLoanClientOfficeMismatch = !!loanClientTransferRequirement;
 
   // Close actions menu when clicking outside
 
@@ -733,6 +769,23 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
         });
 
         if (button && dropdown) {
+          if (hasLoanClientOfficeMismatch) {
+            dropdown.querySelectorAll('[data-action]').forEach((actionButton) => {
+              const action = actionButton.getAttribute('data-action');
+              if (!isLoanDetailsOfficeRestrictedAction(action)) {
+                return;
+              }
+
+              actionButton.setAttribute('aria-disabled', 'true');
+              actionButton.setAttribute('data-office-restricted', 'true');
+              actionButton.setAttribute(
+                'title',
+                'Transfer client to your branch to use this action'
+              );
+              actionButton.classList.add('opacity-50', 'cursor-not-allowed');
+            });
+          }
+
           // Toggle dropdown on button click
           button.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -830,6 +883,18 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
             actionBtn.addEventListener('click', (e) => {
               e.stopPropagation();
               const action = actionBtn.getAttribute('data-action');
+
+              if (
+                hasLoanClientOfficeMismatch &&
+                isLoanDetailsOfficeRestrictedAction(action)
+              ) {
+                dropdown.classList.add('hidden');
+                if (paymentsSubmenu) paymentsSubmenu.style.display = 'none';
+                if (moreSubmenu) moreSubmenu.style.display = 'none';
+                setLoanClientTransferErrorMessage(null);
+                setShowLoanClientTransferModal(true);
+                return;
+              }
               
               // Don't close dropdown for submenu triggers
               if (action !== 'payments' && action !== 'more') {
@@ -1007,7 +1072,14 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
         container.innerHTML = '';
       }
     };
-  }, [loan, clientId, loanId, loanProductCanTopup, setShowRepaymentModal]);
+  }, [
+    clientId,
+    hasLoanClientOfficeMismatch,
+    loan,
+    loanId,
+    loanProductCanTopup,
+    setShowRepaymentModal,
+  ]);
 
   const fetchLoanData = async () => {
     try {
@@ -1174,6 +1246,61 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
   useEffect(() => {
     fetchLoanData();
   }, [clientId, loanId]);
+
+  const handleTransferLoanClientOffice = async () => {
+    if (!loanClientTransferRequirement) {
+      return;
+    }
+
+    setLoanClientTransferErrorMessage(null);
+    setIsTransferringLoanClient(true);
+
+    try {
+      const response = await fetch(
+        `/api/fineract/clients/${loanClientTransferRequirement.clientId}/transfer-office`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            clientOfficeId: loanClientTransferRequirement.clientOfficeId,
+            destinationOfficeId:
+              loanClientTransferRequirement.destinationOfficeId,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(
+          errorData?.error ||
+            "Failed to transfer the client to your branch. Please try again."
+        );
+      }
+
+      toast({
+        title: "Client Transferred",
+        description: `${loanClientTransferRequirement.clientDisplayName} is now in your branch.`,
+        variant: "success",
+      });
+
+      setLoanClientTransferErrorMessage(null);
+      setShowLoanClientTransferModal(false);
+      await fetchLoanData();
+    } catch (transferError) {
+      const transferErrorMessage =
+        getExistingClientTransferErrorMessage(transferError);
+      setLoanClientTransferErrorMessage(transferErrorMessage);
+      toast({
+        title: "Transfer Failed",
+        description: transferErrorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      setIsTransferringLoanClient(false);
+    }
+  };
 
   const formatDate = (date: string | number[] | undefined): string => {
     if (!date) return "N/A";
@@ -4407,6 +4534,64 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
 
 
       </Tabs>
+
+      <AlertDialog
+        open={Boolean(showLoanClientTransferModal && loanClientTransferRequirement)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Transfer Client Before Continuing</AlertDialogTitle>
+            <AlertDialogDescription>
+              {loanClientTransferRequirement
+                ? `${loanClientTransferRequirement.clientDisplayName} belongs to ${
+                    loanClientTransferRequirement.clientOfficeName ||
+                    "another branch"
+                  }. Transfer the client to ${
+                    loanClientTransferRequirement.destinationOfficeName ||
+                    "your branch"
+                  } before using this action on the loan.`
+                : "Transfer this client to your branch before using this action on the loan."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {loanClientTransferErrorMessage ? (
+            <Alert className="border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
+              <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+              <AlertDescription className="text-red-800 dark:text-red-200">
+                {loanClientTransferErrorMessage}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              type="button"
+              disabled={isTransferringLoanClient}
+              onClick={() => {
+                setShowLoanClientTransferModal(false);
+                setLoanClientTransferErrorMessage(null);
+              }}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              type="button"
+              disabled={isTransferringLoanClient}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleTransferLoanClientOffice();
+              }}
+            >
+              {isTransferringLoanClient ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Transferring...
+                </>
+              ) : (
+                "Transfer Now"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Repayment Modal */}
       <RepaymentModal

--- a/app/api/fineract/loans/[id]/approve/route.ts
+++ b/app/api/fineract/loans/[id]/approve/route.ts
@@ -18,7 +18,9 @@ export async function GET(
     
     // Build the endpoint URL
     const endpoint = `/loans/${id}/template?templateType=${templateType}`;
-    const data = await fetchFineractAPI(endpoint);
+    const data = await fetchFineractAPI(endpoint, {
+      authMode: "service",
+    });
     
     return NextResponse.json(data);
   } catch (error: any) {
@@ -44,7 +46,9 @@ export async function POST(
     
     // First, check the current loan status to provide better error messages
     try {
-      const loanData = await fetchFineractAPI(`/loans/${id}`);
+      const loanData = await fetchFineractAPI(`/loans/${id}`, {
+        authMode: "service",
+      });
       const loanStatus = loanData.status?.value;
       
       // Check if loan is in a state that allows approval

--- a/app/api/fineract/loans/[id]/charges/template/route.ts
+++ b/app/api/fineract/loans/[id]/charges/template/route.ts
@@ -9,6 +9,7 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(`/loans/${loanId}/charges/template`, {
+      authMode: "service",
       method: "GET",
     });
 

--- a/app/api/fineract/loans/[id]/collaterals/route.ts
+++ b/app/api/fineract/loans/[id]/collaterals/route.ts
@@ -7,7 +7,9 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/collaterals`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/collaterals`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan collaterals:", error);

--- a/app/api/fineract/loans/[id]/collaterals/template/route.ts
+++ b/app/api/fineract/loans/[id]/collaterals/template/route.ts
@@ -7,7 +7,9 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/collaterals/template`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/collaterals/template`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching collateral template:", error);

--- a/app/api/fineract/loans/[id]/disburse/route.ts
+++ b/app/api/fineract/loans/[id]/disburse/route.ts
@@ -99,7 +99,9 @@ export async function POST(
     let ussdPhone: string | undefined;
     let isUssdLinked = false;
     try {
-      const loan = await fetchFineractAPI(`/loans/${id}`);
+      const loan = await fetchFineractAPI(`/loans/${id}`, {
+        authMode: "service",
+      });
       const externalId = loan?.externalId;
       if (externalId) {
         const ussd = await prisma.ussdLoanApplication.findFirst({

--- a/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
@@ -1,44 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth";
-import { getSession as getCustomSession } from "@/app/actions/auth";
-import { getFineractTenantId } from "@/lib/fineract-tenant-service";
-
-const baseUrl = process.env.FINERACT_BASE_URL || "http://10.10.0.143:8443";
-
-/**
- * Get access token from either NextAuth session or custom JWT session
- */
-async function getAccessToken(): Promise<string | undefined> {
-  try {
-    const nextAuthSession = await getSession();
-    if (nextAuthSession?.accessToken) {
-      return nextAuthSession.accessToken;
-    }
-
-    const customSession = await getCustomSession();
-    if (customSession?.accessToken) {
-      return customSession.accessToken;
-    }
-
-    return undefined;
-  } catch (error) {
-    console.error("Error getting access token:", error);
-    return undefined;
-  }
-}
+import { buildFineractRequest } from "@/lib/api";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; documentId: string }> }
 ) {
   try {
-    const accessToken = await getAccessToken();
-    const fineractTenantId = await getFineractTenantId();
-
-    if (!accessToken) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const { id: loanId, documentId } = await params;
 
     console.log("=== DOWNLOADING LOAN DOCUMENT ===");
@@ -46,13 +13,21 @@ export async function GET(
     console.log("Document ID:", documentId);
 
     // For file downloads, we need to handle the response differently
-    const url = `${baseUrl}/fineract-provider/api/v1/loans/${loanId}/documents/${documentId}/attachment`;
+    const { headers, url } = await buildFineractRequest(
+      `/loans/${loanId}/documents/${documentId}/attachment`,
+      {
+        authMode: "service",
+        headers: {
+          Accept: "*/*",
+        },
+      }
+    );
     console.log("Download URL:", url);
 
     let response;
 
     // Check if it's HTTP and use different approach
-    if (baseUrl.startsWith("http://")) {
+    if (url.startsWith("http://")) {
       // Use Node.js built-in http module for HTTP URLs
       const http = require("http");
       const urlModule = require("url");
@@ -64,11 +39,7 @@ export async function GET(
         port: parsedUrl.port || 80,
         path: parsedUrl.path,
         method: "GET",
-        headers: {
-          Accept: "*/*",
-          Authorization: `Basic ${accessToken}`,
-          "Fineract-Platform-TenantId": fineractTenantId,
-        },
+        headers,
       };
 
       response = await new Promise<any>((resolve, reject) => {
@@ -103,11 +74,7 @@ export async function GET(
 
       response = await fetch(url, {
         method: "GET",
-        headers: {
-          Accept: "*/*",
-          Authorization: `Basic ${accessToken}`,
-          "Fineract-Platform-TenantId": fineractTenantId,
-        },
+        headers,
         // Skip SSL verification for local development
         agent: new https.Agent({
           rejectUnauthorized: false,

--- a/app/api/fineract/loans/[id]/documents/route.ts
+++ b/app/api/fineract/loans/[id]/documents/route.ts
@@ -62,7 +62,9 @@ export async function GET(
       uploadRecords.map((record) => [record.documentId, record])
     );
 
-    const data = await fetchFineractAPI(`/loans/${loanId}/documents`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/documents`, {
+      authMode: "service",
+    });
 
     if (data && Array.isArray(data)) {
       return NextResponse.json(

--- a/app/api/fineract/loans/[id]/guarantors/route.ts
+++ b/app/api/fineract/loans/[id]/guarantors/route.ts
@@ -11,7 +11,9 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const data = await fetchFineractAPI(`/loans/${id}?associations=guarantors`);
+    const data = await fetchFineractAPI(`/loans/${id}?associations=guarantors`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching loan guarantors:', error);

--- a/app/api/fineract/loans/[id]/guarantors/template/route.ts
+++ b/app/api/fineract/loans/[id]/guarantors/template/route.ts
@@ -11,7 +11,9 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const data = await fetchFineractAPI(`/loans/${id}/guarantors/template`);
+    const data = await fetchFineractAPI(`/loans/${id}/guarantors/template`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching guarantors template:', error);

--- a/app/api/fineract/loans/[id]/interest-pauses/route.ts
+++ b/app/api/fineract/loans/[id]/interest-pauses/route.ts
@@ -9,6 +9,7 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(`/loans/${loanId}/interest-pauses`, {
+      authMode: "service",
       method: "GET",
     });
 

--- a/app/api/fineract/loans/[id]/notes/route.ts
+++ b/app/api/fineract/loans/[id]/notes/route.ts
@@ -7,7 +7,9 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/notes`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/notes`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan notes:", error);

--- a/app/api/fineract/loans/[id]/old/[oldId]/statement/route.ts
+++ b/app/api/fineract/loans/[id]/old/[oldId]/statement/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { format } from "date-fns";
-import { getAccessToken, getFineractTenantId } from "@/lib/api";
+import { buildFineractRequest } from "@/lib/api";
 import {
   generateConsolidatedStatementHTML,
   parseFineractDate,
@@ -32,8 +32,6 @@ type RefinanceLoanLike = {
   closureLoanAccountNo?: string;
   topupAmount?: number | null;
 };
-
-const baseUrl = process.env.FINERACT_BASE_URL || "http://10.10.0.143:8443";
 
 function getConsolidatedTransactionType(tx: TransactionLike): string {
   return getDisplayedTransactionType(tx);
@@ -102,22 +100,20 @@ export async function GET(
     const fromDate = searchParams.get("from");
     const toDate = searchParams.get("to");
 
-    const accessToken = await getAccessToken();
-    const fineractTenantId = await getFineractTenantId();
-
-    if (!accessToken) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const headers = {
-      Authorization: `Basic ${accessToken}`,
-      "Fineract-Platform-TenantId": fineractTenantId,
-      Accept: "application/json",
-    };
+    const [newLoanRequest, oldLoanRequest] = await Promise.all([
+      buildFineractRequest(`/loans/${newLoanId}?associations=all`, {
+        authMode: "service",
+        headers: { Accept: "application/json" },
+      }),
+      buildFineractRequest(`/loans/${oldId}?associations=all`, {
+        authMode: "service",
+        headers: { Accept: "application/json" },
+      }),
+    ]);
 
     const [newLoanResponse, oldLoanResponse] = await Promise.all([
-      fetch(`${baseUrl}/fineract-provider/api/v1/loans/${newLoanId}?associations=all`, { headers }),
-      fetch(`${baseUrl}/fineract-provider/api/v1/loans/${oldId}?associations=all`, { headers }),
+      fetch(newLoanRequest.url, { headers: newLoanRequest.headers }),
+      fetch(oldLoanRequest.url, { headers: oldLoanRequest.headers }),
     ]);
 
     if (!newLoanResponse.ok) {
@@ -164,9 +160,13 @@ export async function GET(
     let clientData = null;
     const clientId = newLoan.clientId || oldLoan.clientId;
     if (clientId) {
+      const clientRequest = await buildFineractRequest(`/clients/${clientId}`, {
+        authMode: "service",
+        headers: { Accept: "application/json" },
+      });
       const clientResponse = await fetch(
-        `${baseUrl}/fineract-provider/api/v1/clients/${clientId}`,
-        { headers }
+        clientRequest.url,
+        { headers: clientRequest.headers }
       );
 
       if (clientResponse.ok) {

--- a/app/api/fineract/loans/[id]/route.ts
+++ b/app/api/fineract/loans/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getFineractServiceWithSession } from "@/lib/fineract-api";
+import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
@@ -18,11 +18,16 @@ export async function GET(
     const session = await getSession();
     const tenantSlug = extractTenantSlugFromRequest(request);
 
-    // Get associations parameter if provided, otherwise default to 'all'
     const associations = searchParams.get("associations") || "all";
+    const exclude = searchParams.get("exclude");
+    const fineractQuery = new URLSearchParams({ associations });
+    if (exclude) {
+      fineractQuery.set("exclude", exclude);
+    }
 
-    const fineractService = await getFineractServiceWithSession();
-    const data = await fineractService.getLoan(id, associations);
+    const data = await fetchFineractAPI(`/loans/${id}?${fineractQuery.toString()}`, {
+      authMode: "service",
+    });
     const officeScope = resolveOmamaOfficeScope({
       tenantSlug,
       roles: ((session?.user as any)?.roles || []) as Array<{

--- a/app/api/fineract/loans/[id]/statement/route.ts
+++ b/app/api/fineract/loans/[id]/statement/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAccessToken, getFineractTenantId } from "@/lib/api";
+import { buildFineractRequest } from "@/lib/api";
 import {
   generateLoanStatementHTML,
   transformFineractLoanToStatement,
@@ -7,8 +7,6 @@ import {
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getSession, getCurrentUserDetails } from "@/lib/auth";
 import { resolveInterestRateDisplayMode } from "@/lib/interest-rate-display";
-
-const baseUrl = process.env.FINERACT_BASE_URL || "http://10.10.0.143:8443";
 
 /**
  * GET /api/fineract/loans/[id]/statement
@@ -31,28 +29,24 @@ export async function GET(
     const fromDate = searchParams.get("from");
     const toDate = searchParams.get("to");
 
-    const accessToken = await getAccessToken();
-    const fineractTenantId = await getFineractTenantId();
-
-    if (!accessToken) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     console.log("=== GENERATING LOAN STATEMENT ===");
     console.log("Loan ID:", loanId);
     console.log("Format:", format);
 
-    // Fetch loan with all associations
-    const loanUrl = `${baseUrl}/fineract-provider/api/v1/loans/${loanId}?associations=all`;
+    const { headers: loanHeaders, url: loanUrl } = await buildFineractRequest(
+      `/loans/${loanId}?associations=all`,
+      {
+        authMode: "service",
+        headers: {
+          Accept: "application/json",
+        },
+      }
+    );
     console.log("Fetching loan from:", loanUrl);
 
     const loanResponse = await fetch(loanUrl, {
       method: "GET",
-      headers: {
-        Authorization: `Basic ${accessToken}`,
-        "Fineract-Platform-TenantId": fineractTenantId,
-        Accept: "application/json",
-      },
+      headers: loanHeaders,
     });
 
     if (!loanResponse.ok) {
@@ -77,14 +71,18 @@ export async function GET(
     let clientData = null;
     if (loanData.clientId) {
       try {
-        const clientUrl = `${baseUrl}/fineract-provider/api/v1/clients/${loanData.clientId}`;
+        const { headers: clientHeaders, url: clientUrl } = await buildFineractRequest(
+          `/clients/${loanData.clientId}`,
+          {
+            authMode: "service",
+            headers: {
+              Accept: "application/json",
+            },
+          }
+        );
         const clientResponse = await fetch(clientUrl, {
           method: "GET",
-          headers: {
-            Authorization: `Basic ${accessToken}`,
-            "Fineract-Platform-TenantId": fineractTenantId,
-            Accept: "application/json",
-          },
+          headers: clientHeaders,
         });
 
         if (clientResponse.ok) {

--- a/app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts
@@ -7,7 +7,9 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/transactions/template?command=charge-off`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/transactions/template?command=charge-off`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching charge-off template:", error);

--- a/app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts
@@ -9,7 +9,10 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(
-      `/loans/${loanId}/transactions/template?command=creditBalanceRefund&locale=en&dateFormat=dd MMMM yyyy`
+      `/loans/${loanId}/transactions/template?command=creditBalanceRefund&locale=en&dateFormat=dd MMMM yyyy`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts
@@ -7,7 +7,9 @@ export async function GET(
 ) {
   try {
     const { id: loanId } = await params;
-    const data = await fetchFineractAPI(`/loans/${loanId}/transactions/template?command=goodwillCredit`);
+    const data = await fetchFineractAPI(`/loans/${loanId}/transactions/template?command=goodwillCredit`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching goodwill credit template:", error);
@@ -17,4 +19,3 @@ export async function GET(
     return NextResponse.json({ error: error.message || "Failed to fetch goodwill credit template" }, { status: 500 });
   }
 }
-

--- a/app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts
@@ -9,7 +9,10 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(
-      `/loans/${loanId}/transactions/template?command=interestPaymentWaiver&locale=en&dateFormat=dd MMMM yyyy`
+      `/loans/${loanId}/transactions/template?command=interestPaymentWaiver&locale=en&dateFormat=dd MMMM yyyy`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts
@@ -9,7 +9,10 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(
-      `/loans/${loanId}/transactions/template?command=merchantIssuedRefund&locale=en&dateFormat=dd MMMM yyyy`
+      `/loans/${loanId}/transactions/template?command=merchantIssuedRefund&locale=en&dateFormat=dd MMMM yyyy`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts
@@ -9,7 +9,10 @@ export async function GET(
     const { id: loanId } = await params;
     
     const data = await fetchFineractAPI(
-      `/loans/${loanId}/transactions/template?command=payoutRefund&locale=en&dateFormat=dd MMMM yyyy`
+      `/loans/${loanId}/transactions/template?command=payoutRefund&locale=en&dateFormat=dd MMMM yyyy`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/loans/[id]/transactions/template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/template/route.ts
@@ -21,7 +21,9 @@ export async function GET(
       );
     }
 
-    const data = await fetchFineractAPI(`/loans/${id}/transactions/template?command=${command}`);
+    const data = await fetchFineractAPI(`/loans/${id}/transactions/template?command=${command}`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching loan transaction template:', error);

--- a/app/api/fineract/loans/[id]/undodisbursal/route.ts
+++ b/app/api/fineract/loans/[id]/undodisbursal/route.ts
@@ -24,7 +24,9 @@ export async function POST(
           getActiveFacilityForClient(Number(fineractClientId)),
         ]);
         if (link && facility) {
-          const loanDetails = await fetchFineractAPI(`/loans/${loanId}`);
+          const loanDetails = await fetchFineractAPI(`/loans/${loanId}`, {
+            authMode: "service",
+          });
           const disbursedAmount = loanDetails?.approvedPrincipal ?? loanDetails?.principal ?? 0;
           await updateFacility(Number(fineractClientId), facility.id, {
             utilized_amount: Math.max(0, facility.utilized_amount - disbursedAmount),

--- a/app/api/fineract/loans/product/[id]/route.ts
+++ b/app/api/fineract/loans/product/[id]/route.ts
@@ -11,7 +11,9 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const data = await fetchFineractAPI(`/loanproducts/${id}`);
+    const data = await fetchFineractAPI(`/loanproducts/${id}`, {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan product:", error);

--- a/app/api/fineract/paymenttypes/route.ts
+++ b/app/api/fineract/paymenttypes/route.ts
@@ -7,7 +7,9 @@ import { fetchFineractAPI } from "@/lib/api";
  */
 export async function GET() {
   try {
-    const data = await fetchFineractAPI("/paymenttypes");
+    const data = await fetchFineractAPI("/paymenttypes", {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching payment types:", error);

--- a/app/api/fineract/reports/route.ts
+++ b/app/api/fineract/reports/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getFineractServiceWithSession } from "@/lib/fineract-api";
+import { getFineractServiceWithServiceAuth } from "@/lib/fineract-api";
 
 const isPentahoReport = (report: unknown) => {
   if (!report || typeof report !== "object") {
@@ -15,7 +15,7 @@ const isPentahoReport = (report: unknown) => {
 
 export async function GET(request: NextRequest) {
   try {
-    const fineractService = await getFineractServiceWithSession();
+    const fineractService = await getFineractServiceWithServiceAuth();
     const { searchParams } = new URL(request.url);
     const reportName = searchParams.get("reportName");
     const action = searchParams.get("action");

--- a/app/api/fineract/rescheduleloans/[id]/route.ts
+++ b/app/api/fineract/rescheduleloans/[id]/route.ts
@@ -20,7 +20,10 @@ export async function GET(
     const query = searchParams.toString();
 
     const data = await fetchFineractAPI(
-      `/rescheduleloans/${id}${query ? `?${query}` : ''}`
+      `/rescheduleloans/${id}${query ? `?${query}` : ''}`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/rescheduleloans/route.ts
+++ b/app/api/fineract/rescheduleloans/route.ts
@@ -23,7 +23,10 @@ export async function GET(request: Request) {
     }
 
     const data = await fetchFineractAPI(
-      `/rescheduleloans${query ? `?${query}` : ''}`
+      `/rescheduleloans${query ? `?${query}` : ''}`,
+      {
+        authMode: "service",
+      }
     );
 
     return NextResponse.json(data);

--- a/app/api/fineract/rescheduleloans/template/route.ts
+++ b/app/api/fineract/rescheduleloans/template/route.ts
@@ -7,7 +7,9 @@ import { fetchFineractAPI } from '@/lib/api';
  */
 export async function GET() {
   try {
-    const data = await fetchFineractAPI('/rescheduleloans/template');
+    const data = await fetchFineractAPI('/rescheduleloans/template', {
+      authMode: "service",
+    });
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching reschedule loan template:', error);

--- a/lib/__tests__/loan-details-office-gate.test.ts
+++ b/lib/__tests__/loan-details-office-gate.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/testdb";
+
+test("flags loan details actions that must be blocked across branches", async () => {
+  const {
+    isLoanDetailsOfficeRestrictedAction,
+  } = await import("../loan-details-office-gate");
+
+  assert.equal(isLoanDetailsOfficeRestrictedAction("add-charge"), true);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("make-repayment"), true);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("reverse-payout"), true);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("approve-loan"), false);
+  assert.equal(isLoanDetailsOfficeRestrictedAction(null), false);
+});
+
+test("builds a transfer requirement when the loan client belongs to another branch", async () => {
+  const {
+    getLoanDetailsOfficeTransferRequirement,
+  } = await import("../loan-details-office-gate");
+
+  const requirement = getLoanDetailsOfficeTransferRequirement({
+    clientId: 104,
+    clientDisplayName: "Jane Doe",
+    clientOfficeId: 12,
+    clientOfficeName: "Kitwe",
+    userOfficeId: 5,
+    userOfficeName: "Lusaka",
+  });
+
+  assert.deepEqual(requirement, {
+    clientId: 104,
+    clientDisplayName: "Jane Doe",
+    clientOfficeId: 12,
+    clientOfficeName: "Kitwe",
+    destinationOfficeId: 5,
+    destinationOfficeName: "Lusaka",
+  });
+});
+
+test("falls back to the loan office when the client payload does not include office details", async () => {
+  const {
+    getLoanDetailsOfficeTransferRequirement,
+  } = await import("../loan-details-office-gate");
+
+  const requirement = getLoanDetailsOfficeTransferRequirement({
+    clientId: 104,
+    clientDisplayName: "Jane Doe",
+    clientOfficeId: undefined,
+    clientOfficeName: undefined,
+    loanOfficeId: 8,
+    loanOfficeName: "Ndola",
+    userOfficeId: 5,
+    userOfficeName: "Lusaka",
+  });
+
+  assert.deepEqual(requirement, {
+    clientId: 104,
+    clientDisplayName: "Jane Doe",
+    clientOfficeId: 8,
+    clientOfficeName: "Ndola",
+    destinationOfficeId: 5,
+    destinationOfficeName: "Lusaka",
+  });
+});
+
+test("does not require a transfer when the loan client already belongs to the user's branch", async () => {
+  const {
+    getLoanDetailsOfficeTransferRequirement,
+  } = await import("../loan-details-office-gate");
+
+  const requirement = getLoanDetailsOfficeTransferRequirement({
+    clientId: 104,
+    clientDisplayName: "Jane Doe",
+    clientOfficeId: 5,
+    clientOfficeName: "Lusaka",
+    userOfficeId: 5,
+    userOfficeName: "Lusaka",
+  });
+
+  assert.equal(requirement, null);
+});

--- a/lib/__tests__/loan-details-service-auth.test.ts
+++ b/lib/__tests__/loan-details-service-auth.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("loan details Fineract GET surface is wired to service auth", () => {
+  const filesWithServiceAuthExpectation: Array<{
+    path: string;
+    pattern: RegExp;
+  }> = [
+    {
+      path: "app/api/fineract/loans/[id]/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/product/[id]/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/paymenttypes/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/reports/route.ts",
+      pattern: /getFineractServiceWithServiceAuth/,
+    },
+    {
+      path: "app/api/fineract/rescheduleloans/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/rescheduleloans/template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/rescheduleloans/[id]/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/approve/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/collaterals/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/collaterals/template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/documents/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/notes/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/interest-pauses/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/charges/template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/guarantors/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/guarantors/template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/disburse/route.ts",
+      pattern: /fetchFineractAPI\(`\/loans\/\$\{id\}`,\s*\{\s*authMode:\s*"service"/,
+    },
+    {
+      path: "app/api/fineract/loans/[id]/undodisbursal/route.ts",
+      pattern:
+        /fetchFineractAPI\(`\/loans\/\$\{loanId\}`,\s*\{\s*authMode:\s*"service"/,
+    },
+    {
+      path: "lib/fineract-credit-facility.ts",
+      pattern: /authMode:\s*"service"/,
+    },
+  ];
+
+  for (const file of filesWithServiceAuthExpectation) {
+    const source = readRepoFile(file.path);
+    assert.match(source, file.pattern, `${file.path} should opt into service auth`);
+  }
+});
+
+test("raw loan details routes build service-authenticated Fineract requests", () => {
+  const rawRouteFiles = [
+    "app/api/fineract/loans/[id]/statement/route.ts",
+    "app/api/fineract/loans/[id]/old/[oldId]/statement/route.ts",
+    "app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts",
+  ];
+
+  for (const file of rawRouteFiles) {
+    const source = readRepoFile(file);
+    assert.match(source, /buildFineractRequest/, `${file} should use the shared request builder`);
+    assert.match(source, /authMode:\s*"service"/, `${file} should request service auth`);
+  }
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -16,6 +16,12 @@ export type FineractRequestInit = RequestInit & {
   authMode?: FineractAuthMode;
 };
 
+type FineractRequestConfig = {
+  headers: Record<string, string>;
+  requestOptions: RequestInit;
+  url: string;
+};
+
 /**
  * Get access token - prefer the logged-in user's Fineract session and
  * fall back to the service token when no session is available.
@@ -56,6 +62,42 @@ export async function getAccessToken(): Promise<string> {
   return SERVICE_TOKEN;
 }
 
+async function resolveFineractAuthToken(
+  authMode: FineractAuthMode
+): Promise<string> {
+  return authMode === "service" ? SERVICE_TOKEN : await getAccessToken();
+}
+
+export async function buildFineractRequest(
+  endpoint: string,
+  options: FineractRequestInit = {},
+  version: "v1" | "v2" = "v1"
+): Promise<FineractRequestConfig> {
+  const { authMode = "session", ...requestOptions } = options;
+  const accessToken = await resolveFineractAuthToken(authMode);
+  const fineractTenantId = await getFineractTenantIdFromService();
+
+  const url = `${baseUrl}/fineract-provider/api/${version}${
+    endpoint.startsWith("/") ? endpoint : `/${endpoint}`
+  }`;
+
+  const headers: Record<string, string> = {
+    ...(requestOptions.headers as Record<string, string> | undefined),
+    Authorization: `Basic ${accessToken}`,
+    "Fineract-Platform-TenantId": fineractTenantId,
+  };
+
+  if (!(requestOptions.body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  return {
+    headers,
+    requestOptions,
+    url,
+  };
+}
+
 /**
  * Makes an authenticated request to the Fineract API
  * @param endpoint - The API endpoint to call (without the base URL)
@@ -68,26 +110,11 @@ export async function fetchFineractAPI(
   options: FineractRequestInit = {},
   version: "v1" | "v2" = "v1"
 ) {
-  const { authMode = "session", ...requestOptions } = options;
-  const accessToken =
-    authMode === "service" ? SERVICE_TOKEN : await getAccessToken();
-  const fineractTenantId = await getFineractTenantIdFromService();
-
-  const url = `${baseUrl}/fineract-provider/api/${version}${
-    endpoint.startsWith("/") ? endpoint : `/${endpoint}`
-  }`;
-
-  const headers: any = {
-    ...requestOptions.headers,
-    Authorization: `Basic ${accessToken}`,
-    "Fineract-Platform-TenantId": fineractTenantId,
-  };
-
-  // Only set Content-Type to application/json if body is NOT FormData
-  // For FormData, let the browser set the correct Content-Type with boundary
-  if (!(requestOptions.body instanceof FormData)) {
-    headers["Content-Type"] = "application/json";
-  }
+  const { headers, requestOptions, url } = await buildFineractRequest(
+    endpoint,
+    options,
+    version
+  );
 
   try {
     let response;

--- a/lib/fineract-api.ts
+++ b/lib/fineract-api.ts
@@ -1676,6 +1676,21 @@ export async function getFineractServiceWithSession(): Promise<FineractAPIServic
   }
 }
 
+export async function getFineractServiceWithServiceAuth(): Promise<FineractAPIService> {
+  try {
+    const { getFineractTenantId } = await import("./fineract-tenant-service");
+    const fineractTenantId = await getFineractTenantId();
+    return getFineractService(SERVICE_TOKEN, fineractTenantId);
+  } catch (error) {
+    console.error("Error in getFineractServiceWithServiceAuth:", error);
+    throw new Error(
+      `Failed to initialize service-auth Fineract service: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`
+    );
+  }
+}
+
 export async function getFineractServiceWithSystemAuth(): Promise<FineractAPIService> {
   try {
     const { getFineractTenantId } = await import("./fineract-tenant-service");

--- a/lib/fineract-credit-facility.ts
+++ b/lib/fineract-credit-facility.ts
@@ -119,7 +119,8 @@ export async function getActiveFacilityForClient(
 ): Promise<CreditFacility | null> {
   try {
     const rows: CreditFacility[] = await fetchFineractAPI(
-      `/datatables/credit_facility/${clientId}`
+      `/datatables/credit_facility/${clientId}`,
+      { authMode: "service" }
     );
     if (!Array.isArray(rows)) return null;
     return rows.find((r) => r.status === "ACTIVE") ?? null;
@@ -133,7 +134,8 @@ export async function getPendingFacilityForClient(
 ): Promise<CreditFacility | null> {
   try {
     const rows: CreditFacility[] = await fetchFineractAPI(
-      `/datatables/credit_facility/${clientId}`
+      `/datatables/credit_facility/${clientId}`,
+      { authMode: "service" }
     );
     if (!Array.isArray(rows)) return null;
     return rows.find((r) => r.status === "PENDING") ?? null;
@@ -148,7 +150,8 @@ export async function getFacilityByRef(
 ): Promise<CreditFacility | null> {
   try {
     const rows: CreditFacility[] = await fetchFineractAPI(
-      `/datatables/credit_facility/${clientId}`
+      `/datatables/credit_facility/${clientId}`,
+      { authMode: "service" }
     );
     if (!Array.isArray(rows)) return null;
     return rows.find((r) => r.facility_ref === facilityRef) ?? null;
@@ -188,7 +191,8 @@ export async function getFacilityLoanLink(
 ): Promise<CreditFacilityLoan | null> {
   try {
     const result = await fetchFineractAPI(
-      `/datatables/credit_facility_loan/${loanId}`
+      `/datatables/credit_facility_loan/${loanId}`,
+      { authMode: "service" }
     );
     // Fineract returns an array even for non-multiRow datatables
     const row = Array.isArray(result) ? result[0] : result;

--- a/lib/loan-details-office-gate.ts
+++ b/lib/loan-details-office-gate.ts
@@ -1,0 +1,52 @@
+import {
+  getExistingClientTransferRequirement,
+  normalizeOfficeId,
+  type ExistingClientTransferRequirement,
+  type OfficeIdValue,
+} from "./fineract-client-office-transfer";
+
+export const LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS = [
+  "add-charge",
+  "make-repayment",
+  "reverse-payout",
+] as const;
+
+export type LoanDetailsOfficeRestrictedAction =
+  (typeof LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS)[number];
+
+export interface LoanDetailsOfficeTransferRequirementInput {
+  clientId: number;
+  clientDisplayName: string;
+  clientOfficeId: OfficeIdValue;
+  clientOfficeName?: string | null;
+  loanOfficeId?: OfficeIdValue;
+  loanOfficeName?: string | null;
+  userOfficeId: OfficeIdValue;
+  userOfficeName?: string | null;
+}
+
+export function isLoanDetailsOfficeRestrictedAction(
+  action: string | null | undefined
+): action is LoanDetailsOfficeRestrictedAction {
+  return LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS.includes(
+    action as LoanDetailsOfficeRestrictedAction
+  );
+}
+
+export function getLoanDetailsOfficeTransferRequirement(
+  input: LoanDetailsOfficeTransferRequirementInput
+): ExistingClientTransferRequirement | null {
+  const resolvedClientOfficeId =
+    normalizeOfficeId(input.clientOfficeId) ?? normalizeOfficeId(input.loanOfficeId);
+  const resolvedClientOfficeName =
+    input.clientOfficeName?.trim() || input.loanOfficeName?.trim() || null;
+
+  return getExistingClientTransferRequirement({
+    clientId: input.clientId,
+    clientDisplayName: input.clientDisplayName.trim() || "This client",
+    clientOfficeId: resolvedClientOfficeId,
+    clientOfficeName: resolvedClientOfficeName,
+    creatorOfficeId: input.userOfficeId,
+    creatorOfficeName: input.userOfficeName,
+  });
+}


### PR DESCRIPTION
## Summary
- use service-account auth for Fineract GETs reachable from the loan details page
- gate loan details actions by client and logged-in user office match, and prompt client transfer on mismatch
- add focused regression coverage for loan details auth and office-gated actions

## Test Plan
- node --import tsx --test 'lib/__tests__/loan-details-office-gate.test.ts' 'lib/__tests__/loan-details-service-auth.test.ts'
- pnpm build
