### PR TITLE
Remove loan details branch transfer restrictions

### DIFF
--- a/lib/__tests__/loan-details-office-gate.test.ts
+++ b/lib/__tests__/loan-details-office-gate.test.ts
@@ -3,19 +3,19 @@ import test from "node:test";
 
 process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/testdb";
 
-test("flags loan details actions that must be blocked across branches", async () => {
+test("does not flag loan details actions as office-restricted", async () => {
   const {
     isLoanDetailsOfficeRestrictedAction,
   } = await import("../loan-details-office-gate");
 
-  assert.equal(isLoanDetailsOfficeRestrictedAction("add-charge"), true);
-  assert.equal(isLoanDetailsOfficeRestrictedAction("make-repayment"), true);
-  assert.equal(isLoanDetailsOfficeRestrictedAction("reverse-payout"), true);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("add-charge"), false);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("make-repayment"), false);
+  assert.equal(isLoanDetailsOfficeRestrictedAction("reverse-payout"), false);
   assert.equal(isLoanDetailsOfficeRestrictedAction("approve-loan"), false);
   assert.equal(isLoanDetailsOfficeRestrictedAction(null), false);
 });
 
-test("builds a transfer requirement when the loan client belongs to another branch", async () => {
+test("does not require a transfer when the loan client belongs to another branch", async () => {
   const {
     getLoanDetailsOfficeTransferRequirement,
   } = await import("../loan-details-office-gate");
@@ -29,17 +29,10 @@ test("builds a transfer requirement when the loan client belongs to another bran
     userOfficeName: "Lusaka",
   });
 
-  assert.deepEqual(requirement, {
-    clientId: 104,
-    clientDisplayName: "Jane Doe",
-    clientOfficeId: 12,
-    clientOfficeName: "Kitwe",
-    destinationOfficeId: 5,
-    destinationOfficeName: "Lusaka",
-  });
+  assert.equal(requirement, null);
 });
 
-test("falls back to the loan office when the client payload does not include office details", async () => {
+test("does not require a transfer when only the loan office differs", async () => {
   const {
     getLoanDetailsOfficeTransferRequirement,
   } = await import("../loan-details-office-gate");
@@ -55,14 +48,7 @@ test("falls back to the loan office when the client payload does not include off
     userOfficeName: "Lusaka",
   });
 
-  assert.deepEqual(requirement, {
-    clientId: 104,
-    clientDisplayName: "Jane Doe",
-    clientOfficeId: 8,
-    clientOfficeName: "Ndola",
-    destinationOfficeId: 5,
-    destinationOfficeName: "Lusaka",
-  });
+  assert.equal(requirement, null);
 });
 
 test("does not require a transfer when the loan client already belongs to the user's branch", async () => {

--- a/lib/loan-details-office-gate.ts
+++ b/lib/loan-details-office-gate.ts
@@ -1,15 +1,9 @@
-import {
-  getExistingClientTransferRequirement,
-  normalizeOfficeId,
-  type ExistingClientTransferRequirement,
-  type OfficeIdValue,
+import type {
+  ExistingClientTransferRequirement,
+  OfficeIdValue,
 } from "./fineract-client-office-transfer";
 
-export const LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS = [
-  "add-charge",
-  "make-repayment",
-  "reverse-payout",
-] as const;
+export const LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS = [] as const;
 
 export type LoanDetailsOfficeRestrictedAction =
   (typeof LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS)[number];
@@ -26,27 +20,13 @@ export interface LoanDetailsOfficeTransferRequirementInput {
 }
 
 export function isLoanDetailsOfficeRestrictedAction(
-  action: string | null | undefined
-): action is LoanDetailsOfficeRestrictedAction {
-  return LOAN_DETAILS_OFFICE_RESTRICTED_ACTIONS.includes(
-    action as LoanDetailsOfficeRestrictedAction
-  );
+  _action: string | null | undefined
+): _action is LoanDetailsOfficeRestrictedAction {
+  return false;
 }
 
 export function getLoanDetailsOfficeTransferRequirement(
-  input: LoanDetailsOfficeTransferRequirementInput
+  _input: LoanDetailsOfficeTransferRequirementInput
 ): ExistingClientTransferRequirement | null {
-  const resolvedClientOfficeId =
-    normalizeOfficeId(input.clientOfficeId) ?? normalizeOfficeId(input.loanOfficeId);
-  const resolvedClientOfficeName =
-    input.clientOfficeName?.trim() || input.loanOfficeName?.trim() || null;
-
-  return getExistingClientTransferRequirement({
-    clientId: input.clientId,
-    clientDisplayName: input.clientDisplayName.trim() || "This client",
-    clientOfficeId: resolvedClientOfficeId,
-    clientOfficeName: resolvedClientOfficeName,
-    creatorOfficeId: input.userOfficeId,
-    creatorOfficeName: input.userOfficeName,
-  });
+  return null;
 }


### PR DESCRIPTION
## Summary
- remove the loan details office gate so loan actions are no longer branch-restricted
- stop generating the client transfer requirement that drove the loan details warning badge
- update the focused regression test to assert unrestricted loan details behavior

## Test Plan
- ./node_modules/.bin/tsx --test lib/__tests__/loan-details-office-gate.test.ts