### PR TITLE
Show repayment creator from loan transaction source

### DIFF
--- a/app/(application)/clients/[id]/loans/[loanId]/transactions/[transactionId]/page.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/transactions/[transactionId]/page.tsx
@@ -17,13 +17,37 @@ import { toast } from "@/components/ui/use-toast";
 interface LoanResponse {
   id: number;
   currency?: { code: string; name: string };
-  transactions?: any[];
+  transactions?: LoanTransaction[];
 }
 
 interface PaymentTypeOption {
   id: number;
   name: string;
   isCashPayment?: boolean;
+}
+
+interface PaymentTypesResponse {
+  pageItems?: PaymentTypeOption[];
+}
+
+interface LoanTransaction {
+  id: number;
+  transactionId?: string | null;
+  externalId?: string | null;
+  amount?: number;
+  date?: number[];
+  manuallyReversed?: boolean;
+  type?: {
+    repayment?: boolean;
+    recoveryRepayment?: boolean;
+    disbursement?: boolean;
+  };
+  paymentDetailData?: {
+    paymentType?: {
+      id?: number;
+      name?: string;
+    };
+  };
 }
 
 interface RepaymentCashLinkData {
@@ -43,17 +67,21 @@ interface RepaymentCashLinkData {
   reversedAt?: string | null;
 }
 
+interface LoanTransactionCreatorResponse {
+  name?: string | null;
+  source?: "journal" | "report" | "none";
+}
+
 export default function TransactionDetailsPage() {
   const router = useRouter();
   const params = useParams();
-  const clientId = params.id as string;
   const loanId = params.loanId as string;
   const transactionId = Number(params.transactionId as string);
 
   const { currencyCode: orgCurrency } = useCurrency();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [transaction, setTransaction] = useState<any | null>(null);
+  const [transaction, setTransaction] = useState<LoanTransaction | null>(null);
   const [loanCurrency, setLoanCurrency] = useState<string>("");
   const [showChargeback, setShowChargeback] = useState(false);
   const [showUndo, setShowUndo] = useState(false);
@@ -65,6 +93,8 @@ export default function TransactionDetailsPage() {
   const [undoError, setUndoError] = useState<string | null>(null);
   const [repaymentLink, setRepaymentLink] = useState<RepaymentCashLinkData | null>(null);
   const [loadingRepaymentLink, setLoadingRepaymentLink] = useState(false);
+  const [repaymentCreatorName, setRepaymentCreatorName] = useState<string | null>(null);
+  const [loadingRepaymentCreator, setLoadingRepaymentCreator] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -75,28 +105,28 @@ export default function TransactionDetailsPage() {
         if (!res.ok) throw new Error(`Failed to fetch loan: ${res.statusText}`);
         const data: LoanResponse = await res.json();
         setLoanCurrency(data.currency?.code || orgCurrency);
-        const tx = (data.transactions || []).find((t: any) => Number(t.id) === transactionId);
+        const tx = (data.transactions || []).find((t) => Number(t.id) === transactionId);
         setTransaction(tx || null);
         if (!tx) setError("Transaction not found");
-      } catch (e: any) {
-        setError(e.message || "Unknown error");
+      } catch (error: unknown) {
+        setError(error instanceof Error ? error.message : "Unknown error");
       } finally {
         setLoading(false);
       }
     };
 
     fetchData();
-  }, [loanId, transactionId]);
+  }, [loanId, orgCurrency, transactionId]);
 
   useEffect(() => {
     const fetchPaymentTypes = async () => {
       try {
         const res = await fetch('/api/fineract/paymenttypes');
         if (!res.ok) return;
-        const data = await res.json();
+        const data: PaymentTypeOption[] | PaymentTypesResponse = await res.json();
         if (Array.isArray(data)) {
           setPaymentTypes(
-            data.map((p: any) => ({
+            data.map((p) => ({
               id: p.id,
               name: p.name,
               isCashPayment: p.isCashPayment,
@@ -104,7 +134,7 @@ export default function TransactionDetailsPage() {
           );
         } else if (Array.isArray(data.pageItems)) {
           setPaymentTypes(
-            data.pageItems.map((p: any) => ({
+            data.pageItems.map((p) => ({
               id: p.id,
               name: p.name,
               isCashPayment: p.isCashPayment,
@@ -126,6 +156,52 @@ export default function TransactionDetailsPage() {
   );
   const isCashRepaymentUndo =
     isRepaymentTransaction && !!transactionPaymentType?.isCashPayment;
+
+  useEffect(() => {
+    if (!isRepaymentTransaction || !transaction) {
+      setRepaymentCreatorName(null);
+      setLoadingRepaymentCreator(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchRepaymentCreator = async () => {
+      try {
+        setLoadingRepaymentCreator(true);
+        const response = await fetch(
+          `/api/fineract/loans/${loanId}/transactions/${transactionId}/creator`
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch repayment creator: ${response.statusText}`
+          );
+        }
+
+        const data: LoanTransactionCreatorResponse = await response.json();
+
+        if (!cancelled) {
+          setRepaymentCreatorName(data.name?.trim() || null);
+        }
+      } catch (err) {
+        console.error("Error fetching repayment creator:", err);
+        if (!cancelled) {
+          setRepaymentCreatorName(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingRepaymentCreator(false);
+        }
+      }
+    };
+
+    void fetchRepaymentCreator();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isRepaymentTransaction, loanId, transaction, transactionId]);
 
   useEffect(() => {
     if (showUndo && isCashRepaymentUndo) {
@@ -255,6 +331,16 @@ export default function TransactionDetailsPage() {
               <div className="text-sm text-muted-foreground">Payment Type</div>
               <div className="font-medium">{transaction?.paymentDetailData?.paymentType?.name || ""}</div>
             </div>
+            {isRepaymentTransaction && (
+              <div className="space-y-1">
+                <div className="text-sm text-muted-foreground">Recorded By</div>
+                <div className="font-medium">
+                  {loadingRepaymentCreator
+                    ? "Loading..."
+                    : repaymentCreatorName || "Not available"}
+                </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/app/api/fineract/loans/[id]/transactions/[transactionId]/creator/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/[transactionId]/creator/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getLoanTransactionCreator } from "@/lib/fineract-loan-transaction-creator";
+
+export async function GET(
+  _request: Request,
+  {
+    params,
+  }: {
+    params: Promise<{ id: string; transactionId: string }>;
+  }
+) {
+  try {
+    const { transactionId } = await params;
+    const loanTransactionId = Number(transactionId);
+
+    if (!Number.isInteger(loanTransactionId) || loanTransactionId <= 0) {
+      return NextResponse.json(
+        { error: "A valid loan transaction id is required" },
+        { status: 400 }
+      );
+    }
+
+    const creator = await getLoanTransactionCreator({
+      loanTransactionId,
+    });
+
+    return NextResponse.json(creator);
+  } catch (error: unknown) {
+    console.error("Error fetching loan transaction creator:", error);
+
+    return NextResponse.json(
+      {
+        error: "Failed to fetch loan transaction creator",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/__tests__/loan-transaction-creator.test.ts
+++ b/lib/__tests__/loan-transaction-creator.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("builds the journal transaction reference for a loan transaction", async () => {
+  let mod: Record<string, unknown>;
+
+  try {
+    mod = await import("../loan-transaction-creator");
+  } catch {
+    mod = {};
+  }
+
+  assert.equal(typeof mod.getLoanTransactionJournalReference, "function");
+
+  const getLoanTransactionJournalReference = mod.getLoanTransactionJournalReference as (
+    transaction: Record<string, unknown>
+  ) => string | null;
+
+  assert.equal(
+    getLoanTransactionJournalReference({ transactionId: "L412707", id: 412707 }),
+    "L412707"
+  );
+  assert.equal(
+    getLoanTransactionJournalReference({ externalId: "L493655", id: 493655 }),
+    "L493655"
+  );
+  assert.equal(getLoanTransactionJournalReference({ id: 1042324 }), "L1042324");
+});
+
+test("extracts the repayment creator name from journal entries", async () => {
+  let mod: Record<string, unknown>;
+
+  try {
+    mod = await import("../loan-transaction-creator");
+  } catch {
+    mod = {};
+  }
+
+  assert.equal(typeof mod.getJournalEntriesCreatorName, "function");
+
+  const getJournalEntriesCreatorName = mod.getJournalEntriesCreatorName as (
+    payload: Record<string, unknown>
+  ) => string | null;
+
+  assert.equal(
+    getJournalEntriesCreatorName({
+      pageItems: [
+        { createdByUserName: "" },
+        { createdByUserName: "ELIAH.NYIRENDA" },
+      ],
+    }),
+    "ELIAH.NYIRENDA"
+  );
+});
+
+test("returns null when journal entries do not expose a creator name", async () => {
+  let mod: Record<string, unknown>;
+
+  try {
+    mod = await import("../loan-transaction-creator");
+  } catch {
+    mod = {};
+  }
+
+  assert.equal(typeof mod.getJournalEntriesCreatorName, "function");
+
+  const getJournalEntriesCreatorName = mod.getJournalEntriesCreatorName as (
+    payload: Record<string, unknown>
+  ) => string | null;
+
+  assert.equal(
+    getJournalEntriesCreatorName({
+      pageItems: [{ createdByUserName: "" }, { createdByUserName: "   " }],
+    }),
+    null
+  );
+  assert.equal(getJournalEntriesCreatorName({ pageItems: [] }), null);
+});
+
+test("falls back to the loan transaction creator report when journal entries are absent", async () => {
+  let mod: Record<string, unknown>;
+
+  try {
+    mod = await import("../loan-transaction-creator");
+  } catch {
+    mod = {};
+  }
+
+  assert.equal(typeof mod.resolveLoanTransactionCreatorName, "function");
+
+  const resolveLoanTransactionCreatorName = mod.resolveLoanTransactionCreatorName as (
+    payload: Record<string, unknown>
+  ) => string | null;
+
+  assert.equal(
+    resolveLoanTransactionCreatorName({
+      journalEntriesPayload: { pageItems: [] },
+      reportPayload: [{ created_by_user_name: "ELIAH.NYIRENDA" }],
+    }),
+    "ELIAH.NYIRENDA"
+  );
+});
+
+test("prefers the loan transaction creator report over journal entries", async () => {
+  let mod: Record<string, unknown>;
+
+  try {
+    mod = await import("../loan-transaction-creator");
+  } catch {
+    mod = {};
+  }
+
+  assert.equal(typeof mod.resolveLoanTransactionCreatorName, "function");
+
+  const resolveLoanTransactionCreatorName = mod.resolveLoanTransactionCreatorName as (
+    payload: Record<string, unknown>
+  ) => string | null;
+
+  assert.equal(
+    resolveLoanTransactionCreatorName({
+      journalEntriesPayload: {
+        pageItems: [{ createdByUserName: "App Administrator" }],
+      },
+      reportPayload: [{ created_by_user_name: "system" }],
+    }),
+    "system"
+  );
+});

--- a/lib/fineract-loan-transaction-creator.ts
+++ b/lib/fineract-loan-transaction-creator.ts
@@ -1,0 +1,128 @@
+import "server-only";
+
+import { fetchFineractAPI } from "@/lib/api";
+import { resolveLoanTransactionCreatorName } from "@/lib/loan-transaction-creator";
+
+export const LOAN_TRANSACTION_CREATOR_REPORT =
+  "LM_LOAN_TRANSACTION_CREATOR_LOOKUP_V2";
+
+const LOAN_TRANSACTION_CREATOR_PARAMETER_ID = 1006;
+
+let reportSetupPromise: Promise<void> | null = null;
+
+function isAlreadyExistsError(error: unknown): boolean {
+  const err = error as { message?: string; status?: number; errorData?: unknown };
+  const message = [
+    err?.message,
+    typeof err?.errorData === "object" && err.errorData
+      ? JSON.stringify(err.errorData)
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    err?.status === 409 ||
+    message.includes("already") ||
+    message.includes("exist")
+  );
+}
+
+async function setupLoanTransactionCreatorReport(): Promise<void> {
+  const report = {
+    reportName: LOAN_TRANSACTION_CREATOR_REPORT,
+    reportType: "Table",
+    reportSubType: "",
+    reportCategory: "Loans",
+    description:
+      "Lookup the Fineract user who created a specific loan transaction.",
+    useReport: true,
+    reportSql: `SELECT lt.id AS loan_transaction_id,
+       lt.loan_id,
+       COALESCE(NULLIF(TRIM(CONCAT(COALESCE(au.firstname, ''), ' ', COALESCE(au.lastname, ''))), ''), au.username) AS created_by_user_name,
+       au.username AS created_by_username
+FROM m_loan_transaction lt
+JOIN m_appuser au ON au.id = lt.created_by
+WHERE lt.id = COALESCE(NULLIF(regexp_replace('\${transactionId}', '[^0-9]', '', 'g'), '')::bigint, -1)`,
+    reportParameters: [
+      {
+        parameterId: LOAN_TRANSACTION_CREATOR_PARAMETER_ID,
+        reportParameterName: "transactionId",
+      },
+    ],
+  };
+
+  let existingReports: Array<{ id: number; reportName: string }> = [];
+
+  try {
+    existingReports =
+      (await fetchFineractAPI("/reports", {
+        authMode: "service",
+        cache: "no-store",
+      })) ?? [];
+  } catch {
+    existingReports = [];
+  }
+
+  const existingId = existingReports.find(
+    (existing) => existing.reportName === report.reportName
+  )?.id;
+
+  try {
+    if (existingId) {
+      await fetchFineractAPI(`/reports/${existingId}`, {
+        authMode: "service",
+        method: "PUT",
+        body: JSON.stringify(report),
+      });
+      return;
+    }
+
+    await fetchFineractAPI("/reports", {
+      authMode: "service",
+      method: "POST",
+      body: JSON.stringify(report),
+    });
+  } catch (error: unknown) {
+    if (!isAlreadyExistsError(error)) {
+      throw error;
+    }
+  }
+}
+
+async function ensureLoanTransactionCreatorReport(): Promise<void> {
+  if (!reportSetupPromise) {
+    reportSetupPromise = setupLoanTransactionCreatorReport().catch((error) => {
+      reportSetupPromise = null;
+      throw error;
+    });
+  }
+
+  await reportSetupPromise;
+}
+
+export async function getLoanTransactionCreator(options: {
+  loanTransactionId: number;
+}): Promise<{ name: string | null; source: "report" | "none" }> {
+  await ensureLoanTransactionCreatorReport();
+
+  const reportPayload = await fetchFineractAPI(
+    `/runreports/${LOAN_TRANSACTION_CREATOR_REPORT}?genericResultSet=false&R_transactionId=${encodeURIComponent(
+      String(options.loanTransactionId)
+    )}`,
+    {
+      authMode: "service",
+      cache: "no-store",
+    }
+  );
+
+  const creatorName = resolveLoanTransactionCreatorName({
+    reportPayload,
+  });
+
+  return {
+    name: creatorName,
+    source: creatorName ? "report" : "none",
+  };
+}

--- a/lib/loan-transaction-creator.ts
+++ b/lib/loan-transaction-creator.ts
@@ -1,0 +1,143 @@
+type LoanTransactionReferenceCandidate = {
+  id?: number | null;
+  transactionId?: string | null;
+  externalId?: string | null;
+};
+
+type JournalEntryCandidate = {
+  createdByUserName?: string | null;
+};
+
+type JournalEntriesPayload = {
+  pageItems?: JournalEntryCandidate[] | null;
+};
+
+type ReportRow = Record<string, unknown>;
+
+type ReportPayload =
+  | ReportRow[]
+  | {
+      columnHeaders?: Array<{ columnName?: string; name?: string } | string>;
+      data?: Array<{ row?: unknown[] } | unknown[]>;
+      pageItems?: ReportRow[] | null;
+    }
+  | null
+  | undefined;
+
+export function getLoanTransactionJournalReference(
+  transaction: LoanTransactionReferenceCandidate | null | undefined
+): string | null {
+  if (!transaction) return null;
+
+  if (
+    typeof transaction.transactionId === "string" &&
+    /^L\d+$/.test(transaction.transactionId)
+  ) {
+    return transaction.transactionId;
+  }
+
+  if (
+    typeof transaction.externalId === "string" &&
+    /^L\d+$/.test(transaction.externalId)
+  ) {
+    return transaction.externalId;
+  }
+
+  if (typeof transaction.id === "number" && Number.isFinite(transaction.id)) {
+    return `L${transaction.id}`;
+  }
+
+  return null;
+}
+
+export function getJournalEntriesCreatorName(
+  payload: JournalEntriesPayload | null | undefined
+): string | null {
+  if (!payload?.pageItems?.length) return null;
+
+  for (const entry of payload.pageItems) {
+    const candidate = entry?.createdByUserName?.trim();
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
+function parseReportRows(payload: ReportPayload): ReportRow[] {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== "object") return [];
+
+  if (Array.isArray(payload.pageItems)) {
+    return payload.pageItems;
+  }
+
+  if (!Array.isArray(payload.columnHeaders) || !Array.isArray(payload.data)) {
+    return [];
+  }
+
+  const columns = payload.columnHeaders.map((column) => {
+    const name =
+      typeof column === "string" ? column : column.columnName || column.name || "";
+
+    return String(name)
+      .trim()
+      .toLowerCase()
+      .replaceAll(" ", "_");
+  });
+
+  return payload.data.map((item) => {
+    const values = Array.isArray(item) ? item : item.row || [];
+    const row: ReportRow = {};
+
+    columns.forEach((column, index) => {
+      row[column] = values[index];
+    });
+
+    return row;
+  });
+}
+
+function getRowString(
+  row: ReportRow,
+  keys: string[]
+): string | null {
+  for (const key of keys) {
+    const value = row[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+export function getLoanTransactionReportCreatorName(
+  payload: ReportPayload
+): string | null {
+  const rows = parseReportRows(payload);
+
+  for (const row of rows) {
+    const candidate = getRowString(row, [
+      "created_by_user_name",
+      "createdbyusername",
+      "created_by_username",
+      "loan_txn_user",
+      "username",
+    ]);
+
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
+export function resolveLoanTransactionCreatorName(options: {
+  journalEntriesPayload?: JournalEntriesPayload | null;
+  reportPayload?: ReportPayload;
+}): string | null {
+  return (
+    getLoanTransactionReportCreatorName(options.reportPayload) ||
+    getJournalEntriesCreatorName(options.journalEntriesPayload) ||
+    null
+  );
+}


### PR DESCRIPTION
## Summary
- show the repayment creator on loan transaction details
- resolve the creator from the Fineract loan transaction source via a stretchy report
- remove the initial journal-entry fetch so the loan-transaction source is primary

## Test Plan
- npx tsx --test lib/__tests__/loan-transaction-creator.test.ts
- npx eslint 'lib/loan-transaction-creator.ts' 'lib/fineract-loan-transaction-creator.ts' 'lib/__tests__/loan-transaction-creator.test.ts' 'app/api/fineract/loans/[id]/transactions/[transactionId]/creator/route.ts' 'app/(application)/clients/[id]/loans/[loanId]/transactions/[transactionId]/page.tsx'
- git diff --check