### PR TITLE
Use tomorrow for client transfer proposals

### DIFF
--- a/lib/__tests__/fineract-client-transfer-service-auth.test.ts
+++ b/lib/__tests__/fineract-client-transfer-service-auth.test.ts
@@ -3,6 +3,24 @@ import test from "node:test";
 
 process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/testdb";
 
+function formatExpectedTomorrowDate(baseDate = new Date()) {
+  const tomorrow = new Date(baseDate);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    timeZone: "Africa/Harare",
+  }).formatToParts(tomorrow);
+
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+
+  return `${day} ${month} ${year}`;
+}
+
 test("client transfer commands use the service account headers", async () => {
   const [{ getSearchAuthToken }, { transferClientToOfficeWithServiceAuth }] =
     await Promise.all([
@@ -47,7 +65,7 @@ test("client transfer commands use the service account headers", async () => {
   assert.equal(proposeBody.destinationOfficeId, 10);
   assert.equal(proposeBody.dateFormat, "dd MMMM yyyy");
   assert.equal(proposeBody.locale, "en");
-  assert.ok(typeof proposeBody.transferDate === "string");
+  assert.equal(proposeBody.transferDate, formatExpectedTomorrowDate());
   assert.ok(typeof proposeBody.note === "string");
 
   assert.deepEqual(Object.keys(acceptBody).sort(), ["note"]);

--- a/lib/fineract-client-transfer-service.ts
+++ b/lib/fineract-client-transfer-service.ts
@@ -15,6 +15,12 @@ function formatClientTransferDate(date = new Date()) {
   return `${day} ${month} ${year}`;
 }
 
+function getTomorrowDate(baseDate = new Date()) {
+  const tomorrow = new Date(baseDate);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow;
+}
+
 export function buildClientTransferCommandBody(args: {
   command: "proposeTransfer" | "acceptTransfer" | "rejectTransfer";
   destinationOfficeId?: number;
@@ -23,7 +29,7 @@ export function buildClientTransferCommandBody(args: {
   if (args.command === "proposeTransfer") {
     return {
       destinationOfficeId: args.destinationOfficeId,
-      transferDate: formatClientTransferDate(),
+      transferDate: formatClientTransferDate(getTomorrowDate()),
       dateFormat: "dd MMMM yyyy",
       locale: "en",
       note: args.note,


### PR DESCRIPTION
## Summary
- make client transfer proposals default to tomorrow instead of today
- keep the change in the shared transfer helper used by the dev branch flow
- update the transfer helper test to assert the tomorrow date

## Verification
- attempted `npx tsx --test lib/__tests__/fineract-client-transfer-service-auth.test.ts` but the clean worktree is missing generated Prisma artifacts (`@/app/generated/prisma`)
- attempted `npm exec eslint -- lib/fineract-client-transfer-service.ts lib/__tests__/fineract-client-transfer-service-auth.test.ts` but the clean worktree does not have the local eslint dependency graph installed
