### PR TITLE
Revert tomorrow-based client transfer proposals

### DIFF
--- a/lib/__tests__/fineract-client-transfer-service-auth.test.ts
+++ b/lib/__tests__/fineract-client-transfer-service-auth.test.ts
@@ -3,24 +3,6 @@ import test from "node:test";
 
 process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/testdb";
 
-function formatExpectedTomorrowDate(baseDate = new Date()) {
-  const tomorrow = new Date(baseDate);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-
-  const parts = new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-    timeZone: "Africa/Harare",
-  }).formatToParts(tomorrow);
-
-  const day = parts.find((part) => part.type === "day")?.value;
-  const month = parts.find((part) => part.type === "month")?.value;
-  const year = parts.find((part) => part.type === "year")?.value;
-
-  return `${day} ${month} ${year}`;
-}
-
 test("client transfer commands use the service account headers", async () => {
   const [{ getSearchAuthToken }, { transferClientToOfficeWithServiceAuth }] =
     await Promise.all([
@@ -65,7 +47,7 @@ test("client transfer commands use the service account headers", async () => {
   assert.equal(proposeBody.destinationOfficeId, 10);
   assert.equal(proposeBody.dateFormat, "dd MMMM yyyy");
   assert.equal(proposeBody.locale, "en");
-  assert.equal(proposeBody.transferDate, formatExpectedTomorrowDate());
+  assert.ok(typeof proposeBody.transferDate === "string");
   assert.ok(typeof proposeBody.note === "string");
 
   assert.deepEqual(Object.keys(acceptBody).sort(), ["note"]);

--- a/lib/fineract-client-transfer-service.ts
+++ b/lib/fineract-client-transfer-service.ts
@@ -15,12 +15,6 @@ function formatClientTransferDate(date = new Date()) {
   return `${day} ${month} ${year}`;
 }
 
-function getTomorrowDate(baseDate = new Date()) {
-  const tomorrow = new Date(baseDate);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  return tomorrow;
-}
-
 export function buildClientTransferCommandBody(args: {
   command: "proposeTransfer" | "acceptTransfer" | "rejectTransfer";
   destinationOfficeId?: number;
@@ -29,7 +23,7 @@ export function buildClientTransferCommandBody(args: {
   if (args.command === "proposeTransfer") {
     return {
       destinationOfficeId: args.destinationOfficeId,
-      transferDate: formatClientTransferDate(getTomorrowDate()),
+      transferDate: formatClientTransferDate(),
       dateFormat: "dd MMMM yyyy",
       locale: "en",
       note: args.note,


### PR DESCRIPTION
## Summary
- revert the client transfer proposal date back to the current day
- remove the temporary tomorrow-date helper from the transfer service
- restore the transfer auth test to the pre-change expectation

## Testing
- npx tsx --test lib/__tests__/fineract-client-transfer-service-auth.test.ts