### PR TITLE
Scope user signatures by tenant

### DIFF
--- a/app/actions/user-signature-actions.ts
+++ b/app/actions/user-signature-actions.ts
@@ -5,6 +5,12 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { hasPermissionServer } from "@/lib/authorization";
+import {
+  getUserSignatureCreateData,
+  getUserSignatureDeleteWhere,
+  getUserSignatureUniqueWhere,
+} from "@/lib/user-signature-scope";
+import { requireCurrentTenant } from "@/lib/user-login-service";
 import { SpecificPermission } from "@/shared/types/auth";
 
 const maxSignatureSizeBytes = 2 * 1024 * 1024;
@@ -72,9 +78,12 @@ async function resolveUserId(): Promise<number> {
 }
 
 export async function getMySignature(): Promise<{ signatureData: string | null }> {
-  const fineractUserId = await resolveUserId();
+  const [fineractUserId, tenant] = await Promise.all([
+    resolveUserId(),
+    requireCurrentTenant(),
+  ]);
   const record = await prisma.userSignature.findUnique({
-    where: { fineractUserId },
+    where: getUserSignatureUniqueWhere(tenant.id, fineractUserId),
     select: { signatureData: true },
   });
   return { signatureData: record?.signatureData ?? null };
@@ -88,18 +97,26 @@ export async function saveMySignature(
     return { success: false, error: validationError };
   }
 
-  const fineractUserId = await resolveUserId();
+  const [fineractUserId, tenant] = await Promise.all([
+    resolveUserId(),
+    requireCurrentTenant(),
+  ]);
   await prisma.userSignature.upsert({
-    where: { fineractUserId },
-    create: { fineractUserId, signatureData },
+    where: getUserSignatureUniqueWhere(tenant.id, fineractUserId),
+    create: getUserSignatureCreateData(tenant.id, fineractUserId, signatureData),
     update: { signatureData },
   });
   return { success: true };
 }
 
 export async function deleteMySignature(): Promise<{ success: boolean }> {
-  const fineractUserId = await resolveUserId();
-  await prisma.userSignature.deleteMany({ where: { fineractUserId } });
+  const [fineractUserId, tenant] = await Promise.all([
+    resolveUserId(),
+    requireCurrentTenant(),
+  ]);
+  await prisma.userSignature.deleteMany({
+    where: getUserSignatureDeleteWhere(tenant.id, fineractUserId),
+  });
   return { success: true };
 }
 
@@ -112,8 +129,9 @@ export async function getUserSignatureAction(
   );
 
   const parsed = managedUserSignatureSchema.parse({ userId });
+  const tenant = await requireCurrentTenant();
   const record = await prisma.userSignature.findUnique({
-    where: { fineractUserId: parsed.userId },
+    where: getUserSignatureUniqueWhere(tenant.id, parsed.userId),
     select: { signatureData: true },
   });
 
@@ -131,6 +149,7 @@ export async function saveUserSignatureAction(input: {
     );
 
     const parsed = managedUserSignatureSchema.parse(input);
+    const tenant = await requireCurrentTenant();
     const validationError = validateSignatureData(input.signatureData);
 
     if (validationError) {
@@ -138,11 +157,12 @@ export async function saveUserSignatureAction(input: {
     }
 
     await prisma.userSignature.upsert({
-      where: { fineractUserId: parsed.userId },
-      create: {
-        fineractUserId: parsed.userId,
-        signatureData: input.signatureData,
-      },
+      where: getUserSignatureUniqueWhere(tenant.id, parsed.userId),
+      create: getUserSignatureCreateData(
+        tenant.id,
+        parsed.userId,
+        input.signatureData
+      ),
       update: {
         signatureData: input.signatureData,
       },
@@ -172,9 +192,10 @@ export async function deleteUserSignatureAction(input: {
     );
 
     const parsed = managedUserSignatureSchema.parse(input);
+    const tenant = await requireCurrentTenant();
 
     await prisma.userSignature.deleteMany({
-      where: { fineractUserId: parsed.userId },
+      where: getUserSignatureDeleteWhere(tenant.id, parsed.userId),
     });
 
     revalidateSignaturePaths(parsed.userId);

--- a/lib/__tests__/user-signature-scope.test.ts
+++ b/lib/__tests__/user-signature-scope.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("builds tenant-scoped UserSignature query inputs", async () => {
+  const {
+    getUserSignatureCreateData,
+    getUserSignatureDeleteWhere,
+    getUserSignatureUniqueWhere,
+  } = await import("../user-signature-scope");
+
+  assert.deepEqual(getUserSignatureUniqueWhere("tenant-rulethu", 1), {
+    tenantId_fineractUserId: {
+      tenantId: "tenant-rulethu",
+      fineractUserId: 1,
+    },
+  });
+
+  assert.deepEqual(getUserSignatureDeleteWhere("tenant-rulethu", 1), {
+    tenantId: "tenant-rulethu",
+    fineractUserId: 1,
+  });
+
+  assert.deepEqual(
+    getUserSignatureCreateData(
+      "tenant-rulethu",
+      1,
+      "data:image/png;base64,aA=="
+    ),
+    {
+      tenantId: "tenant-rulethu",
+      fineractUserId: 1,
+      signatureData: "data:image/png;base64,aA==",
+    }
+  );
+});

--- a/lib/user-signature-scope.ts
+++ b/lib/user-signature-scope.ts
@@ -1,0 +1,33 @@
+export function getUserSignatureUniqueWhere(
+  tenantId: string,
+  fineractUserId: number
+) {
+  return {
+    tenantId_fineractUserId: {
+      tenantId,
+      fineractUserId,
+    },
+  };
+}
+
+export function getUserSignatureDeleteWhere(
+  tenantId: string,
+  fineractUserId: number
+) {
+  return {
+    tenantId,
+    fineractUserId,
+  };
+}
+
+export function getUserSignatureCreateData(
+  tenantId: string,
+  fineractUserId: number,
+  signatureData: string
+) {
+  return {
+    tenantId,
+    fineractUserId,
+    signatureData,
+  };
+}

--- a/prisma/migrations/20260701110000_scope_user_signatures_by_tenant/migration.sql
+++ b/prisma/migrations/20260701110000_scope_user_signatures_by_tenant/migration.sql
@@ -1,0 +1,42 @@
+-- Add tenant ownership before replacing the old global fineractUserId key.
+ALTER TABLE "UserSignature" ADD COLUMN "tenantId" TEXT;
+
+DO $$
+DECLARE
+    backfill_tenant_id TEXT;
+    tenant_count INTEGER;
+BEGIN
+    IF EXISTS (SELECT 1 FROM "UserSignature" WHERE "tenantId" IS NULL) THEN
+        SELECT COUNT(*) INTO tenant_count FROM "Tenant";
+
+        IF tenant_count = 1 THEN
+            SELECT "id" INTO backfill_tenant_id FROM "Tenant" LIMIT 1;
+        ELSE
+            SELECT "id" INTO backfill_tenant_id
+            FROM "Tenant"
+            WHERE "slug" = current_setting('loan_matrix.user_signature_backfill_tenant_slug', true)
+            LIMIT 1;
+        END IF;
+
+        IF backfill_tenant_id IS NULL THEN
+            RAISE EXCEPTION 'UserSignature tenant backfill requires exactly one tenant or SET loan_matrix.user_signature_backfill_tenant_slug before running this migration';
+        END IF;
+
+        UPDATE "UserSignature"
+        SET "tenantId" = backfill_tenant_id
+        WHERE "tenantId" IS NULL;
+    END IF;
+END $$;
+
+ALTER TABLE "UserSignature" ALTER COLUMN "tenantId" SET NOT NULL;
+
+DROP INDEX "UserSignature_fineractUserId_key";
+DROP INDEX "UserSignature_fineractUserId_idx";
+
+CREATE UNIQUE INDEX "UserSignature_tenantId_fineractUserId_key" ON "UserSignature"("tenantId", "fineractUserId");
+CREATE INDEX "UserSignature_tenantId_fineractUserId_idx" ON "UserSignature"("tenantId", "fineractUserId");
+
+ALTER TABLE "UserSignature"
+ADD CONSTRAINT "UserSignature_tenantId_fkey"
+FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Tenant {
   slaConfigs             SLAConfig[]
   teams                  Team[]
   userLogins             UserLogin[]
+  userSignatures         UserSignature[]
   userLoginBlockEvents   UserLoginBlockEvent[]
   mfaChallenges          MfaChallenge[]
   validationRules        ValidationRule[]
@@ -1476,12 +1477,15 @@ model RepaymentCashLink {
 
 model UserSignature {
   id              String   @id @default(cuid())
-  fineractUserId  Int      @unique
+  tenantId        String
+  fineractUserId  Int
   signatureData   String   @db.Text
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+  tenant          Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  @@index([fineractUserId])
+  @@unique([tenantId, fineractUserId])
+  @@index([tenantId, fineractUserId])
 }
 
 enum RevolvingCreditDrawdownStatus {


### PR DESCRIPTION
## Summary
- Adds tenant ownership to UserSignature and changes uniqueness to tenant + Fineract user.
- Scopes signature reads, saves, and deletes by the current tenant.
- Adds a guarded migration and focused test for the tenant-scoped query inputs.

## Test Plan
- ./node_modules/.bin/tsx --test lib/__tests__/user-signature-scope.test.ts
- DATABASE_URL=postgresql://user:pass@localhost:5432/testdb ./node_modules/.bin/prisma validate
- ./node_modules/.bin/tsc --noEmit --pretty false filtered for UserSignature files/symbols

## Notes
- Full tsc still has unrelated existing repo-wide diagnostics.
- ESLint could not run locally because installed node_modules is missing @eslint/eslintrc.
