### PR TITLE
Send login OTP through configured MFA channels

### DIFF
--- a/app/api/auth/mfa/start/route.ts
+++ b/app/api/auth/mfa/start/route.ts
@@ -125,6 +125,7 @@ export async function POST(request: NextRequest) {
     const delivery = await sendMfaChallengeMessages({
       tenantId: tenant.id,
       username: authUser.username,
+      tenantName: tenant.name,
       targets: deliveryTargets,
       code,
     });

--- a/app/api/auth/mfa/start/route.ts
+++ b/app/api/auth/mfa/start/route.ts
@@ -12,7 +12,7 @@ import {
   invalidateActiveMfaChallenges,
   formatMfaDeliveryTargets,
   resolveMfaDeliveryTargets,
-  resolveMfaDestinations,
+  resolveMfaLoginDestinations,
   sendMfaChallengeMessages,
   serializeMfaAuthContext,
 } from "@/lib/mfa";
@@ -59,9 +59,6 @@ export async function POST(request: NextRequest) {
       tenantId: tenant.id,
       fineractUserId: authUser.userId,
       username: authUser.username,
-      ...(authUser.fineractEmail
-        ? { email: authUser.fineractEmail }
-        : {}),
     });
 
     const tenantMfaConfig = getTenantMfaConfig(tenant.settings);
@@ -82,8 +79,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const destinations = resolveMfaDestinations({
-      email: userLogin.email || authUser.fineractEmail,
+    const destinations = resolveMfaLoginDestinations({
+      userLoginEmail: userLogin.email,
       phone: userLogin.phone,
       countryCode: userLogin.countryCode,
     });
@@ -173,7 +170,6 @@ export async function POST(request: NextRequest) {
       tenantId: tenant.id,
       fineractUserId: authUser.userId,
       username: authUser.username,
-      email: userLogin.email || authUser.fineractEmail,
       phone: userLogin.phone,
       countryCode: userLogin.countryCode,
       lastMfaChannel: delivery.deliveredChannels.join(","),

--- a/app/api/auth/mfa/start/route.ts
+++ b/app/api/auth/mfa/start/route.ts
@@ -8,12 +8,12 @@ import {
 import {
   buildMissingMfaContactMessage,
   createMfaChallengeRecord,
-  getAvailableMfaChannels,
   getTenantMfaConfig,
   invalidateActiveMfaChallenges,
-  maskMfaDestination,
+  formatMfaDeliveryTargets,
+  resolveMfaDeliveryTargets,
   resolveMfaDestinations,
-  sendMfaChallengeMessage,
+  sendMfaChallengeMessages,
   serializeMfaAuthContext,
 } from "@/lib/mfa";
 import {
@@ -22,7 +22,6 @@ import {
   USER_LOGIN_BLOCKED_MESSAGE,
   upsertUserLogin,
 } from "@/lib/user-login-service";
-import type { MfaChannel } from "@/shared/types/tenant";
 
 export async function POST(request: NextRequest) {
   try {
@@ -31,10 +30,6 @@ export async function POST(request: NextRequest) {
       typeof body.username === "string" ? body.username.trim() : "";
     const password =
       typeof body.password === "string" ? body.password : "";
-    const requestedChannel =
-      body.channel === "email" || body.channel === "sms"
-        ? (body.channel as MfaChannel)
-        : undefined;
 
     if (!username || !password) {
       return NextResponse.json(
@@ -87,55 +82,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (tenantMfaConfig.channels.length === 0) {
-      return NextResponse.json(
-        {
-          success: false,
-          error:
-            "Multi-factor authentication is enabled for your tenant, but no channels are configured. Contact your system administrator for help.",
-        },
-        { status: 400 }
-      );
-    }
-
     const destinations = resolveMfaDestinations({
       email: userLogin.email || authUser.fineractEmail,
       phone: userLogin.phone,
       countryCode: userLogin.countryCode,
     });
-    const availableChannels = getAvailableMfaChannels(
-      tenantMfaConfig.channels,
-      destinations
-    );
+    const deliveryTargets = resolveMfaDeliveryTargets({
+      configuredChannels: tenantMfaConfig.channels,
+      destinations,
+    });
 
-    if (requestedChannel && !tenantMfaConfig.channels.includes(requestedChannel)) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "The selected MFA channel is not enabled for your tenant.",
-        },
-        { status: 400 }
-      );
-    }
-
-    if (
-      requestedChannel &&
-      !availableChannels.includes(requestedChannel)
-    ) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: buildMissingMfaContactMessage({
-            configuredChannels: tenantMfaConfig.channels,
-            destinations,
-            requestedChannel,
-          }),
-        },
-        { status: 400 }
-      );
-    }
-
-    if (availableChannels.length === 0) {
+    if (deliveryTargets.length === 0) {
       return NextResponse.json(
         {
           success: false,
@@ -148,42 +105,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!requestedChannel && availableChannels.length > 1) {
-      return NextResponse.json({
-        success: true,
-        requiresMfa: true,
-        requiresChannelSelection: true,
-        availableChannels,
-        destinations: Object.fromEntries(
-          availableChannels.map((channel) => [
-            channel,
-            maskMfaDestination(
-              channel,
-              channel === "email"
-                ? destinations.email || ""
-                : destinations.sms || ""
-            ),
-          ])
-        ),
-      });
-    }
-
-    const chosenChannel = requestedChannel ?? availableChannels[0];
-    const destination = destinations[chosenChannel];
-
-    if (!destination) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: buildMissingMfaContactMessage({
-            configuredChannels: tenantMfaConfig.channels,
-            destinations,
-            requestedChannel: chosenChannel,
-          }),
-        },
-        { status: 400 }
-      );
-    }
+    const primaryTarget = deliveryTargets[0];
 
     await invalidateActiveMfaChallenges(tenant.id, authUser.userId);
 
@@ -191,8 +113,8 @@ export async function POST(request: NextRequest) {
       tenantId: tenant.id,
       fineractUserId: authUser.userId,
       username: authUser.username,
-      channel: chosenChannel,
-      destination,
+      channel: primaryTarget.channel,
+      destination: primaryTarget.destination,
       authContext: serializeMfaAuthContext({
         ...authUser,
         tenantId: tenant.id,
@@ -200,15 +122,14 @@ export async function POST(request: NextRequest) {
       maxAttempts: tenantMfaConfig.maxAttempts,
     });
 
-    const delivered = await sendMfaChallengeMessage({
+    const delivery = await sendMfaChallengeMessages({
       tenantId: tenant.id,
       username: authUser.username,
-      channel: chosenChannel,
-      destination,
+      targets: deliveryTargets,
       code,
     });
 
-    if (!delivered) {
+    if (delivery.successfulDeliveries === 0) {
       await prisma.mfaChallenge.update({
         where: { id: challenge.id },
         data: {
@@ -220,13 +141,32 @@ export async function POST(request: NextRequest) {
         {
           success: false,
           error:
-            chosenChannel === "email"
-              ? "We could not send a verification email. Contact your system administrator for help."
-              : "We could not send a verification SMS. Contact your system administrator for help.",
+            "We could not send a verification code through any configured MFA channel. Contact your system administrator for help.",
         },
         { status: 500 }
       );
     }
+
+    const primaryDeliveredTarget = delivery.deliveredTargets[0];
+    if (!primaryDeliveredTarget) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "We could not send a verification code through any configured MFA channel. Contact your system administrator for help.",
+        },
+        { status: 500 }
+      );
+    }
+
+    const deliveredChallenge = await prisma.mfaChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        channel: primaryDeliveredTarget.channel,
+        destination: primaryDeliveredTarget.destination,
+        maskedDestination: formatMfaDeliveryTargets(delivery.deliveredTargets),
+      },
+    });
 
     await upsertUserLogin({
       tenantId: tenant.id,
@@ -235,17 +175,18 @@ export async function POST(request: NextRequest) {
       email: userLogin.email || authUser.fineractEmail,
       phone: userLogin.phone,
       countryCode: userLogin.countryCode,
-      lastMfaChannel: chosenChannel,
+      lastMfaChannel: delivery.deliveredChannels.join(","),
       lastMfaSentAt: new Date(),
     });
 
     return NextResponse.json({
       success: true,
       requiresMfa: true,
-      challengeId: challenge.id,
-      channel: chosenChannel,
-      maskedDestination: challenge.maskedDestination,
-      expiresAt: challenge.expiresAt,
+      challengeId: deliveredChallenge.id,
+      channel: deliveredChallenge.channel,
+      maskedDestination: deliveredChallenge.maskedDestination,
+      deliveryDescription: deliveredChallenge.maskedDestination,
+      expiresAt: deliveredChallenge.expiresAt,
     });
   } catch (error) {
     if (error instanceof FineractAuthenticationError) {

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -21,17 +21,12 @@ import { useAuth } from "@/contexts/auth-context";
 import { useRouter } from "next/navigation";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
-import type { MfaChannel } from "@/shared/types/tenant";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [availableChannels, setAvailableChannels] = useState<MfaChannel[]>([]);
-  const [channelDestinations, setChannelDestinations] = useState<
-    Partial<Record<MfaChannel, string | null>>
-  >({});
   const { login, status } = useAuth();
   const router = useRouter();
 
@@ -42,7 +37,7 @@ export default function LoginPage() {
     }
   }, [status, router]);
 
-  const submitLogin = async (channel?: MfaChannel) => {
+  const submitLogin = async () => {
     setError("");
 
     if (!username || !password) {
@@ -53,7 +48,7 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      const result = await login(username, password, channel);
+      const result = await login(username, password);
 
       if (result.success) {
         window.location.href = "/leads";
@@ -61,12 +56,6 @@ export default function LoginPage() {
       }
 
       if (result.requiresMfa) {
-        if ("requiresChannelSelection" in result && result.requiresChannelSelection) {
-          setAvailableChannels(result.availableChannels);
-          setChannelDestinations(result.destinations);
-          return;
-        }
-
         if ("challengeId" in result) {
           router.push(`/auth/mfa?challengeId=${encodeURIComponent(result.challengeId)}`);
           return;
@@ -75,8 +64,6 @@ export default function LoginPage() {
 
       if ("error" in result) {
         setError(result.error || "Login failed");
-        setAvailableChannels([]);
-        setChannelDestinations({});
       }
     } catch (err) {
       setError("An error occurred during login");
@@ -211,36 +198,6 @@ export default function LoginPage() {
                   </div>
                 )}
 
-                {availableChannels.length > 0 && (
-                  <div className="rounded-md border border-blue-500/30 bg-blue-500/5 p-4 space-y-3">
-                    <div className="space-y-1">
-                      <p className="text-sm font-medium text-foreground">
-                        Choose where to receive your verification code
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Select one of the configured MFA channels for your account.
-                      </p>
-                    </div>
-                    <div className="grid gap-2">
-                      {availableChannels.map((channel) => (
-                        <Button
-                          key={channel}
-                          type="button"
-                          variant="outline"
-                          disabled={isLoading}
-                          onClick={() => submitLogin(channel)}
-                          className="justify-between"
-                        >
-                          <span className="uppercase">{channel}</span>
-                          <span className="text-xs text-muted-foreground">
-                            {channelDestinations[channel] || ""}
-                          </span>
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
                 <div className="space-y-2">
                   <Label
                     htmlFor="username"
@@ -255,11 +212,7 @@ export default function LoginPage() {
                       placeholder="Enter your username"
                       className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       value={username}
-                      onChange={(e) => {
-                        setUsername(e.target.value);
-                        setAvailableChannels([]);
-                        setChannelDestinations({});
-                      }}
+                      onChange={(e) => setUsername(e.target.value)}
                       required
                     />
                     <svg
@@ -299,11 +252,7 @@ export default function LoginPage() {
                       type="password"
                       className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value);
-                        setAvailableChannels([]);
-                        setChannelDestinations({});
-                      }}
+                      onChange={(e) => setPassword(e.target.value)}
                       required
                     />
                     <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-blue-500" />

--- a/app/auth/mfa/page.tsx
+++ b/app/auth/mfa/page.tsx
@@ -29,6 +29,7 @@ type ChallengeSummary = {
   username: string;
   channel: MfaChannel;
   maskedDestination: string;
+  deliveryDescription?: string;
   expiresAt: string;
   resendAvailableAt: string;
   attemptsUsed: number;
@@ -497,7 +498,7 @@ function MfaPageContent() {
                 </p>
                 {challenge && (
                   <p className="text-sm text-muted-foreground">
-                    {challenge.channel.toUpperCase()} to {challenge.maskedDestination}
+                    Code sent via {challenge.deliveryDescription || challenge.maskedDestination}
                   </p>
                 )}
               </div>

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -2,7 +2,6 @@
 
 import React, { createContext, useContext } from "react";
 import { signIn, signOut, useSession, getSession } from "next-auth/react";
-import type { MfaChannel } from "@/shared/types/tenant";
 
 type LoginResult =
   | { success: true }
@@ -10,21 +9,12 @@ type LoginResult =
       success: false;
       error: string;
       requiresMfa?: false;
-      requiresChannelSelection?: false;
     }
   | {
       success: false;
       requiresMfa: true;
       challengeId: string;
-      channel: MfaChannel;
-      maskedDestination: string;
-    }
-  | {
-      success: false;
-      requiresMfa: true;
-      requiresChannelSelection: true;
-      availableChannels: MfaChannel[];
-      destinations: Partial<Record<MfaChannel, string | null>>;
+      deliveryDescription?: string;
     };
 
 type AuthContextType = {
@@ -35,11 +25,7 @@ type AuthContextType = {
     email?: string | null;
     image?: string | null;
   } | null;
-  login: (
-    username: string,
-    password: string,
-    channel?: MfaChannel
-  ) => Promise<LoginResult>;
+  login: (username: string, password: string) => Promise<LoginResult>;
   logout: () => Promise<void>;
 };
 
@@ -95,14 +81,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = async (
     username: string,
-    password: string,
-    channel?: MfaChannel
+    password: string
   ): Promise<LoginResult> => {
     try {
       const mfaStartRes = await fetch("/api/auth/mfa/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password, channel }),
+        body: JSON.stringify({ username, password }),
       });
       const mfaStartData = await mfaStartRes.json();
 
@@ -114,22 +99,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (mfaStartData.requiresMfa) {
-        if (mfaStartData.requiresChannelSelection) {
-          return {
-            success: false,
-            requiresMfa: true,
-            requiresChannelSelection: true,
-            availableChannels: mfaStartData.availableChannels || [],
-            destinations: mfaStartData.destinations || {},
-          };
-        }
-
         return {
           success: false,
           requiresMfa: true,
           challengeId: mfaStartData.challengeId,
-          channel: mfaStartData.channel,
-          maskedDestination: mfaStartData.maskedDestination,
+          deliveryDescription: mfaStartData.deliveryDescription,
         };
       }
 

--- a/lib/__tests__/mfa-channel-resolution.test.ts
+++ b/lib/__tests__/mfa-channel-resolution.test.ts
@@ -131,7 +131,7 @@ test("sends MFA challenge messages to every target and counts successful deliver
   assert.deepEqual(result.deliveredChannels, ["email"]);
 });
 
-test("builds a branded MFA email template with tenant name, logo, prominent OTP, and security copy", async () => {
+test("builds a branded MFA email template with tenant name, no logo, prominent OTP, and security copy", async () => {
   process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
   process.env.NEXTAUTH_URL = "https://app.kenacloanmatrix.com";
 
@@ -145,7 +145,8 @@ test("builds a branded MFA email template with tenant name, logo, prominent OTP,
 
   assert.equal(email.subject, "Goodfellow Loan Matrix verification code");
   assert.match(email.html, /Goodfellow Loan Matrix/);
-  assert.match(email.html, /https:\/\/app\.kenacloanmatrix\.com\/kenac_logo\.png/);
+  assert.doesNotMatch(email.html, /kenac_logo\.png/);
+  assert.doesNotMatch(email.html, /<img\b/i);
   assert.match(email.html, /123456/);
   assert.match(email.html, /letter-spacing:\s*0\.28em/);
   assert.match(email.html, /font-size:\s*32px/);

--- a/lib/__tests__/mfa-channel-resolution.test.ts
+++ b/lib/__tests__/mfa-channel-resolution.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
 
 test("defaults MFA channels to email when tenant settings do not configure channels", () => {
   process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
@@ -57,6 +65,42 @@ test("builds MFA delivery targets only for configured channels with destinations
     }),
     []
   );
+});
+
+test("builds login MFA destinations from UserLogin email only", async () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+
+  const { resolveMfaLoginDestinations } = await import("../mfa");
+
+  assert.deepEqual(
+    resolveMfaLoginDestinations({
+      userLoginEmail: " login.user@example.com ",
+      phone: "0971234567",
+      countryCode: "+260",
+    }),
+    {
+      email: "login.user@example.com",
+      sms: "+260971234567",
+    }
+  );
+
+  assert.equal(
+    resolveMfaLoginDestinations({
+      userLoginEmail: null,
+      phone: null,
+      countryCode: null,
+    }).email,
+    null
+  );
+});
+
+test("login and resend MFA flows keep UserLogin as the single email source", () => {
+  const startRoute = readRepoFile("app/api/auth/mfa/start/route.ts");
+  const mfaModule = readRepoFile("lib/mfa.ts");
+
+  assert.match(startRoute, /resolveMfaLoginDestinations/);
+  assert.doesNotMatch(startRoute, /authUser\.fineractEmail/);
+  assert.doesNotMatch(mfaModule, /email:\s*userLogin\?\.email\s*\|\|\s*authContext\?\.email/);
 });
 
 test("sends MFA challenge messages to every target and counts successful deliveries", async () => {

--- a/lib/__tests__/mfa-channel-resolution.test.ts
+++ b/lib/__tests__/mfa-channel-resolution.test.ts
@@ -86,3 +86,27 @@ test("sends MFA challenge messages to every target and counts successful deliver
   assert.equal(result.successfulDeliveries, 1);
   assert.deepEqual(result.deliveredChannels, ["email"]);
 });
+
+test("builds a branded MFA email template with tenant name, logo, prominent OTP, and security copy", async () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+  process.env.NEXTAUTH_URL = "https://app.kenacloanmatrix.com";
+
+  const { buildMfaChallengeEmail } = await import("../mfa");
+
+  const email = buildMfaChallengeEmail({
+    tenantName: "Goodfellow",
+    username: "alice",
+    code: "123456",
+  });
+
+  assert.equal(email.subject, "Goodfellow Loan Matrix verification code");
+  assert.match(email.html, /Goodfellow Loan Matrix/);
+  assert.match(email.html, /https:\/\/app\.kenacloanmatrix\.com\/kenac_logo\.png/);
+  assert.match(email.html, /123456/);
+  assert.match(email.html, /letter-spacing:\s*0\.28em/);
+  assert.match(email.html, /font-size:\s*32px/);
+  assert.match(email.html, /This code expires in 10 minutes/);
+  assert.match(email.html, /Kenac will never ask for this code/);
+  assert.match(email.text, /Goodfellow Loan Matrix/);
+  assert.match(email.text, /123456/);
+});

--- a/lib/__tests__/mfa-channel-resolution.test.ts
+++ b/lib/__tests__/mfa-channel-resolution.test.ts
@@ -94,12 +94,17 @@ test("builds login MFA destinations from UserLogin email only", async () => {
   );
 });
 
-test("login and resend MFA flows keep UserLogin as the single email source", () => {
+test("login, session, and resend MFA flows keep UserLogin as the single email source", () => {
   const startRoute = readRepoFile("app/api/auth/mfa/start/route.ts");
+  const authModule = readRepoFile("lib/auth.ts");
   const mfaModule = readRepoFile("lib/mfa.ts");
+  const lastLoginUpdateCall =
+    authModule.match(/updateUserLoginLastLogin\(\{[\s\S]*?\}\);/)?.[0] ?? "";
 
   assert.match(startRoute, /resolveMfaLoginDestinations/);
   assert.doesNotMatch(startRoute, /authUser\.fineractEmail/);
+  assert.match(lastLoginUpdateCall, /updateUserLoginLastLogin/);
+  assert.doesNotMatch(lastLoginUpdateCall, /\bemail\s*:/);
   assert.doesNotMatch(mfaModule, /email:\s*userLogin\?\.email\s*\|\|\s*authContext\?\.email/);
 });
 

--- a/lib/__tests__/mfa-channel-resolution.test.ts
+++ b/lib/__tests__/mfa-channel-resolution.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("defaults MFA channels to email when tenant settings do not configure channels", () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+
+  return import("../mfa").then(({ getTenantMfaConfig }) => {
+  assert.deepEqual(
+    getTenantMfaConfig({ features: { usesMFA: true } }).channels,
+    ["email"]
+  );
+
+  assert.deepEqual(
+    getTenantMfaConfig({ features: { usesMFA: true, mfaChannels: [] } }).channels,
+    ["email"]
+  );
+  });
+});
+
+test("builds MFA delivery targets only for configured channels with destinations", async () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+
+  const { resolveMfaDeliveryTargets } = await import("../mfa");
+
+  assert.deepEqual(
+    resolveMfaDeliveryTargets({
+      configuredChannels: ["sms", "email"],
+      destinations: {
+        sms: "+260971234567",
+        email: "user@example.com",
+      },
+    }),
+    [
+      { channel: "sms", destination: "+260971234567" },
+      { channel: "email", destination: "user@example.com" },
+    ]
+  );
+
+  assert.deepEqual(
+    resolveMfaDeliveryTargets({
+      configuredChannels: ["sms"],
+      destinations: {
+        sms: "+260971234567",
+        email: "user@example.com",
+      },
+    }),
+    [{ channel: "sms", destination: "+260971234567" }]
+  );
+
+  assert.deepEqual(
+    resolveMfaDeliveryTargets({
+      configuredChannels: ["email"],
+      destinations: {
+        sms: "+260971234567",
+        email: null,
+      },
+    }),
+    []
+  );
+});
+
+test("sends MFA challenge messages to every target and counts successful deliveries", async () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+
+  const { sendMfaChallengeMessages } = await import("../mfa");
+  const calls: Array<{ channel: string; destination: string; code: string }> = [];
+
+  const result = await sendMfaChallengeMessages({
+    tenantId: "tenant-1",
+    username: "alice",
+    code: "123456",
+    targets: [
+      { channel: "sms", destination: "+260971234567" },
+      { channel: "email", destination: "user@example.com" },
+    ],
+    sendMessage: async ({ channel, destination, code }) => {
+      calls.push({ channel, destination, code });
+      return channel === "email";
+    },
+  });
+
+  assert.deepEqual(calls, [
+    { channel: "sms", destination: "+260971234567", code: "123456" },
+    { channel: "email", destination: "user@example.com", code: "123456" },
+  ]);
+  assert.equal(result.successfulDeliveries, 1);
+  assert.deepEqual(result.deliveredChannels, ["email"]);
+});

--- a/lib/__tests__/notification-service-email.test.ts
+++ b/lib/__tests__/notification-service-email.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("sendEmail posts the notification service email payload contract", async (t) => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+  const previousNotificationServiceUrl = process.env.NOTIFICATION_SERVICE_URL;
+  const previousEmailNotificationServiceUrl =
+    process.env.EMAIL_NOTIFICATION_SERVICE_URL;
+  const previousMfaEmailFrom = process.env.MFA_EMAIL_FROM;
+
+  t.after(() => {
+    if (previousNotificationServiceUrl === undefined) {
+      delete process.env.NOTIFICATION_SERVICE_URL;
+    } else {
+      process.env.NOTIFICATION_SERVICE_URL = previousNotificationServiceUrl;
+    }
+
+    if (previousEmailNotificationServiceUrl === undefined) {
+      delete process.env.EMAIL_NOTIFICATION_SERVICE_URL;
+    } else {
+      process.env.EMAIL_NOTIFICATION_SERVICE_URL =
+        previousEmailNotificationServiceUrl;
+    }
+
+    if (previousMfaEmailFrom === undefined) {
+      delete process.env.MFA_EMAIL_FROM;
+    } else {
+      process.env.MFA_EMAIL_FROM = previousMfaEmailFrom;
+    }
+  });
+
+  process.env.NOTIFICATION_SERVICE_URL = "https://notifications.example.test";
+  delete process.env.EMAIL_NOTIFICATION_SERVICE_URL;
+  delete process.env.MFA_EMAIL_FROM;
+
+  const { sendEmail } = await import("../notification-service");
+  let requestBody: Record<string, unknown> | null = null;
+
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  });
+
+  const delivered = await sendEmail(
+    [" borrower@example.com "],
+    "Verification code",
+    "<strong>123456</strong>",
+    { text: "123456" }
+  );
+
+  assert.equal(delivered, true);
+  assert.deepEqual(requestBody?.to, ["borrower@example.com"]);
+  assert.equal(requestBody?.subject, "Verification code");
+  assert.equal(requestBody?.body, "<strong>123456</strong>");
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -171,10 +171,6 @@ export const authOptions: NextAuthOptions = {
               tenantId: user.tenantId,
               fineractUserId: user.userId,
               username: user.name,
-              email:
-                typeof user.email === "string" && user.email.includes("@")
-                  ? user.email
-                  : undefined,
             });
           }
         }

--- a/lib/mfa.ts
+++ b/lib/mfa.ts
@@ -34,6 +34,29 @@ function getMfaChannelLabel(channel: MfaChannel) {
   return channel === "sms" ? "SMS" : "email";
 }
 
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function getPublicBaseUrl() {
+  return (
+    process.env.NEXTAUTH_URL ||
+    process.env.APP_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    ""
+  ).replace(/\/$/, "");
+}
+
+function getKenacLogoUrl() {
+  const baseUrl = getPublicBaseUrl();
+  return baseUrl ? `${baseUrl}/kenac_logo.png` : "/kenac_logo.png";
+}
+
 type SerializedMfaAuthContext = {
   id: string;
   tenantId: string;
@@ -371,14 +394,103 @@ export function parseMfaAuthContext(
   };
 }
 
+export function buildMfaChallengeEmail(input: {
+  tenantName?: string | null;
+  username: string;
+  code: string;
+}) {
+  const trimmedTenantName = input.tenantName?.trim();
+  const tenantProductName = trimmedTenantName
+    ? `${trimmedTenantName} Loan Matrix`
+    : "Loan Matrix";
+  const safeTenantProductName = escapeHtml(tenantProductName);
+  const safeUsername = escapeHtml(input.username || "there");
+  const safeCode = escapeHtml(input.code);
+  const logoUrl = escapeHtml(getKenacLogoUrl());
+  const subject = `${tenantProductName} verification code`;
+  const text = [
+    `${tenantProductName}`,
+    "",
+    `Hello ${input.username || "there"},`,
+    "",
+    `Your verification code is ${input.code}.`,
+    `This code expires in ${MFA_EXPIRY_MINUTES} minutes.`,
+    "",
+    "Do not share this code. Kenac will never ask for this code.",
+  ].join("\n");
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f3f6fb;font-family:Arial,Helvetica,sans-serif;color:#111827;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f3f6fb;margin:0;padding:28px 12px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:16px;overflow:hidden;border:1px solid #dbeafe;box-shadow:0 18px 42px rgba(37,99,235,0.14);">
+            <tr>
+              <td style="background:#2563eb;background:linear-gradient(135deg,#2563eb 0%,#3b82f6 100%);padding:26px 30px 30px 30px;text-align:left;">
+                <img src="${logoUrl}" width="118" alt="Kenac" style="display:block;border:0;outline:none;text-decoration:none;max-width:118px;height:auto;margin-bottom:22px;">
+                <div style="font-size:13px;line-height:18px;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;color:#bfdbfe;">Secure sign in</div>
+                <h1 style="margin:8px 0 0 0;font-size:24px;line-height:31px;font-weight:800;color:#ffffff;">${safeTenantProductName}</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px 30px 10px 30px;">
+                <p style="margin:0 0 10px 0;font-size:16px;line-height:24px;color:#111827;">Hello ${safeUsername},</p>
+                <p style="margin:0;font-size:15px;line-height:23px;color:#4b5563;">Use this verification code to complete your Loan Matrix sign in.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:22px 30px 8px 30px;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:14px;">
+                  <tr>
+                    <td align="center" style="padding:24px 16px;">
+                      <div style="font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:0.12em;font-weight:700;color:#2563eb;margin-bottom:10px;">Verification code</div>
+                      <div style="font-size:32px;line-height:38px;letter-spacing:0.28em;font-weight:800;color:#111827;font-family:'SFMono-Regular',Consolas,'Liberation Mono',monospace;">${safeCode}</div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 30px 30px 30px;">
+                <p style="margin:0 0 14px 0;font-size:14px;line-height:22px;color:#374151;">This code expires in ${MFA_EXPIRY_MINUTES} minutes.</p>
+                <div style="border-left:4px solid #3b82f6;background:#f8fafc;border-radius:8px;padding:12px 14px;">
+                  <p style="margin:0;font-size:13px;line-height:20px;color:#475569;">Do not share this code. Kenac will never ask for this code.</p>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td style="background:#f8fafc;padding:18px 30px;text-align:center;border-top:1px solid #e5e7eb;">
+                <p style="margin:0;font-size:12px;line-height:18px;color:#64748b;">If you did not request this code, contact your system administrator.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  return {
+    subject,
+    html,
+    text,
+  };
+}
+
 export async function sendMfaChallengeMessage(input: {
   tenantId: string;
   username: string;
   channel: MfaChannel;
   destination: string;
   code: string;
+  tenantName?: string | null;
 }) {
-  const { tenantId, username, channel, destination, code } = input;
+  const { tenantId, username, channel, destination, code, tenantName } = input;
   const message = `Your Loan Matrix ${MFA_CODE_LENGTH}-digit verification code is ${code}. It expires in ${MFA_EXPIRY_MINUTES} minutes.`;
 
   if (channel === "sms") {
@@ -388,12 +500,15 @@ export async function sendMfaChallengeMessage(input: {
     });
   }
 
-  const subject = "Your Loan Matrix verification code";
-  const html = `<p>Hello ${username},</p><p>Your Loan Matrix ${MFA_CODE_LENGTH}-digit verification code is <strong>${code}</strong>.</p><p>This code expires in ${MFA_EXPIRY_MINUTES} minutes.</p>`;
+  const email = buildMfaChallengeEmail({
+    tenantName,
+    username,
+    code,
+  });
 
-  return sendEmail([destination], subject, html, {
+  return sendEmail([destination], email.subject, email.html, {
     tenantId,
-    text: `Hello ${username},\n\n${message}`,
+    text: email.text,
     logLabel: "mfa-login-email",
   });
 }
@@ -401,6 +516,7 @@ export async function sendMfaChallengeMessage(input: {
 export async function sendMfaChallengeMessages(input: {
   tenantId: string;
   username: string;
+  tenantName?: string | null;
   targets: MfaDeliveryTarget[];
   code: string;
   sendMessage?: typeof sendMfaChallengeMessage;
@@ -415,6 +531,7 @@ export async function sendMfaChallengeMessages(input: {
           channel: target.channel,
           destination: target.destination,
           code: input.code,
+          tenantName: input.tenantName,
         });
 
         return {
@@ -525,7 +642,7 @@ async function getMfaChallengeDeliveryContext(
   const [tenant, userLogin] = await Promise.all([
     prisma.tenant.findUnique({
       where: { id: tenantId },
-      select: { settings: true },
+      select: { name: true, settings: true },
     }),
     getUserLoginByFineractUserId(tenantId, challenge.fineractUserId),
   ]);
@@ -540,6 +657,7 @@ async function getMfaChallengeDeliveryContext(
   return {
     configuredChannels: tenantMfaConfig.channels,
     destinations,
+    tenantName: tenant?.name,
     targets: resolveMfaDeliveryTargets({
       configuredChannels: tenantMfaConfig.channels,
       destinations,
@@ -649,6 +767,7 @@ export async function resendMfaChallenge(tenantId: string, challengeId: string) 
   const delivery = await sendMfaChallengeMessages({
     tenantId,
     username: updatedChallenge.username,
+    tenantName: deliveryContext.tenantName,
     targets: deliveryContext.targets,
     code,
   });

--- a/lib/mfa.ts
+++ b/lib/mfa.ts
@@ -25,6 +25,15 @@ const MFA_ALLOWED_CHANNELS: MfaChannel[] = ["email", "sms"];
 
 type MfaDestinations = Record<MfaChannel, string | null>;
 
+type MfaDeliveryTarget = {
+  channel: MfaChannel;
+  destination: string;
+};
+
+function getMfaChannelLabel(channel: MfaChannel) {
+  return channel === "sms" ? "SMS" : "email";
+}
+
 type SerializedMfaAuthContext = {
   id: string;
   tenantId: string;
@@ -98,9 +107,11 @@ export function getTenantMfaConfig(settings: unknown): {
       ? config.mfaChannels
       : [];
 
-  const channels = rawChannels.filter((channel): channel is MfaChannel =>
+  const configuredChannels = rawChannels.filter((channel): channel is MfaChannel =>
     MFA_ALLOWED_CHANNELS.includes(channel as MfaChannel)
   );
+  const channels =
+    configuredChannels.length > 0 ? configuredChannels : (["email"] as MfaChannel[]);
   const rawMaxAttempts = featureConfig.mfaMaxAttempts ?? config.mfaMaxAttempts;
   const parsedMaxAttempts =
     typeof rawMaxAttempts === "number"
@@ -144,6 +155,32 @@ export function getAvailableMfaChannels(
   return configuredChannels.filter((channel) => Boolean(destinations[channel]));
 }
 
+export function resolveMfaDeliveryTargets(input: {
+  configuredChannels: MfaChannel[];
+  destinations: MfaDestinations;
+}): MfaDeliveryTarget[] {
+  const seenChannels = new Set<MfaChannel>();
+
+  return input.configuredChannels.reduce<MfaDeliveryTarget[]>((targets, channel) => {
+    if (seenChannels.has(channel)) {
+      return targets;
+    }
+
+    seenChannels.add(channel);
+    const destination = input.destinations[channel];
+
+    if (!destination) {
+      return targets;
+    }
+
+    targets.push({
+      channel,
+      destination,
+    });
+    return targets;
+  }, []);
+}
+
 export function maskEmailAddress(email: string) {
   const trimmed = email.trim();
   const [localPart, domain] = trimmed.split("@");
@@ -171,6 +208,18 @@ export function maskMfaDestination(channel: MfaChannel, destination: string) {
   return channel === "email"
     ? maskEmailAddress(destination)
     : maskPhoneNumber(destination);
+}
+
+export function formatMfaDeliveryTargets(targets: MfaDeliveryTarget[]) {
+  return targets
+    .map(
+      (target) =>
+        `${getMfaChannelLabel(target.channel)} to ${maskMfaDestination(
+          target.channel,
+          target.destination
+        )}`
+    )
+    .join(", ");
 }
 
 export function buildMissingMfaContactMessage(input: {
@@ -349,6 +398,51 @@ export async function sendMfaChallengeMessage(input: {
   });
 }
 
+export async function sendMfaChallengeMessages(input: {
+  tenantId: string;
+  username: string;
+  targets: MfaDeliveryTarget[];
+  code: string;
+  sendMessage?: typeof sendMfaChallengeMessage;
+}) {
+  const sendMessage = input.sendMessage ?? sendMfaChallengeMessage;
+  const results = await Promise.all(
+    input.targets.map(async (target) => {
+      try {
+        const delivered = await sendMessage({
+          tenantId: input.tenantId,
+          username: input.username,
+          channel: target.channel,
+          destination: target.destination,
+          code: input.code,
+        });
+
+        return {
+          ...target,
+          delivered,
+        };
+      } catch (error) {
+        console.error(
+          `Failed to send MFA ${target.channel} notification:`,
+          error
+        );
+        return {
+          ...target,
+          delivered: false,
+        };
+      }
+    })
+  );
+  const deliveredTargets = results.filter((result) => result.delivered);
+
+  return {
+    results,
+    deliveredTargets,
+    deliveredChannels: deliveredTargets.map((target) => target.channel),
+    successfulDeliveries: deliveredTargets.length,
+  };
+}
+
 export async function invalidateActiveMfaChallenges(
   tenantId: string,
   fineractUserId: number
@@ -421,6 +515,38 @@ async function getTenantChallengeOrThrow(tenantId: string, challengeId: string) 
   return challenge;
 }
 
+async function getMfaChallengeDeliveryContext(
+  tenantId: string,
+  challenge: {
+    fineractUserId: number;
+    authContext: unknown;
+  }
+) {
+  const [tenant, userLogin] = await Promise.all([
+    prisma.tenant.findUnique({
+      where: { id: tenantId },
+      select: { settings: true },
+    }),
+    getUserLoginByFineractUserId(tenantId, challenge.fineractUserId),
+  ]);
+  const tenantMfaConfig = getTenantMfaConfig(tenant?.settings);
+  const authContext = parseMfaAuthContext(challenge.authContext);
+  const destinations = resolveMfaDestinations({
+    email: userLogin?.email || authContext?.email,
+    phone: userLogin?.phone,
+    countryCode: userLogin?.countryCode,
+  });
+
+  return {
+    configuredChannels: tenantMfaConfig.channels,
+    destinations,
+    targets: resolveMfaDeliveryTargets({
+      configuredChannels: tenantMfaConfig.channels,
+      destinations,
+    }),
+  };
+}
+
 export async function getMfaChallengeSummary(tenantId: string, challengeId: string) {
   const challenge = await getTenantChallengeOrThrow(tenantId, challengeId);
 
@@ -437,6 +563,7 @@ export async function getMfaChallengeSummary(tenantId: string, challengeId: stri
     username: challenge.username,
     channel: challenge.channel as MfaChannel,
     maskedDestination: challenge.maskedDestination,
+    deliveryDescription: challenge.maskedDestination,
     expiresAt: challenge.expiresAt,
     resendAvailableAt: getMfaResendAvailableAt(challenge.lastSentAt),
     ...getMfaAttemptState(challenge),
@@ -489,6 +616,20 @@ export async function resendMfaChallenge(tenantId: string, challengeId: string) 
 
   const code = generateMfaCode();
   const expiresAt = getMfaExpiryDate();
+  const deliveryContext = await getMfaChallengeDeliveryContext(
+    tenantId,
+    challenge
+  );
+
+  if (deliveryContext.targets.length === 0) {
+    throw new MfaChallengeError(
+      buildMissingMfaContactMessage({
+        configuredChannels: deliveryContext.configuredChannels,
+        destinations: deliveryContext.destinations,
+      }),
+      400
+    );
+  }
 
   const updatedChallenge = await prisma.mfaChallenge.update({
     where: { id: challenge.id },
@@ -505,15 +646,14 @@ export async function resendMfaChallenge(tenantId: string, challengeId: string) 
     },
   });
 
-  const delivered = await sendMfaChallengeMessage({
+  const delivery = await sendMfaChallengeMessages({
     tenantId,
     username: updatedChallenge.username,
-    channel: updatedChallenge.channel as MfaChannel,
-    destination: updatedChallenge.destination,
+    targets: deliveryContext.targets,
     code,
   });
 
-  if (!delivered) {
+  if (delivery.successfulDeliveries === 0) {
     await prisma.mfaChallenge.update({
       where: { id: challenge.id },
       data: {
@@ -527,13 +667,31 @@ export async function resendMfaChallenge(tenantId: string, challengeId: string) 
     );
   }
 
+  const primaryDeliveredTarget = delivery.deliveredTargets[0];
+  if (!primaryDeliveredTarget) {
+    throw new MfaChallengeError(
+      "We could not resend the verification code. Please log in again or contact your system administrator for help.",
+      500
+    );
+  }
+
+  const deliveredChallenge = await prisma.mfaChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      channel: primaryDeliveredTarget.channel,
+      destination: primaryDeliveredTarget.destination,
+      maskedDestination: formatMfaDeliveryTargets(delivery.deliveredTargets),
+    },
+  });
+
   return {
-    id: updatedChallenge.id,
-    channel: updatedChallenge.channel as MfaChannel,
-    maskedDestination: updatedChallenge.maskedDestination,
-    expiresAt: updatedChallenge.expiresAt,
-    resendAvailableAt: getMfaResendAvailableAt(updatedChallenge.lastSentAt),
-    ...getMfaAttemptState(updatedChallenge),
+    id: deliveredChallenge.id,
+    channel: deliveredChallenge.channel as MfaChannel,
+    maskedDestination: deliveredChallenge.maskedDestination,
+    deliveryDescription: deliveredChallenge.maskedDestination,
+    expiresAt: deliveredChallenge.expiresAt,
+    resendAvailableAt: getMfaResendAvailableAt(deliveredChallenge.lastSentAt),
+    ...getMfaAttemptState(deliveredChallenge),
   };
 }
 

--- a/lib/mfa.ts
+++ b/lib/mfa.ts
@@ -171,6 +171,18 @@ export function resolveMfaDestinations(input: {
   };
 }
 
+export function resolveMfaLoginDestinations(input: {
+  userLoginEmail?: string | null;
+  phone?: string | null;
+  countryCode?: string | null;
+}): MfaDestinations {
+  return resolveMfaDestinations({
+    email: input.userLoginEmail,
+    phone: input.phone,
+    countryCode: input.countryCode,
+  });
+}
+
 export function getAvailableMfaChannels(
   configuredChannels: MfaChannel[],
   destinations: MfaDestinations
@@ -647,9 +659,8 @@ async function getMfaChallengeDeliveryContext(
     getUserLoginByFineractUserId(tenantId, challenge.fineractUserId),
   ]);
   const tenantMfaConfig = getTenantMfaConfig(tenant?.settings);
-  const authContext = parseMfaAuthContext(challenge.authContext);
-  const destinations = resolveMfaDestinations({
-    email: userLogin?.email || authContext?.email,
+  const destinations = resolveMfaLoginDestinations({
+    userLoginEmail: userLogin?.email,
     phone: userLogin?.phone,
     countryCode: userLogin?.countryCode,
   });

--- a/lib/mfa.ts
+++ b/lib/mfa.ts
@@ -43,20 +43,6 @@ function escapeHtml(value: string) {
     .replace(/'/g, "&#39;");
 }
 
-function getPublicBaseUrl() {
-  return (
-    process.env.NEXTAUTH_URL ||
-    process.env.APP_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    ""
-  ).replace(/\/$/, "");
-}
-
-function getKenacLogoUrl() {
-  const baseUrl = getPublicBaseUrl();
-  return baseUrl ? `${baseUrl}/kenac_logo.png` : "/kenac_logo.png";
-}
-
 type SerializedMfaAuthContext = {
   id: string;
   tenantId: string;
@@ -418,7 +404,6 @@ export function buildMfaChallengeEmail(input: {
   const safeTenantProductName = escapeHtml(tenantProductName);
   const safeUsername = escapeHtml(input.username || "there");
   const safeCode = escapeHtml(input.code);
-  const logoUrl = escapeHtml(getKenacLogoUrl());
   const subject = `${tenantProductName} verification code`;
   const text = [
     `${tenantProductName}`,
@@ -444,7 +429,6 @@ export function buildMfaChallengeEmail(input: {
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:16px;overflow:hidden;border:1px solid #dbeafe;box-shadow:0 18px 42px rgba(37,99,235,0.14);">
             <tr>
               <td style="background:#2563eb;background:linear-gradient(135deg,#2563eb 0%,#3b82f6 100%);padding:26px 30px 30px 30px;text-align:left;">
-                <img src="${logoUrl}" width="118" alt="Kenac" style="display:block;border:0;outline:none;text-decoration:none;max-width:118px;height:auto;margin-bottom:22px;">
                 <div style="font-size:13px;line-height:18px;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;color:#bfdbfe;">Secure sign in</div>
                 <h1 style="margin:8px 0 0 0;font-size:24px;line-height:31px;font-weight:800;color:#ffffff;">${safeTenantProductName}</h1>
               </td>

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -199,9 +199,9 @@ export async function sendEmail(
     const tenantId = await resolveNotificationServiceTenantId(options?.tenantId);
     const payload = {
       tenantId,
-      emailAddresses: validEmails,
+      to: validEmails,
       subject,
-      html,
+      body: html,
       text: options?.text,
       fromEmail: options?.fromEmail || process.env.MFA_EMAIL_FROM,
       messageId:

--- a/lib/user-login-service.ts
+++ b/lib/user-login-service.ts
@@ -203,7 +203,6 @@ export async function updateUserLoginLastLogin(input: {
   tenantId: string;
   fineractUserId: number;
   username: string;
-  email?: string | null;
 }) {
   return upsertUserLogin({
     ...input,


### PR DESCRIPTION
## Summary
- Default empty or missing tenant mfaChannels to email when MFA is enabled
- Send one login OTP to every configured, available MFA channel instead of asking users to choose
- Keep users on login with an error when no configured channel successfully sends

## Test Plan
- ./node_modules/.bin/tsx --test lib/__tests__/mfa-channel-resolution.test.ts
- ./node_modules/.bin/tsx --test lib/__tests__/loan-lifecycle-actions.test.ts

## Notes
- Full tsc --noEmit is currently blocked by existing repo-wide TypeScript errors unrelated to this change
- Targeted ESLint is currently blocked because @eslint/eslintrc is missing from the local ESLint config resolution