### PR TITLE
Add payment confirmation workflow

### DIFF
--- a/app/(application)/components/mobile-sidebar.tsx
+++ b/app/(application)/components/mobile-sidebar.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { TenantDisplayClient } from "@/components/tenant-display-client";
 import { useMobileMenu } from "./mobile-menu-context";
 import { useFeatureFlags } from "@/hooks/use-feature-flags";
+import { useUserRoles } from "@/components/role-guard";
 
 interface MobileSidebarProps {
   /** Organization logo URL from document service (when set) */
@@ -38,16 +39,20 @@ export function MobileSidebar({
   const { theme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const { isEnabled } = useFeatureFlags();
+  const { hasAnyRole, isLoading: rolesLoading } = useUserRoles();
+  const canSeeLeadConfiguration =
+    !rolesLoading && hasAnyRole(["SUPER_ADMIN"]) && isEnabled("leadConfig");
 
   // Avoid hydration mismatch
   useEffect(() => {
-    setMounted(true);
+    const frame = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(frame);
   }, []);
 
   // Close mobile menu when changing routes
   useEffect(() => {
     setMobileMenuOpen(false);
-  }, [pathname]);
+  }, [pathname, setMobileMenuOpen]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -64,7 +69,7 @@ export function MobileSidebar({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, []);
+  }, [setMobileMenuOpen]);
 
   // Prevent body scroll when mobile menu is open
   useEffect(() => {
@@ -201,17 +206,29 @@ export function MobileSidebar({
                       USSD Leads
                     </Link>
                   )}
-                  {isEnabled("leadConfig") && (
-                    <Link
-                      href="/leads/config"
-                      className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
-                        pathname === "/leads/config"
-                          ? iconColorActive
-                          : `${iconColor} hover:${textColor}`
-                      }`}
-                    >
-                      Configuration
-                    </Link>
+                  {canSeeLeadConfiguration && (
+                    <>
+                      <Link
+                        href="/leads/config"
+                        className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
+                          pathname === "/leads/config"
+                            ? iconColorActive
+                            : `${iconColor} hover:${textColor}`
+                        }`}
+                      >
+                        Configuration
+                      </Link>
+                      <Link
+                        href="/leads/payment-confirmation"
+                        className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
+                          pathname === "/leads/payment-confirmation"
+                            ? iconColorActive
+                            : `${iconColor} hover:${textColor}`
+                        }`}
+                      >
+                        Payment Confirmation
+                      </Link>
+                    </>
                   )}
                 </div>
               )}

--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -53,6 +53,10 @@ export function SidebarNav({ canReadUsers }: Readonly<SidebarNavProps>) {
     isEnabled("leadConfig")
   ) {
     leadsSubMenuItems.push({ label: "Configuration", href: "/leads/config" });
+    leadsSubMenuItems.push({
+      label: "Payment Confirmation",
+      href: "/leads/payment-confirmation",
+    });
   }
 
   const organizationSubMenuItems: SubMenuItem[] = [];

--- a/app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx
+++ b/app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx
@@ -1,0 +1,1057 @@
+"use client";
+
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import Papa from "papaparse";
+import {
+  Ban,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  FileSpreadsheet,
+  Loader2,
+  RefreshCw,
+  Search,
+  XCircle,
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const NONE_VALUE = "__none__";
+
+type CsvRow = Record<string, string>;
+
+type ColumnMapping = {
+  referenceColumn: string;
+  loanIdColumn: string;
+  loanAccountNoColumn: string;
+  fineractClientIdColumn: string;
+  clientNameColumn: string;
+};
+
+type LookupPayment = {
+  internalReferenceNumber?: string | null;
+  userReferenceNumber?: string | null;
+  providerReferenceNumber?: string | null;
+  status?: string | null;
+  callbackStatus?: string | null;
+  paymentConfirmed?: boolean;
+  confirmedAt?: string | null;
+  canConfirm?: boolean;
+};
+
+type LookupItem = {
+  id: string;
+  uploadId: string;
+  rowNumber?: number | null;
+  paymentReference: string;
+  matched: boolean;
+  actionStatus: string;
+  fineractLoanId?: number | null;
+  fineractClientId?: number | null;
+  loanAccountNo?: string | null;
+  clientName?: string | null;
+  createdAt?: string;
+  payment?: LookupPayment | null;
+};
+
+type LookupResponse = {
+  upload: {
+    id: string;
+    fileName: string;
+    totalRows: number;
+    matchedCount: number;
+    unmatchedCount: number;
+  };
+  matched: LookupItem[];
+  unmatched: LookupItem[];
+};
+
+type AuditItem = {
+  id: string;
+  uploadId?: string | null;
+  rowNumber?: number | null;
+  paymentReference: string;
+  action: string;
+  actionStatus: string;
+  fineractLoanId?: number | null;
+  fineractClientId?: number | null;
+  loanAccountNo?: string | null;
+  clientName?: string | null;
+  paymentProviderReference?: string | null;
+  paymentStatus?: string | null;
+  paymentConfirmedAt?: string | null;
+  actedByName?: string | null;
+  errorMessage?: string | null;
+  createdAt?: string | null;
+  upload?: {
+    fileName: string;
+    createdAt?: string | null;
+  } | null;
+};
+
+type AuditPage = {
+  items: AuditItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+const EMPTY_MAPPING: ColumnMapping = {
+  referenceColumn: "",
+  loanIdColumn: "",
+  loanAccountNoColumn: "",
+  fineractClientIdColumn: "",
+  clientNameColumn: "",
+};
+
+const FIELD_LABELS: Record<keyof ColumnMapping, string> = {
+  referenceColumn: "Reference column *",
+  loanIdColumn: "Loan ID column",
+  loanAccountNoColumn: "Loan account column",
+  fineractClientIdColumn: "Client ID column",
+  clientNameColumn: "Client name column",
+};
+
+const AUTO_DETECT_PATTERNS: Record<keyof ColumnMapping, RegExp> = {
+  referenceColumn:
+    /^(payment[_\s-]?ref|payment[_\s-]?reference|internal[_\s-]?reference[_\s-]?number|internalreference|reference|ref)$/i,
+  loanIdColumn: /^(loan[_\s-]?id|loanid|fineract[_\s-]?loan[_\s-]?id)$/i,
+  loanAccountNoColumn:
+    /^(loan[_\s-]?account[_\s-]?no|loan[_\s-]?account|account[_\s-]?no)$/i,
+  fineractClientIdColumn:
+    /^(client[_\s-]?id|fineract[_\s-]?client[_\s-]?id)$/i,
+  clientNameColumn: /^(client[_\s-]?name|customer[_\s-]?name|name)$/i,
+};
+
+function formatDate(value?: string | null): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function normalizeCell(value: unknown): string {
+  return typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T> {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(data?.error || data?.message || "Request failed");
+  }
+  return data as T;
+}
+
+function statusVariant(status?: string | null): "default" | "secondary" | "destructive" | "outline" {
+  const normalized = String(status || "").toUpperCase();
+  if (["FAILED", "ERROR"].includes(normalized)) return "destructive";
+  if (["SUCCESS", "CONFIRMED", "MATCHED", "COMPLETED"].includes(normalized)) {
+    return "secondary";
+  }
+  return "outline";
+}
+
+function StatusBadge({ status }: { status?: string | null }) {
+  return (
+    <Badge variant={statusVariant(status)} className="max-w-full">
+      {status || "-"}
+    </Badge>
+  );
+}
+
+function AuditTable({
+  page,
+  loading,
+  error,
+  onPageChange,
+}: {
+  page: AuditPage;
+  loading: boolean;
+  error: string | null;
+  onPageChange: (page: number) => void;
+}) {
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <XCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <div className="rounded-md border overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Reference</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Loan ID</TableHead>
+                <TableHead>Client</TableHead>
+                <TableHead>File</TableHead>
+                <TableHead>Actor</TableHead>
+                <TableHead>Date</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-24 text-center">
+                    <Loader2 className="mx-auto h-5 w-5 animate-spin text-muted-foreground" />
+                  </TableCell>
+                </TableRow>
+              ) : page.items.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                    No records
+                  </TableCell>
+                </TableRow>
+              ) : (
+                page.items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium whitespace-nowrap">
+                      {item.paymentReference}
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={item.actionStatus} />
+                    </TableCell>
+                    <TableCell>{item.fineractLoanId || "-"}</TableCell>
+                    <TableCell className="min-w-40">{item.clientName || "-"}</TableCell>
+                    <TableCell className="min-w-44">{item.upload?.fileName || "-"}</TableCell>
+                    <TableCell>{item.actedByName || "-"}</TableCell>
+                    <TableCell className="whitespace-nowrap">{formatDate(item.createdAt)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted-foreground">
+            {page.total} records
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page.page - 1)}
+              disabled={loading || page.page <= 1}
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              {page.page} / {page.totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page.page + 1)}
+              disabled={loading || page.page >= page.totalPages}
+              aria-label="Next page"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PaymentConfirmationClient() {
+  const [activeTab, setActiveTab] = useState("upload");
+  const [file, setFile] = useState<File | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [previewRows, setPreviewRows] = useState<CsvRow[]>([]);
+  const [allRows, setAllRows] = useState<CsvRow[]>([]);
+  const [mapping, setMapping] = useState<ColumnMapping>(EMPTY_MAPPING);
+  const [lookup, setLookup] = useState<LookupResponse | null>(null);
+  const [selectedConfirmRefs, setSelectedConfirmRefs] = useState<Set<string>>(new Set());
+  const [selectedRejectRefs, setSelectedRejectRefs] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [lookupLoading, setLookupLoading] = useState(false);
+  const [confirmLoading, setConfirmLoading] = useState(false);
+  const [rejectLoading, setRejectLoading] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const [confirmedPageNumber, setConfirmedPageNumber] = useState(1);
+  const [confirmedPage, setConfirmedPage] = useState<AuditPage>({
+    items: [],
+    total: 0,
+    page: 1,
+    pageSize: 20,
+    totalPages: 1,
+  });
+  const [confirmedLoading, setConfirmedLoading] = useState(false);
+  const [confirmedError, setConfirmedError] = useState<string | null>(null);
+
+  const [unconfirmedPageNumber, setUnconfirmedPageNumber] = useState(1);
+  const [unconfirmedPage, setUnconfirmedPage] = useState<AuditPage>({
+    items: [],
+    total: 0,
+    page: 1,
+    pageSize: 20,
+    totalPages: 1,
+  });
+  const [unconfirmedLoading, setUnconfirmedLoading] = useState(false);
+  const [unconfirmedError, setUnconfirmedError] = useState<string | null>(null);
+
+  const confirmableMatched = useMemo(
+    () => lookup?.matched.filter((item) => item.payment?.canConfirm) || [],
+    [lookup]
+  );
+  const rejectableUnmatched = useMemo(
+    () => lookup?.unmatched.filter((item) => Boolean(item.fineractLoanId)) || [],
+    [lookup]
+  );
+
+  const loadConfirmed = useCallback(async () => {
+    setConfirmedLoading(true);
+    setConfirmedError(null);
+    try {
+      const response = await fetch(
+        `/api/leads/payment-confirmation/confirmed?page=${confirmedPageNumber}&pageSize=20`,
+        { cache: "no-store" }
+      );
+      const data = await readJsonResponse<AuditPage>(response);
+      setConfirmedPage(data);
+    } catch (err) {
+      setConfirmedError(err instanceof Error ? err.message : "Failed to load records");
+    } finally {
+      setConfirmedLoading(false);
+    }
+  }, [confirmedPageNumber]);
+
+  const loadUnconfirmed = useCallback(async () => {
+    setUnconfirmedLoading(true);
+    setUnconfirmedError(null);
+    try {
+      const response = await fetch(
+        `/api/leads/payment-confirmation/unconfirmed?page=${unconfirmedPageNumber}&pageSize=20`,
+        { cache: "no-store" }
+      );
+      const data = await readJsonResponse<AuditPage>(response);
+      setUnconfirmedPage(data);
+    } catch (err) {
+      setUnconfirmedError(err instanceof Error ? err.message : "Failed to load records");
+    } finally {
+      setUnconfirmedLoading(false);
+    }
+  }, [unconfirmedPageNumber]);
+
+  useEffect(() => {
+    if (activeTab !== "confirmed") return;
+    const timeout = window.setTimeout(() => {
+      void loadConfirmed();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [activeTab, loadConfirmed, refreshKey]);
+
+  useEffect(() => {
+    if (activeTab !== "unconfirmed") return;
+    const timeout = window.setTimeout(() => {
+      void loadUnconfirmed();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [activeTab, loadUnconfirmed, refreshKey]);
+
+  const resetUploadState = useCallback(() => {
+    setHeaders([]);
+    setPreviewRows([]);
+    setAllRows([]);
+    setMapping(EMPTY_MAPPING);
+    setLookup(null);
+    setSelectedConfirmRefs(new Set());
+    setSelectedRejectRefs(new Set());
+    setError(null);
+    setNotice(null);
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const selected = event.target.files?.[0] || null;
+      setFile(selected);
+      resetUploadState();
+
+      if (!selected) return;
+
+      Papa.parse(selected, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (results) => {
+          if (results.errors.length > 0 && results.data.length === 0) {
+            setError("Failed to parse CSV file");
+            return;
+          }
+
+          const parsedHeaders = (results.meta.fields || []).map((header) =>
+            header.trim()
+          );
+          const usableHeaders = parsedHeaders.filter(Boolean);
+          const parsedRows = (results.data as Record<string, unknown>[]).map(
+            (row) => {
+              const normalizedRow: CsvRow = {};
+              for (const [key, value] of Object.entries(row)) {
+                const normalizedKey = key.trim();
+                if (!normalizedKey) continue;
+                normalizedRow[normalizedKey] = normalizeCell(value);
+              }
+              return normalizedRow;
+            }
+          );
+
+          if (usableHeaders.length === 0) {
+            setError("No CSV headers were found");
+            return;
+          }
+
+          const autoMapping = { ...EMPTY_MAPPING };
+          for (const [field, pattern] of Object.entries(AUTO_DETECT_PATTERNS)) {
+            const match = usableHeaders.find((header) => pattern.test(header));
+            if (match) {
+              autoMapping[field as keyof ColumnMapping] = match;
+            }
+          }
+
+          setHeaders(usableHeaders);
+          setPreviewRows(parsedRows.slice(0, 5));
+          setAllRows(parsedRows);
+          setMapping(autoMapping);
+        },
+        error: () => {
+          setError("Failed to read CSV file");
+        },
+      });
+    },
+    [resetUploadState]
+  );
+
+  const updateMapping = (field: keyof ColumnMapping, value: string) => {
+    setMapping((current) => ({
+      ...current,
+      [field]: value === NONE_VALUE ? "" : value,
+    }));
+  };
+
+  const getMappedLabel = (header: string) => {
+    const mapped = Object.entries(mapping).find(([, value]) => value === header);
+    if (!mapped) return null;
+    return FIELD_LABELS[mapped[0] as keyof ColumnMapping].replace(" *", "");
+  };
+
+  const handleLookup = async () => {
+    setError(null);
+    setNotice(null);
+
+    if (!file || allRows.length === 0) {
+      setError("Choose a CSV file");
+      return;
+    }
+
+    if (!mapping.referenceColumn) {
+      setError("Select the reference column");
+      return;
+    }
+
+    const rows = allRows.map((row, index) => ({
+      rowNumber: index + 1,
+      paymentReference: row[mapping.referenceColumn] || "",
+      fineractLoanId: mapping.loanIdColumn ? row[mapping.loanIdColumn] || null : null,
+      loanAccountNo: mapping.loanAccountNoColumn
+        ? row[mapping.loanAccountNoColumn] || null
+        : null,
+      fineractClientId: mapping.fineractClientIdColumn
+        ? row[mapping.fineractClientIdColumn] || null
+        : null,
+      clientName: mapping.clientNameColumn ? row[mapping.clientNameColumn] || null : null,
+      rawRow: row,
+    }));
+
+    setLookupLoading(true);
+    try {
+      const response = await fetch("/api/leads/payment-confirmation/lookup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileName: file.name,
+          columnMapping: mapping,
+          rows,
+        }),
+      });
+      const data = await readJsonResponse<LookupResponse>(response);
+      setLookup(data);
+      setSelectedConfirmRefs(
+        new Set(
+          data.matched
+            .filter((item) => item.payment?.canConfirm)
+            .map((item) => item.paymentReference)
+        )
+      );
+      setSelectedRejectRefs(
+        new Set(
+          data.unmatched
+            .filter((item) => Boolean(item.fineractLoanId))
+            .map((item) => item.paymentReference)
+        )
+      );
+      setNotice(
+        `${data.upload.matchedCount} matched, ${data.upload.unmatchedCount} unmatched`
+      );
+      setRefreshKey((key) => key + 1);
+    } catch (err) {
+      setLookup(null);
+      setError(err instanceof Error ? err.message : "Lookup failed");
+    } finally {
+      setLookupLoading(false);
+    }
+  };
+
+  const toggleConfirmRef = (reference: string, checked: boolean) => {
+    setSelectedConfirmRefs((current) => {
+      const next = new Set(current);
+      if (checked) next.add(reference);
+      else next.delete(reference);
+      return next;
+    });
+  };
+
+  const toggleRejectRef = (reference: string, checked: boolean) => {
+    setSelectedRejectRefs((current) => {
+      const next = new Set(current);
+      if (checked) next.add(reference);
+      else next.delete(reference);
+      return next;
+    });
+  };
+
+  const toggleAllConfirmable = (checked: boolean) => {
+    setSelectedConfirmRefs((current) => {
+      const next = new Set(current);
+      for (const item of confirmableMatched) {
+        if (checked) next.add(item.paymentReference);
+        else next.delete(item.paymentReference);
+      }
+      return next;
+    });
+  };
+
+  const toggleAllRejectable = (checked: boolean) => {
+    setSelectedRejectRefs((current) => {
+      const next = new Set(current);
+      for (const item of rejectableUnmatched) {
+        if (checked) next.add(item.paymentReference);
+        else next.delete(item.paymentReference);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    if (!lookup || selectedConfirmRefs.size === 0) return;
+
+    setConfirmLoading(true);
+    setError(null);
+    setNotice(null);
+
+    const paymentReferences = Array.from(selectedConfirmRefs);
+    try {
+      const response = await fetch("/api/leads/payment-confirmation/confirm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uploadId: lookup.upload.id,
+          paymentReferences,
+        }),
+      });
+      const data = await readJsonResponse<{
+        confirmedPaymentReferences: string[];
+        failedPaymentReferences: string[];
+        confirmedAt?: string;
+      }>(response);
+      const confirmedSet = new Set(data.confirmedPaymentReferences);
+
+      setLookup((current) =>
+        current
+          ? {
+              ...current,
+              matched: current.matched.map((item) =>
+                confirmedSet.has(item.paymentReference)
+                  ? {
+                      ...item,
+                      actionStatus: "CONFIRMED",
+                      payment: item.payment
+                        ? {
+                            ...item.payment,
+                            paymentConfirmed: true,
+                            canConfirm: false,
+                            confirmedAt: data.confirmedAt || null,
+                          }
+                        : item.payment,
+                    }
+                  : item
+              ),
+            }
+          : current
+      );
+      setSelectedConfirmRefs(new Set());
+      setNotice(`${data.confirmedPaymentReferences.length} payments confirmed`);
+      setRefreshKey((key) => key + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Confirm failed");
+    } finally {
+      setConfirmLoading(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!lookup || selectedRejectRefs.size === 0) return;
+
+    setRejectLoading(true);
+    setError(null);
+    setNotice(null);
+
+    const items = lookup.unmatched
+      .filter((item) => selectedRejectRefs.has(item.paymentReference))
+      .map((item) => ({
+        paymentReference: item.paymentReference,
+        fineractLoanId: item.fineractLoanId,
+        fineractClientId: item.fineractClientId,
+        loanAccountNo: item.loanAccountNo,
+        clientName: item.clientName,
+      }));
+
+    try {
+      const response = await fetch("/api/leads/payment-confirmation/reject", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uploadId: lookup.upload.id,
+          items,
+        }),
+      });
+      const data = await readJsonResponse<{
+        rejectedReferences: string[];
+        failedReferences: string[];
+      }>(response);
+      const rejectedSet = new Set(data.rejectedReferences);
+      const failedSet = new Set(data.failedReferences);
+
+      setLookup((current) =>
+        current
+          ? {
+              ...current,
+              unmatched: current.unmatched.map((item) =>
+                rejectedSet.has(item.paymentReference)
+                  ? { ...item, actionStatus: "REJECTED" }
+                  : failedSet.has(item.paymentReference)
+                    ? { ...item, actionStatus: "FAILED" }
+                    : item
+              ),
+            }
+          : current
+      );
+      setSelectedRejectRefs(new Set());
+      setNotice(`${data.rejectedReferences.length} loans rejected`);
+      setRefreshKey((key) => key + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Reject failed");
+    } finally {
+      setRejectLoading(false);
+    }
+  };
+
+  const allConfirmableSelected =
+    confirmableMatched.length > 0 &&
+    confirmableMatched.every((item) =>
+      selectedConfirmRefs.has(item.paymentReference)
+    );
+  const allRejectableSelected =
+    rejectableUnmatched.length > 0 &&
+    rejectableUnmatched.every((item) =>
+      selectedRejectRefs.has(item.paymentReference)
+    );
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
+      <TabsList className="grid w-full max-w-3xl grid-cols-3">
+        <TabsTrigger value="upload">Upload</TabsTrigger>
+        <TabsTrigger value="confirmed">Confirmed Payments</TabsTrigger>
+        <TabsTrigger value="unconfirmed">Unconfirmed Payments</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="upload" className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <XCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {notice && (
+          <Alert>
+            <CheckCircle2 className="h-4 w-4" />
+            <AlertTitle>Done</AlertTitle>
+            <AlertDescription>{notice}</AlertDescription>
+          </Alert>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FileSpreadsheet className="h-4 w-4" />
+              CSV Upload
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+              <div className="space-y-2">
+                <Label htmlFor="payment-confirmation-file">CSV file</Label>
+                <Input
+                  id="payment-confirmation-file"
+                  type="file"
+                  accept=".csv,.txt"
+                  onChange={handleFileChange}
+                />
+              </div>
+              <Button
+                type="button"
+                onClick={handleLookup}
+                disabled={lookupLoading || !file || !mapping.referenceColumn}
+              >
+                {lookupLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="h-4 w-4" />
+                )}
+                Lookup
+              </Button>
+            </div>
+
+            {allRows.length > 0 && (
+              <>
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-5">
+                  {(Object.keys(FIELD_LABELS) as (keyof ColumnMapping)[]).map(
+                    (field) => (
+                      <div key={field} className="space-y-2">
+                        <Label>{FIELD_LABELS[field]}</Label>
+                        <Select
+                          value={mapping[field] || NONE_VALUE}
+                          onValueChange={(value) => updateMapping(field, value)}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select column" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value={NONE_VALUE}>Not mapped</SelectItem>
+                            {headers.map((header) => (
+                              <SelectItem key={header} value={header}>
+                                {header}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )
+                  )}
+                </div>
+
+                <div className="rounded-md border overflow-auto max-h-[320px]">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">#</TableHead>
+                        {headers.map((header) => {
+                          const mappedLabel = getMappedLabel(header);
+                          return (
+                            <TableHead key={header} className="whitespace-nowrap">
+                              <div className="flex items-center gap-2">
+                                <span>{header}</span>
+                                {mappedLabel && (
+                                  <Badge variant="secondary">{mappedLabel}</Badge>
+                                )}
+                              </div>
+                            </TableHead>
+                          );
+                        })}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {previewRows.map((row, index) => (
+                        <TableRow key={index}>
+                          <TableCell className="text-muted-foreground">
+                            {index + 1}
+                          </TableCell>
+                          {headers.map((header) => (
+                            <TableCell
+                              key={header}
+                              className="max-w-52 truncate whitespace-nowrap"
+                            >
+                              {row[header] || "-"}
+                            </TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        {lookup && (
+          <div className="grid gap-4 xl:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <CheckCircle2 className="h-4 w-4" />
+                    Matched Payments
+                    <Badge variant="secondary">{lookup.matched.length}</Badge>
+                  </CardTitle>
+                  <Button
+                    type="button"
+                    onClick={handleConfirm}
+                    disabled={confirmLoading || selectedConfirmRefs.size === 0}
+                  >
+                    {confirmLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <CheckCircle2 className="h-4 w-4" />
+                    )}
+                    Confirm
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="rounded-md border overflow-auto max-h-[420px]">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-10">
+                          <Checkbox
+                            checked={allConfirmableSelected}
+                            onCheckedChange={(checked) =>
+                              toggleAllConfirmable(Boolean(checked))
+                            }
+                            aria-label="Select all confirmable payments"
+                          />
+                        </TableHead>
+                        <TableHead>Reference</TableHead>
+                        <TableHead>Provider Ref</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Loan ID</TableHead>
+                        <TableHead>Client</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {lookup.matched.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                            No matched payments
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        lookup.matched.map((item) => (
+                          <TableRow key={item.id}>
+                            <TableCell>
+                              <Checkbox
+                                checked={selectedConfirmRefs.has(item.paymentReference)}
+                                disabled={!item.payment?.canConfirm}
+                                onCheckedChange={(checked) =>
+                                  toggleConfirmRef(
+                                    item.paymentReference,
+                                    Boolean(checked)
+                                  )
+                                }
+                                aria-label={`Select ${item.paymentReference}`}
+                              />
+                            </TableCell>
+                            <TableCell className="font-medium whitespace-nowrap">
+                              {item.paymentReference}
+                            </TableCell>
+                            <TableCell className="whitespace-nowrap">
+                              {item.payment?.providerReferenceNumber || "-"}
+                            </TableCell>
+                            <TableCell>
+                              <StatusBadge status={item.actionStatus} />
+                            </TableCell>
+                            <TableCell>{item.fineractLoanId || "-"}</TableCell>
+                            <TableCell className="min-w-40">{item.clientName || "-"}</TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Ban className="h-4 w-4" />
+                    Unmatched References
+                    <Badge variant="outline">{lookup.unmatched.length}</Badge>
+                  </CardTitle>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleReject}
+                    disabled={rejectLoading || selectedRejectRefs.size === 0}
+                  >
+                    {rejectLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <XCircle className="h-4 w-4" />
+                    )}
+                    Reject Loans
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="rounded-md border overflow-auto max-h-[420px]">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-10">
+                          <Checkbox
+                            checked={allRejectableSelected}
+                            onCheckedChange={(checked) =>
+                              toggleAllRejectable(Boolean(checked))
+                            }
+                            aria-label="Select all rejectable loans"
+                          />
+                        </TableHead>
+                        <TableHead>Reference</TableHead>
+                        <TableHead>Loan ID</TableHead>
+                        <TableHead>Client</TableHead>
+                        <TableHead>Status</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {lookup.unmatched.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
+                            No unmatched references
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        lookup.unmatched.map((item) => (
+                          <TableRow key={item.id}>
+                            <TableCell>
+                              <Checkbox
+                                checked={selectedRejectRefs.has(item.paymentReference)}
+                                disabled={!item.fineractLoanId}
+                                onCheckedChange={(checked) =>
+                                  toggleRejectRef(
+                                    item.paymentReference,
+                                    Boolean(checked)
+                                  )
+                                }
+                                aria-label={`Select ${item.paymentReference}`}
+                              />
+                            </TableCell>
+                            <TableCell className="font-medium whitespace-nowrap">
+                              {item.paymentReference}
+                            </TableCell>
+                            <TableCell>
+                              {item.fineractLoanId || (
+                                <Badge variant="outline">Missing loan ID</Badge>
+                              )}
+                            </TableCell>
+                            <TableCell className="min-w-40">{item.clientName || "-"}</TableCell>
+                            <TableCell>
+                              <StatusBadge status={item.actionStatus} />
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </TabsContent>
+
+      <TabsContent value="confirmed">
+        <div className="mb-3 flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadConfirmed}
+            disabled={confirmedLoading}
+            aria-label="Refresh confirmed payments"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+        </div>
+        <AuditTable
+          page={confirmedPage}
+          loading={confirmedLoading}
+          error={confirmedError}
+          onPageChange={setConfirmedPageNumber}
+        />
+      </TabsContent>
+
+      <TabsContent value="unconfirmed">
+        <div className="mb-3 flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadUnconfirmed}
+            disabled={unconfirmedLoading}
+            aria-label="Refresh unconfirmed payments"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+        </div>
+        <AuditTable
+          page={unconfirmedPage}
+          loading={unconfirmedLoading}
+          error={unconfirmedError}
+          onPageChange={setUnconfirmedPageNumber}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/app/(application)/leads/payment-confirmation/page.tsx
+++ b/app/(application)/leads/payment-confirmation/page.tsx
@@ -1,0 +1,12 @@
+import { PaymentConfirmationClient } from "./components/payment-confirmation-client";
+
+export default function PaymentConfirmationPage() {
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-normal">Payment Confirmation</h1>
+      </div>
+      <PaymentConfirmationClient />
+    </div>
+  );
+}

--- a/app/api/leads/payment-confirmation/confirm/route.ts
+++ b/app/api/leads/payment-confirmation/confirm/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma";
+import prisma from "@/lib/prisma";
+import { requirePaymentConfirmationAccess } from "@/lib/payment-confirmation-access";
+import { confirmPayments } from "@/lib/payment-service";
+
+function normalizeReferences(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+
+  return Array.from(
+    new Set(values.map((value) => String(value ?? "").trim()).filter(Boolean))
+  );
+}
+
+function parseConfirmedAt(value: unknown): Date {
+  if (!value) return new Date();
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requirePaymentConfirmationAccess();
+    if (!access.ok) return access.response;
+
+    const body = await request.json();
+    const uploadId = String(body?.uploadId || "").trim();
+    const paymentReferences = normalizeReferences(body?.paymentReferences);
+
+    if (!uploadId) {
+      return NextResponse.json({ error: "uploadId is required" }, { status: 400 });
+    }
+
+    if (paymentReferences.length === 0) {
+      return NextResponse.json(
+        { error: "At least one payment reference is required" },
+        { status: 400 }
+      );
+    }
+
+    const upload = await prisma.paymentConfirmationUpload.findFirst({
+      where: { id: uploadId, tenantId: access.tenant.id },
+      select: { id: true },
+    });
+
+    if (!upload) {
+      return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+    }
+
+    const confirmationResult = await confirmPayments(
+      access.tenant.slug,
+      paymentReferences
+    );
+    const confirmedSet = new Set(
+      confirmationResult.confirmedPaymentReferences.map((ref) => ref.trim())
+    );
+    const confirmedAt = parseConfirmedAt(confirmationResult.confirmedAt);
+
+    const lookupLogs = await prisma.paymentConfirmationActionLog.findMany({
+      where: {
+        tenantId: access.tenant.id,
+        uploadId,
+        action: "LOOKUP",
+        paymentReference: { in: paymentReferences },
+      },
+      orderBy: [{ rowNumber: "asc" }, { createdAt: "asc" }],
+    });
+    const lookupByReference = new Map(
+      lookupLogs.map((log) => [log.paymentReference, log])
+    );
+
+    await prisma.paymentConfirmationActionLog.createMany({
+      data: paymentReferences.map((paymentReference) => {
+        const lookupLog = lookupByReference.get(paymentReference);
+        const confirmed = confirmedSet.has(paymentReference);
+
+        return {
+          tenantId: access.tenant.id,
+          uploadId,
+          rowNumber: lookupLog?.rowNumber ?? null,
+          paymentReference,
+          matched: Boolean(lookupLog?.matched),
+          action: "CONFIRM_PAYMENT",
+          actionStatus: confirmed ? "SUCCESS" : "FAILED",
+          leadId: lookupLog?.leadId ?? null,
+          fineractLoanId: lookupLog?.fineractLoanId ?? null,
+          fineractClientId: lookupLog?.fineractClientId ?? null,
+          loanAccountNo: lookupLog?.loanAccountNo ?? null,
+          clientName: lookupLog?.clientName ?? null,
+          paymentInternalReference:
+            lookupLog?.paymentInternalReference ?? paymentReference,
+          paymentUserReference: lookupLog?.paymentUserReference ?? null,
+          paymentProviderReference: lookupLog?.paymentProviderReference ?? null,
+          paymentStatus: lookupLog?.paymentStatus ?? null,
+          paymentCallbackStatus: lookupLog?.paymentCallbackStatus ?? null,
+          paymentConfirmed: confirmed,
+          paymentConfirmedAt: confirmed ? confirmedAt : null,
+          actedById: access.actorId,
+          actedByName: access.actorName,
+          errorMessage: confirmed
+            ? null
+            : "Payment service did not confirm this reference",
+          requestPayload: { paymentReferences },
+          responsePayload: confirmationResult.raw as Prisma.InputJsonValue,
+        };
+      }),
+    });
+
+    const confirmedReferences = paymentReferences.filter((reference) =>
+      confirmedSet.has(reference)
+    );
+    const failedReferences = paymentReferences.filter(
+      (reference) => !confirmedSet.has(reference)
+    );
+
+    if (confirmedReferences.length > 0) {
+      await prisma.paymentConfirmationActionLog.updateMany({
+        where: {
+          tenantId: access.tenant.id,
+          uploadId,
+          action: "LOOKUP",
+          paymentReference: { in: confirmedReferences },
+        },
+        data: {
+          actionStatus: "CONFIRMED",
+          paymentConfirmed: true,
+          paymentConfirmedAt: confirmedAt,
+        },
+      });
+    }
+
+    await prisma.paymentConfirmationUpload.update({
+      where: { id: uploadId },
+      data: {
+        confirmedCount: { increment: confirmedReferences.length },
+        failedCount: { increment: failedReferences.length },
+        status: failedReferences.length > 0 ? "PARTIAL" : "COMPLETED",
+      },
+    });
+
+    return NextResponse.json({
+      confirmedPaymentReferences: confirmedReferences,
+      failedPaymentReferences: failedReferences,
+      confirmedAt,
+    });
+  } catch (error) {
+    console.error("Payment confirmation failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to confirm payments",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/leads/payment-confirmation/confirmed/route.ts
+++ b/app/api/leads/payment-confirmation/confirmed/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { requirePaymentConfirmationAccess } from "@/lib/payment-confirmation-access";
+
+type AuditLogWithUpload = {
+  id: string;
+  uploadId: string | null;
+  rowNumber: number | null;
+  paymentReference: string;
+  action: string;
+  actionStatus: string;
+  fineractLoanId: number | null;
+  fineractClientId: number | null;
+  loanAccountNo: string | null;
+  clientName: string | null;
+  paymentProviderReference: string | null;
+  paymentStatus: string | null;
+  paymentConfirmedAt: Date | null;
+  actedByName: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  upload: {
+    id: string;
+    fileName: string;
+    createdAt: Date;
+  } | null;
+};
+
+function parsePageParam(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function toAuditItem(log: AuditLogWithUpload) {
+  return {
+    id: log.id,
+    uploadId: log.uploadId,
+    rowNumber: log.rowNumber,
+    paymentReference: log.paymentReference,
+    action: log.action,
+    actionStatus: log.actionStatus,
+    fineractLoanId: log.fineractLoanId,
+    fineractClientId: log.fineractClientId,
+    loanAccountNo: log.loanAccountNo,
+    clientName: log.clientName,
+    paymentProviderReference: log.paymentProviderReference,
+    paymentStatus: log.paymentStatus,
+    paymentConfirmedAt: log.paymentConfirmedAt,
+    actedByName: log.actedByName,
+    errorMessage: log.errorMessage,
+    createdAt: log.createdAt,
+    upload: log.upload
+      ? {
+          id: log.upload.id,
+          fileName: log.upload.fileName,
+          createdAt: log.upload.createdAt,
+        }
+      : null,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const access = await requirePaymentConfirmationAccess();
+    if (!access.ok) return access.response;
+
+    const searchParams = request.nextUrl.searchParams;
+    const page = parsePageParam(searchParams.get("page"), 1);
+    const pageSize = Math.min(parsePageParam(searchParams.get("pageSize"), 20), 100);
+    const skip = (page - 1) * pageSize;
+
+    const where = {
+      tenantId: access.tenant.id,
+      action: "CONFIRM_PAYMENT",
+      actionStatus: "SUCCESS",
+    };
+
+    const [items, total] = await Promise.all([
+      prisma.paymentConfirmationActionLog.findMany({
+        where,
+        include: {
+          upload: {
+            select: { id: true, fileName: true, createdAt: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: pageSize,
+      }),
+      prisma.paymentConfirmationActionLog.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      items: items.map(toAuditItem),
+      total,
+      page,
+      pageSize,
+      totalPages: Math.max(1, Math.ceil(total / pageSize)),
+    });
+  } catch (error) {
+    console.error("Failed to fetch confirmed payments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch confirmed payments" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/leads/payment-confirmation/lookup/route.ts
+++ b/app/api/leads/payment-confirmation/lookup/route.ts
@@ -1,0 +1,340 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma";
+import prisma from "@/lib/prisma";
+import { requirePaymentConfirmationAccess } from "@/lib/payment-confirmation-access";
+import {
+  lookupPaymentsInBatches,
+  PaymentLookupPayment,
+} from "@/lib/payment-service";
+
+type LookupRowInput = {
+  rowNumber?: number;
+  paymentReference?: string | null;
+  fineractLoanId?: number | string | null;
+  fineractClientId?: number | string | null;
+  loanAccountNo?: string | null;
+  clientName?: string | null;
+  rawRow?: Record<string, string>;
+};
+
+type NormalizedLookupRow = {
+  rowNumber: number;
+  paymentReference: string;
+  fineractLoanId: number | null;
+  fineractClientId: number | null;
+  loanAccountNo: string | null;
+  clientName: string | null;
+  rawRow?: Record<string, string>;
+};
+
+type PaymentConfirmationLookupLog = {
+  id: string;
+  uploadId: string | null;
+  rowNumber: number | null;
+  paymentReference: string;
+  matched: boolean;
+  actionStatus: string;
+  fineractLoanId: number | null;
+  fineractClientId: number | null;
+  loanAccountNo: string | null;
+  clientName: string | null;
+  createdAt: Date;
+  paymentInternalReference: string | null;
+  paymentUserReference: string | null;
+  paymentProviderReference: string | null;
+  paymentStatus: string | null;
+  paymentCallbackStatus: string | null;
+  paymentConfirmed: boolean;
+  paymentConfirmedAt: Date | null;
+};
+
+function normalizeReference(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function parseOptionalInt(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseOptionalDate(value: unknown): Date | null {
+  if (!value) return null;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function getPaymentReference(payment: PaymentLookupPayment): string {
+  return normalizeReference(
+    payment.internalReferenceNumber ||
+      payment.internal_reference_number ||
+      payment.userReferenceNumber ||
+      payment.user_reference_number
+  );
+}
+
+function getProviderReference(payment: PaymentLookupPayment): string | null {
+  return (
+    normalizeReference(
+      payment.providerReferenceNumber || payment.provider_reference_number
+    ) || null
+  );
+}
+
+function isConfirmable(payment: PaymentLookupPayment): boolean {
+  return (
+    Boolean(getProviderReference(payment)) &&
+    String(payment.status || "").toUpperCase() === "COMPLETED" &&
+    !payment.paymentConfirmed
+  );
+}
+
+function toPaymentPayload(payment: PaymentLookupPayment | null) {
+  if (!payment) return null;
+
+  return {
+    id: payment.id ?? null,
+    amount: payment.amount ?? null,
+    currency: payment.currency ?? null,
+    phoneNumber: payment.phoneNumber ?? null,
+    userReferenceNumber: payment.userReferenceNumber ?? null,
+    internalReferenceNumber: payment.internalReferenceNumber ?? null,
+    providerReferenceNumber: payment.providerReferenceNumber ?? null,
+    status: payment.status ?? null,
+    callbackStatus: payment.callbackStatus ?? null,
+    paymentConfirmed: Boolean(payment.paymentConfirmed),
+    confirmedAt: payment.confirmedAt ?? null,
+    createdAt: payment.createdAt ?? null,
+    canConfirm: isConfirmable(payment),
+  };
+}
+
+function toLookupItem(log: PaymentConfirmationLookupLog) {
+  return {
+    id: log.id,
+    uploadId: log.uploadId,
+    rowNumber: log.rowNumber,
+    paymentReference: log.paymentReference,
+    matched: log.matched,
+    actionStatus: log.actionStatus,
+    fineractLoanId: log.fineractLoanId,
+    fineractClientId: log.fineractClientId,
+    loanAccountNo: log.loanAccountNo,
+    clientName: log.clientName,
+    createdAt: log.createdAt,
+    payment: log.matched
+      ? {
+          internalReferenceNumber: log.paymentInternalReference,
+          userReferenceNumber: log.paymentUserReference,
+          providerReferenceNumber: log.paymentProviderReference,
+          status: log.paymentStatus,
+          callbackStatus: log.paymentCallbackStatus,
+          paymentConfirmed: log.paymentConfirmed,
+          confirmedAt: log.paymentConfirmedAt,
+          canConfirm:
+            Boolean(log.paymentProviderReference) &&
+            String(log.paymentStatus || "").toUpperCase() === "COMPLETED" &&
+            !log.paymentConfirmed,
+        }
+      : null,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requirePaymentConfirmationAccess();
+    if (!access.ok) return access.response;
+
+    const body = await request.json();
+    const { fileName, columnMapping, rows } = body as {
+      fileName?: string;
+      columnMapping?: Record<string, string>;
+      rows?: LookupRowInput[];
+    };
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return NextResponse.json({ error: "No CSV rows provided" }, { status: 400 });
+    }
+
+    const normalizedRows: NormalizedLookupRow[] = rows
+      .map((row, index) => {
+        const paymentReference = normalizeReference(row.paymentReference);
+        const explicitLoanId = parseOptionalInt(row.fineractLoanId);
+        const referenceLoanId = parseOptionalInt(paymentReference);
+
+        return {
+          rowNumber: parseOptionalInt(row.rowNumber) ?? index + 1,
+          paymentReference,
+          fineractLoanId: explicitLoanId ?? referenceLoanId,
+          fineractClientId: parseOptionalInt(row.fineractClientId),
+          loanAccountNo: normalizeReference(row.loanAccountNo) || null,
+          clientName: normalizeReference(row.clientName) || null,
+          rawRow: row.rawRow,
+        };
+      })
+      .filter((row) => row.paymentReference.length > 0);
+
+    if (normalizedRows.length === 0) {
+      return NextResponse.json(
+        { error: "No payment references were found in the selected column" },
+        { status: 400 }
+      );
+    }
+
+    const paymentReferences = normalizedRows.map((row) => row.paymentReference);
+    const lookupResult = await lookupPaymentsInBatches(
+      access.tenant.slug,
+      paymentReferences
+    );
+
+    const paymentByReference = new Map<string, PaymentLookupPayment>();
+    for (const payment of lookupResult.items) {
+      const reference = getPaymentReference(payment);
+      if (reference) {
+        paymentByReference.set(reference, payment);
+      }
+    }
+
+    const loanIds = Array.from(
+      new Set(
+        normalizedRows
+          .map((row) => row.fineractLoanId)
+          .filter(
+            (loanId): loanId is number =>
+              typeof loanId === "number" && Number.isFinite(loanId)
+          )
+      )
+    );
+    const loanAccountNos = Array.from(
+      new Set(
+        normalizedRows
+          .map((row) => row.loanAccountNo)
+          .filter((accountNo): accountNo is string => Boolean(accountNo))
+      )
+    );
+    const leadWhere: Prisma.LeadWhereInput[] = [];
+    if (loanIds.length > 0) {
+      leadWhere.push({ fineractLoanId: { in: loanIds } });
+    }
+    if (loanAccountNos.length > 0) {
+      leadWhere.push({ fineractAccountNo: { in: loanAccountNos } });
+    }
+
+    const leads =
+      leadWhere.length > 0
+        ? await prisma.lead.findMany({
+            where: {
+              tenantId: access.tenant.id,
+              OR: leadWhere,
+            },
+            select: {
+              id: true,
+              fineractLoanId: true,
+              fineractClientId: true,
+              fineractAccountNo: true,
+              firstname: true,
+              middlename: true,
+              lastname: true,
+              fullname: true,
+            },
+          })
+        : [];
+
+    const leadByLoanId = new Map(
+      leads
+        .filter((lead) => lead.fineractLoanId)
+        .map((lead) => [lead.fineractLoanId as number, lead])
+    );
+    const leadByAccountNo = new Map(
+      leads
+        .filter((lead) => lead.fineractAccountNo)
+        .map((lead) => [lead.fineractAccountNo as string, lead])
+    );
+
+    const upload = await prisma.paymentConfirmationUpload.create({
+      data: {
+        tenantId: access.tenant.id,
+        fileName: fileName || "payment-confirmation.csv",
+        uploadedById: access.actorId,
+        uploadedByName: access.actorName,
+        status: "LOOKED_UP",
+        totalRows: normalizedRows.length,
+        matchedCount: normalizedRows.filter((row) =>
+          paymentByReference.has(row.paymentReference)
+        ).length,
+        unmatchedCount: normalizedRows.filter(
+          (row) => !paymentByReference.has(row.paymentReference)
+        ).length,
+        columnMapping: columnMapping || undefined,
+      },
+    });
+
+    await prisma.paymentConfirmationActionLog.createMany({
+      data: normalizedRows.map((row) => {
+        const payment = paymentByReference.get(row.paymentReference) || null;
+        const lead =
+          (row.fineractLoanId ? leadByLoanId.get(row.fineractLoanId) : null) ||
+          (row.loanAccountNo ? leadByAccountNo.get(row.loanAccountNo) : null) ||
+          null;
+        const clientName =
+          row.clientName ||
+          lead?.fullname ||
+          [lead?.firstname, lead?.middlename, lead?.lastname]
+            .filter(Boolean)
+            .join(" ") ||
+          null;
+        const paymentPayload = toPaymentPayload(payment);
+
+        return {
+          tenantId: access.tenant.id,
+          uploadId: upload.id,
+          rowNumber: row.rowNumber,
+          paymentReference: row.paymentReference,
+          matched: Boolean(payment),
+          action: "LOOKUP",
+          actionStatus: payment ? "MATCHED" : "UNMATCHED",
+          leadId: lead?.id || null,
+          fineractLoanId: row.fineractLoanId ?? lead?.fineractLoanId ?? null,
+          fineractClientId:
+            row.fineractClientId ?? lead?.fineractClientId ?? null,
+          loanAccountNo: row.loanAccountNo ?? lead?.fineractAccountNo ?? null,
+          clientName,
+          paymentInternalReference: payment?.internalReferenceNumber ?? null,
+          paymentUserReference: payment?.userReferenceNumber ?? null,
+          paymentProviderReference: payment ? getProviderReference(payment) : null,
+          paymentStatus: payment?.status ?? null,
+          paymentCallbackStatus: payment?.callbackStatus ?? null,
+          paymentConfirmed: Boolean(payment?.paymentConfirmed),
+          paymentConfirmedAt: parseOptionalDate(payment?.confirmedAt),
+          actedById: access.actorId,
+          actedByName: access.actorName,
+          rawRow: row.rawRow || undefined,
+          requestPayload: { paymentReference: row.paymentReference },
+          responsePayload: paymentPayload || undefined,
+        };
+      }),
+    });
+
+    const logs = await prisma.paymentConfirmationActionLog.findMany({
+      where: { uploadId: upload.id, action: "LOOKUP" },
+      orderBy: [{ rowNumber: "asc" }, { createdAt: "asc" }],
+    });
+
+    return NextResponse.json({
+      upload,
+      matched: logs.filter((log) => log.matched).map(toLookupItem),
+      unmatched: logs.filter((log) => !log.matched).map(toLookupItem),
+    });
+  } catch (error) {
+    console.error("Payment confirmation lookup failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to lookup payment references",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/leads/payment-confirmation/reject/route.ts
+++ b/app/api/leads/payment-confirmation/reject/route.ts
@@ -1,0 +1,340 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma";
+import prisma from "@/lib/prisma";
+import { fetchFineractAPI } from "@/lib/api";
+import { requirePaymentConfirmationAccess } from "@/lib/payment-confirmation-access";
+import { formatDateForFineractUndo } from "@/lib/bulk-repayment-reverse";
+import { getPipelineStageNameForLoanAction } from "@/lib/fineract-stage-sync";
+
+type RejectItemInput = {
+  paymentReference?: string | null;
+  fineractLoanId?: number | string | null;
+  fineractClientId?: number | string | null;
+  loanAccountNo?: string | null;
+  clientName?: string | null;
+};
+
+type CommandResult = {
+  command: string;
+  status: "SUCCESS" | "FAILED";
+  response?: unknown;
+  error?: string;
+};
+
+function normalizeReference(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function parseOptionalInt(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getErrorMessage(error: unknown): string {
+  const details = error as {
+    message?: string;
+    errorData?: {
+      defaultUserMessage?: string;
+      developerMessage?: string;
+      error?: string;
+      errors?: Array<{
+        defaultUserMessage?: string;
+        developerMessage?: string;
+      }>;
+    };
+  };
+
+  return (
+    details.errorData?.errors?.[0]?.defaultUserMessage ||
+    details.errorData?.errors?.[0]?.developerMessage ||
+    details.errorData?.defaultUserMessage ||
+    details.errorData?.developerMessage ||
+    details.errorData?.error ||
+    details.message ||
+    "Fineract command failed"
+  );
+}
+
+async function runOptionalFineractCommand(
+  loanId: number,
+  command: string,
+  body: Record<string, unknown>
+): Promise<CommandResult> {
+  try {
+    const response = await fetchFineractAPI(`/loans/${loanId}?command=${command}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    return { command, status: "SUCCESS", response };
+  } catch (error) {
+    return { command, status: "FAILED", error: getErrorMessage(error) };
+  }
+}
+
+async function runRequiredFineractCommand(
+  loanId: number,
+  command: string,
+  body: Record<string, unknown>
+): Promise<CommandResult> {
+  try {
+    const response = await fetchFineractAPI(`/loans/${loanId}?command=${command}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    return { command, status: "SUCCESS", response };
+  } catch (error) {
+    return { command, status: "FAILED", error: getErrorMessage(error) };
+  }
+}
+
+async function markLeadRejected(
+  tenantId: string,
+  loanId: number,
+  actorName: string
+) {
+  const targetStageName = getPipelineStageNameForLoanAction("reject");
+  if (!targetStageName) return;
+
+  const lead = await prisma.lead.findFirst({
+    where: { tenantId, fineractLoanId: loanId },
+    select: { id: true, currentStageId: true },
+  });
+  if (!lead) return;
+
+  const targetStage = await prisma.pipelineStage.findFirst({
+    where: { tenantId, name: targetStageName, isActive: true },
+    select: { id: true },
+  });
+  if (!targetStage || lead.currentStageId === targetStage.id) return;
+
+  await prisma.stateTransition.create({
+    data: {
+      leadId: lead.id,
+      tenantId,
+      fromStageId: lead.currentStageId || targetStage.id,
+      toStageId: targetStage.id,
+      event: "loan_reject",
+      triggeredBy: actorName,
+      triggeredAt: new Date(),
+      metadata: {
+        loanId,
+        source: "payment-confirmation",
+      },
+    },
+  });
+
+  await prisma.lead.update({
+    where: { id: lead.id },
+    data: {
+      currentStageId: targetStage.id,
+      status: "REJECTED",
+      updatedAt: new Date(),
+      lastModified: new Date(),
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requirePaymentConfirmationAccess();
+    if (!access.ok) return access.response;
+
+    const body = await request.json();
+    const uploadId = normalizeReference(body?.uploadId);
+    const items = Array.isArray(body?.items)
+      ? (body.items as RejectItemInput[])
+      : [];
+    const baseNote =
+      normalizeReference(body?.note) ||
+      "Rejected after payment confirmation lookup returned no matching payment";
+
+    if (!uploadId) {
+      return NextResponse.json({ error: "uploadId is required" }, { status: 400 });
+    }
+
+    if (items.length === 0) {
+      return NextResponse.json(
+        { error: "At least one payment reference is required" },
+        { status: 400 }
+      );
+    }
+
+    const upload = await prisma.paymentConfirmationUpload.findFirst({
+      where: { id: uploadId, tenantId: access.tenant.id },
+      select: { id: true },
+    });
+
+    if (!upload) {
+      return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+    }
+
+    const paymentReferences = items
+      .map((item) => normalizeReference(item.paymentReference))
+      .filter(Boolean);
+    const lookupLogs = await prisma.paymentConfirmationActionLog.findMany({
+      where: {
+        tenantId: access.tenant.id,
+        uploadId,
+        action: "LOOKUP",
+        paymentReference: { in: paymentReferences },
+      },
+      orderBy: [{ rowNumber: "asc" }, { createdAt: "asc" }],
+    });
+    const lookupByReference = new Map(
+      lookupLogs.map((log) => [log.paymentReference, log])
+    );
+
+    const results = [];
+
+    for (const item of items) {
+      const paymentReference = normalizeReference(item.paymentReference);
+      if (!paymentReference) continue;
+
+      const lookupLog = lookupByReference.get(paymentReference);
+      const fineractLoanId =
+        parseOptionalInt(item.fineractLoanId) ?? lookupLog?.fineractLoanId ?? null;
+      const fineractClientId =
+        parseOptionalInt(item.fineractClientId) ??
+        lookupLog?.fineractClientId ??
+        null;
+      const loanAccountNo =
+        normalizeReference(item.loanAccountNo) || lookupLog?.loanAccountNo || null;
+      const clientName =
+        normalizeReference(item.clientName) || lookupLog?.clientName || null;
+
+      if (!fineractLoanId) {
+        const errorMessage = "No Fineract loan ID was available for this reference";
+        await prisma.paymentConfirmationActionLog.create({
+          data: {
+            tenantId: access.tenant.id,
+            uploadId,
+            rowNumber: lookupLog?.rowNumber ?? null,
+            paymentReference,
+            matched: false,
+            action: "REJECT_LOAN",
+            actionStatus: "FAILED",
+            fineractClientId,
+            loanAccountNo,
+            clientName,
+            actedById: access.actorId,
+            actedByName: access.actorName,
+            errorMessage,
+            requestPayload: item as Prisma.InputJsonValue,
+          },
+        });
+        results.push({ paymentReference, status: "FAILED", error: errorMessage });
+        continue;
+      }
+
+      const note = `${baseNote}. Payment reference: ${paymentReference}`;
+      const commandResults: CommandResult[] = [];
+      commandResults.push(
+        await runOptionalFineractCommand(fineractLoanId, "undodisbursal", {
+          note,
+        })
+      );
+      commandResults.push(
+        await runOptionalFineractCommand(fineractLoanId, "undoapproval", {
+          note,
+        })
+      );
+      const rejectResult = await runRequiredFineractCommand(
+        fineractLoanId,
+        "reject",
+        {
+          rejectedOnDate: formatDateForFineractUndo(new Date()),
+          dateFormat: "dd MMMM yyyy",
+          locale: "en",
+          note,
+        }
+      );
+      commandResults.push(rejectResult);
+
+      const succeeded = rejectResult.status === "SUCCESS";
+      const errorMessage = succeeded ? null : rejectResult.error || "Reject failed";
+
+      if (succeeded) {
+        await markLeadRejected(
+          access.tenant.id,
+          fineractLoanId,
+          access.actorName
+        );
+        await prisma.paymentConfirmationActionLog.updateMany({
+          where: {
+            tenantId: access.tenant.id,
+            uploadId,
+            action: "LOOKUP",
+            paymentReference,
+          },
+          data: {
+            actionStatus: "REJECTED",
+          },
+        });
+      }
+
+      await prisma.paymentConfirmationActionLog.create({
+        data: {
+          tenantId: access.tenant.id,
+          uploadId,
+          rowNumber: lookupLog?.rowNumber ?? null,
+          paymentReference,
+          matched: false,
+          action: "REJECT_LOAN",
+          actionStatus: succeeded ? "SUCCESS" : "FAILED",
+          leadId: lookupLog?.leadId ?? null,
+          fineractLoanId,
+          fineractClientId,
+          loanAccountNo,
+          clientName,
+          actedById: access.actorId,
+          actedByName: access.actorName,
+          errorMessage,
+          requestPayload: item as Prisma.InputJsonValue,
+          responsePayload: { commands: commandResults } as Prisma.InputJsonValue,
+        },
+      });
+
+      results.push({
+        paymentReference,
+        fineractLoanId,
+        status: succeeded ? "SUCCESS" : "FAILED",
+        commands: commandResults,
+        error: errorMessage,
+      });
+    }
+
+    const rejectedReferences = results
+      .filter((result) => result.status === "SUCCESS")
+      .map((result) => result.paymentReference);
+    const failedReferences = results
+      .filter((result) => result.status === "FAILED")
+      .map((result) => result.paymentReference);
+
+    await prisma.paymentConfirmationUpload.update({
+      where: { id: uploadId },
+      data: {
+        rejectedCount: { increment: rejectedReferences.length },
+        failedCount: { increment: failedReferences.length },
+        status: failedReferences.length > 0 ? "PARTIAL" : "COMPLETED",
+      },
+    });
+
+    return NextResponse.json({
+      rejectedReferences,
+      failedReferences,
+      results,
+    });
+  } catch (error) {
+    console.error("Payment confirmation reject failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to reject loans",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/leads/payment-confirmation/unconfirmed/route.ts
+++ b/app/api/leads/payment-confirmation/unconfirmed/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { requirePaymentConfirmationAccess } from "@/lib/payment-confirmation-access";
+
+type AuditLogWithUpload = {
+  id: string;
+  uploadId: string | null;
+  rowNumber: number | null;
+  paymentReference: string;
+  action: string;
+  actionStatus: string;
+  fineractLoanId: number | null;
+  fineractClientId: number | null;
+  loanAccountNo: string | null;
+  clientName: string | null;
+  actedByName: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  upload: {
+    id: string;
+    fileName: string;
+    createdAt: Date;
+  } | null;
+};
+
+function parsePageParam(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function toAuditItem(log: AuditLogWithUpload) {
+  return {
+    id: log.id,
+    uploadId: log.uploadId,
+    rowNumber: log.rowNumber,
+    paymentReference: log.paymentReference,
+    action: log.action,
+    actionStatus: log.actionStatus,
+    fineractLoanId: log.fineractLoanId,
+    fineractClientId: log.fineractClientId,
+    loanAccountNo: log.loanAccountNo,
+    clientName: log.clientName,
+    actedByName: log.actedByName,
+    errorMessage: log.errorMessage,
+    createdAt: log.createdAt,
+    upload: log.upload
+      ? {
+          id: log.upload.id,
+          fileName: log.upload.fileName,
+          createdAt: log.upload.createdAt,
+        }
+      : null,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const access = await requirePaymentConfirmationAccess();
+    if (!access.ok) return access.response;
+
+    const searchParams = request.nextUrl.searchParams;
+    const page = parsePageParam(searchParams.get("page"), 1);
+    const pageSize = Math.min(parsePageParam(searchParams.get("pageSize"), 20), 100);
+    const skip = (page - 1) * pageSize;
+
+    const where = {
+      tenantId: access.tenant.id,
+      OR: [
+        {
+          action: "LOOKUP",
+          actionStatus: { in: ["UNMATCHED", "REJECTED"] },
+        },
+        {
+          action: { in: ["CONFIRM_PAYMENT", "REJECT_LOAN"] },
+          actionStatus: "FAILED",
+        },
+      ],
+    };
+
+    const [items, total] = await Promise.all([
+      prisma.paymentConfirmationActionLog.findMany({
+        where,
+        include: {
+          upload: {
+            select: { id: true, fileName: true, createdAt: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: pageSize,
+      }),
+      prisma.paymentConfirmationActionLog.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      items: items.map(toAuditItem),
+      total,
+      page,
+      pageSize,
+      totalPages: Math.max(1, Math.ceil(total / pageSize)),
+    });
+  } catch (error) {
+    console.error("Failed to fetch unconfirmed payments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch unconfirmed payments" },
+      { status: 500 }
+    );
+  }
+}

--- a/env.example
+++ b/env.example
@@ -12,6 +12,9 @@ FINERACT_TENANT_ID=goodfellow
 FINERACT_USERNAME=mifos
 FINERACT_PASSWORD=password
 
+# Payment Service Configuration
+PAYMENT_SERVICE_BASE_URL=http://localhost:8080
+
 # AMQP Queue Configuration for USSD Leads
 AMQP_HOST=10.10.0.24
 AMQP_PORT=30672

--- a/lib/payment-confirmation-access.ts
+++ b/lib/payment-confirmation-access.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { DEFAULT_FEATURES } from "@/shared/types/tenant";
+
+type PaymentConfirmationAccess =
+  | {
+      ok: true;
+      tenant: NonNullable<Awaited<ReturnType<typeof getTenantFromHeaders>>>;
+      session: NonNullable<Awaited<ReturnType<typeof getSession>>>;
+      actorId: string;
+      actorName: string;
+    }
+  | {
+      ok: false;
+      response: NextResponse;
+    };
+
+export async function requirePaymentConfirmationAccess(): Promise<PaymentConfirmationAccess> {
+  const [tenant, session] = await Promise.all([
+    getTenantFromHeaders(),
+    getSession(),
+  ]);
+
+  if (!session?.user?.userId) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  if (!tenant) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Tenant not found" }, { status: 404 }),
+    };
+  }
+
+  const settings = tenant.settings as unknown as
+    | { features?: Partial<Record<keyof typeof DEFAULT_FEATURES, boolean>> }
+    | null;
+  const features = {
+    ...DEFAULT_FEATURES,
+    ...settings?.features,
+  };
+
+  if (!features.leadConfig) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Feature disabled" }, { status: 403 }),
+    };
+  }
+
+  if (session.user.name !== "mifos") {
+    const superAdminRole = await prisma.userRole.findFirst({
+      where: {
+        tenantId: tenant.id,
+        mifosUserId: session.user.userId,
+        isActive: true,
+        role: {
+          name: "SUPER_ADMIN",
+          isActive: true,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (!superAdminRole) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    tenant,
+    session,
+    actorId: String(session.user.userId),
+    actorName: session.user.name || session.user.email || "system",
+  };
+}

--- a/lib/payment-service.ts
+++ b/lib/payment-service.ts
@@ -1,0 +1,232 @@
+type PaymentServicePage<T> = {
+  content?: T[];
+  items?: T[];
+  pageItems?: T[];
+  data?: T[];
+  totalElements?: number;
+  totalItems?: number;
+  total?: number;
+  totalPages?: number;
+  page?: number;
+  number?: number;
+  size?: number;
+};
+
+type PaymentServiceEnvelope<T> = {
+  data?: T;
+  payload?: T;
+  response?: T;
+  message?: string;
+  success?: boolean;
+};
+
+export type PaymentLookupPayment = {
+  id?: string;
+  tenantId?: string;
+  configId?: string;
+  amount?: number | string;
+  currency?: string;
+  phoneNumber?: string;
+  userReferenceNumber?: string;
+  user_reference_number?: string;
+  internalReferenceNumber?: string;
+  internal_reference_number?: string;
+  providerReferenceNumber?: string | null;
+  provider_reference_number?: string | null;
+  narration?: string;
+  status?: string;
+  callbackStatus?: string;
+  paymentConfirmed?: boolean;
+  confirmedAt?: string | null;
+  type?: string;
+  createdAt?: string;
+};
+
+export type PaymentLookupResult = {
+  items: PaymentLookupPayment[];
+  totalElements: number;
+  totalPages: number;
+  raw: unknown;
+};
+
+export type PaymentConfirmationResult = {
+  confirmedPaymentReferences: string[];
+  confirmedAt?: string;
+  raw: unknown;
+};
+
+type ConfirmedReferencesPayload = {
+  confirmedPaymentReferences?: unknown;
+  confirmedReferences?: unknown;
+  paymentReferences?: unknown;
+  references?: unknown;
+  confirmedAt?: string;
+};
+
+function asPaymentEnvelope<T>(payload: unknown): PaymentServiceEnvelope<T> | T {
+  return payload as PaymentServiceEnvelope<T> | T;
+}
+
+function getPaymentServiceBaseUrl(): string {
+  const baseUrl =
+    process.env.PAYMENT_SERVICE_BASE_URL || process.env.PAYMENT_SERVICE_URL;
+
+  if (!baseUrl) {
+    throw new Error("PAYMENT_SERVICE_BASE_URL is not configured");
+  }
+
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function buildPaymentServiceUrl(path: string): string {
+  const baseUrl = getPaymentServiceBaseUrl();
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (baseUrl.endsWith("/api/v1") && normalizedPath.startsWith("/api/v1/")) {
+    return `${baseUrl}${normalizedPath.replace(/^\/api\/v1/, "")}`;
+  }
+
+  return `${baseUrl}${normalizedPath}`;
+}
+
+function unwrapPaymentResponse<T>(payload: PaymentServiceEnvelope<T> | T): T {
+  const envelope = payload as PaymentServiceEnvelope<T>;
+  return envelope.data ?? envelope.payload ?? envelope.response ?? (payload as T);
+}
+
+function extractPageItems<T>(page: PaymentServicePage<T> | T[]): T[] {
+  if (Array.isArray(page)) return page;
+  return page.content ?? page.items ?? page.pageItems ?? page.data ?? [];
+}
+
+function extractConfirmedReferences(payload: unknown): string[] {
+  const data = unwrapPaymentResponse<ConfirmedReferencesPayload>(
+    asPaymentEnvelope<ConfirmedReferencesPayload>(payload)
+  );
+  const refs =
+    data?.confirmedPaymentReferences ??
+    data?.confirmedReferences ??
+    data?.paymentReferences ??
+    data?.references ??
+    [];
+
+  return Array.isArray(refs)
+    ? refs.map((ref) => String(ref).trim()).filter(Boolean)
+    : [];
+}
+
+async function paymentServiceRequest<T>(
+  tenantId: string,
+  path: string,
+  init: RequestInit
+): Promise<T> {
+  const response = await fetch(buildPaymentServiceUrl(path), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      tenantId,
+      ...(init.headers as Record<string, string> | undefined),
+    },
+    cache: "no-store",
+  });
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const body = payload as { message?: string; error?: string };
+    throw new Error(
+      body?.message ||
+        body?.error ||
+        `Payment service request failed with HTTP ${response.status}`
+    );
+  }
+
+  return payload as T;
+}
+
+export async function lookupPayments(
+  tenantId: string,
+  paymentReferences: string[],
+  page = 0,
+  size = paymentReferences.length
+): Promise<PaymentLookupResult> {
+  const raw = await paymentServiceRequest<unknown>(
+    tenantId,
+    `/api/v1/payments/lookup?page=${page}&size=${size}`,
+    {
+      method: "POST",
+      body: JSON.stringify({ paymentReferences }),
+    }
+  );
+  const pageData = unwrapPaymentResponse<
+    PaymentServicePage<PaymentLookupPayment> | PaymentLookupPayment[]
+  >(
+    asPaymentEnvelope<
+      PaymentServicePage<PaymentLookupPayment> | PaymentLookupPayment[]
+    >(raw)
+  );
+  const items = extractPageItems(pageData);
+
+  return {
+    items,
+    totalElements: Array.isArray(pageData)
+      ? items.length
+      : pageData.totalElements ?? pageData.totalItems ?? pageData.total ?? items.length,
+    totalPages: Array.isArray(pageData) ? 1 : pageData.totalPages ?? 1,
+    raw,
+  };
+}
+
+export async function lookupPaymentsInBatches(
+  tenantId: string,
+  paymentReferences: string[],
+  batchSize = 500
+): Promise<PaymentLookupResult> {
+  const uniqueReferences = Array.from(
+    new Set(paymentReferences.map((ref) => ref.trim()).filter(Boolean))
+  );
+  const allItems: PaymentLookupPayment[] = [];
+  const rawResponses: unknown[] = [];
+
+  for (let index = 0; index < uniqueReferences.length; index += batchSize) {
+    const batch = uniqueReferences.slice(index, index + batchSize);
+    const result = await lookupPayments(tenantId, batch, 0, batch.length);
+    allItems.push(...result.items);
+    rawResponses.push(result.raw);
+  }
+
+  return {
+    items: allItems,
+    totalElements: allItems.length,
+    totalPages: rawResponses.length,
+    raw: rawResponses,
+  };
+}
+
+export async function confirmPayments(
+  tenantId: string,
+  paymentReferences: string[]
+): Promise<PaymentConfirmationResult> {
+  const raw = await paymentServiceRequest<unknown>(
+    tenantId,
+    "/api/v1/payments/confirm",
+    {
+      method: "POST",
+      body: JSON.stringify({ paymentReferences }),
+    }
+  );
+  const data = unwrapPaymentResponse<ConfirmedReferencesPayload>(
+    asPaymentEnvelope<ConfirmedReferencesPayload>(raw)
+  );
+
+  return {
+    confirmedPaymentReferences: extractConfirmedReferences(raw),
+    confirmedAt: data?.confirmedAt,
+    raw,
+  };
+}

--- a/prisma/migrations/20260704120000_add_payment_confirmation_logs/migration.sql
+++ b/prisma/migrations/20260704120000_add_payment_confirmation_logs/migration.sql
@@ -1,0 +1,84 @@
+-- CreateTable
+CREATE TABLE "PaymentConfirmationUpload" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "uploadedById" TEXT,
+    "uploadedByName" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'LOOKED_UP',
+    "totalRows" INTEGER NOT NULL DEFAULT 0,
+    "matchedCount" INTEGER NOT NULL DEFAULT 0,
+    "unmatchedCount" INTEGER NOT NULL DEFAULT 0,
+    "confirmedCount" INTEGER NOT NULL DEFAULT 0,
+    "rejectedCount" INTEGER NOT NULL DEFAULT 0,
+    "failedCount" INTEGER NOT NULL DEFAULT 0,
+    "columnMapping" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PaymentConfirmationUpload_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PaymentConfirmationActionLog" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "uploadId" TEXT,
+    "rowNumber" INTEGER,
+    "paymentReference" TEXT NOT NULL,
+    "matched" BOOLEAN NOT NULL DEFAULT false,
+    "action" TEXT NOT NULL,
+    "actionStatus" TEXT NOT NULL DEFAULT 'PENDING',
+    "leadId" TEXT,
+    "fineractLoanId" INTEGER,
+    "fineractClientId" INTEGER,
+    "loanAccountNo" TEXT,
+    "clientName" TEXT,
+    "paymentInternalReference" TEXT,
+    "paymentUserReference" TEXT,
+    "paymentProviderReference" TEXT,
+    "paymentStatus" TEXT,
+    "paymentCallbackStatus" TEXT,
+    "paymentConfirmed" BOOLEAN NOT NULL DEFAULT false,
+    "paymentConfirmedAt" TIMESTAMP(3),
+    "actedById" TEXT,
+    "actedByName" TEXT,
+    "errorMessage" TEXT,
+    "rawRow" JSONB,
+    "requestPayload" JSONB,
+    "responsePayload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PaymentConfirmationActionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationUpload_tenantId_status_idx" ON "PaymentConfirmationUpload"("tenantId", "status");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationUpload_tenantId_createdAt_idx" ON "PaymentConfirmationUpload"("tenantId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationActionLog_tenantId_action_actionStatus_idx" ON "PaymentConfirmationActionLog"("tenantId", "action", "actionStatus");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationActionLog_tenantId_createdAt_idx" ON "PaymentConfirmationActionLog"("tenantId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationActionLog_uploadId_idx" ON "PaymentConfirmationActionLog"("uploadId");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationActionLog_paymentReference_idx" ON "PaymentConfirmationActionLog"("paymentReference");
+
+-- CreateIndex
+CREATE INDEX "PaymentConfirmationActionLog_fineractLoanId_idx" ON "PaymentConfirmationActionLog"("fineractLoanId");
+
+-- AddForeignKey
+ALTER TABLE "PaymentConfirmationUpload" ADD CONSTRAINT "PaymentConfirmationUpload_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PaymentConfirmationActionLog" ADD CONSTRAINT "PaymentConfirmationActionLog_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PaymentConfirmationActionLog" ADD CONSTRAINT "PaymentConfirmationActionLog_uploadId_fkey" FOREIGN KEY ("uploadId") REFERENCES "PaymentConfirmationUpload"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Tenant {
   invoiceDiscountingCharges InvoiceDiscountingCharge[]
   chargeProducts             ChargeProduct[]
   revolvingCreditFacilities  RevolvingCreditFacility[]
+  paymentConfirmationUploads PaymentConfirmationUpload[]
+  paymentConfirmationActionLogs PaymentConfirmationActionLog[]
 
   @@index([slug])
   @@index([isActive])
@@ -1363,6 +1365,70 @@ model BulkRepaymentItem {
   @@index([uploadId, status])
   @@index([uploadId, reversalStatus])
   @@index([loanId])
+}
+
+// ─── Payment Confirmation (Leads) ──────────────────────────────────────────
+
+model PaymentConfirmationUpload {
+  id             String                         @id @default(cuid())
+  tenantId       String
+  tenant         Tenant                         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  fileName       String
+  uploadedById   String?
+  uploadedByName String?
+  status         String                         @default("LOOKED_UP") // LOOKED_UP, PARTIAL, COMPLETED, FAILED
+  totalRows      Int                            @default(0)
+  matchedCount   Int                            @default(0)
+  unmatchedCount Int                            @default(0)
+  confirmedCount Int                            @default(0)
+  rejectedCount  Int                            @default(0)
+  failedCount    Int                            @default(0)
+  columnMapping  Json?
+  createdAt      DateTime                       @default(now())
+  updatedAt      DateTime                       @updatedAt
+  actionLogs     PaymentConfirmationActionLog[]
+
+  @@index([tenantId, status])
+  @@index([tenantId, createdAt])
+}
+
+model PaymentConfirmationActionLog {
+  id                       String                     @id @default(cuid())
+  tenantId                 String
+  tenant                   Tenant                     @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  uploadId                 String?
+  upload                   PaymentConfirmationUpload? @relation(fields: [uploadId], references: [id], onDelete: Cascade)
+  rowNumber                Int?
+  paymentReference         String
+  matched                  Boolean                    @default(false)
+  action                   String                     // LOOKUP, CONFIRM_PAYMENT, REJECT_LOAN
+  actionStatus             String                     @default("PENDING") // MATCHED, UNMATCHED, SUCCESS, FAILED, REJECTED, CONFIRMED
+  leadId                   String?
+  fineractLoanId           Int?
+  fineractClientId         Int?
+  loanAccountNo            String?
+  clientName               String?
+  paymentInternalReference String?
+  paymentUserReference     String?
+  paymentProviderReference String?
+  paymentStatus            String?
+  paymentCallbackStatus    String?
+  paymentConfirmed         Boolean                    @default(false)
+  paymentConfirmedAt       DateTime?
+  actedById                String?
+  actedByName              String?
+  errorMessage             String?                    @db.Text
+  rawRow                   Json?
+  requestPayload           Json?
+  responsePayload          Json?
+  createdAt                DateTime                   @default(now())
+  updatedAt                DateTime                   @updatedAt
+
+  @@index([tenantId, action, actionStatus])
+  @@index([tenantId, createdAt])
+  @@index([uploadId])
+  @@index([paymentReference])
+  @@index([fineractLoanId])
 }
 
 model LoanEligibilityUpload {


### PR DESCRIPTION
## Summary
- add Leads payment confirmation page with CSV reference-column mapping
- add lookup, confirm, reject, confirmed-list, and unconfirmed-list APIs
- add payment confirmation audit tables and migration
- add payment service client and lead-config visibility menu entry

## Verification
- npx prisma generate
- DATABASE_URL=postgresql://postgres:password@localhost:5432/loan_matrix?schema=public npx prisma validate
- targeted eslint on changed payment confirmation files
- filtered tsc check for payment confirmation files