### PR TITLE
Add payment confirmation access controls

### DIFF
--- a/app/(application)/components/mobile-sidebar.tsx
+++ b/app/(application)/components/mobile-sidebar.tsx
@@ -39,9 +39,14 @@ export function MobileSidebar({
   const { theme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const { isEnabled } = useFeatureFlags();
-  const { hasAnyRole, isLoading: rolesLoading } = useUserRoles();
+  const {
+    canConfirmPayments,
+    hasAnyRole,
+    isLoading: rolesLoading,
+  } = useUserRoles();
   const canSeeLeadConfiguration =
     !rolesLoading && hasAnyRole(["SUPER_ADMIN"]) && isEnabled("leadConfig");
+  const canSeePaymentConfirmation = !rolesLoading && canConfirmPayments;
 
   // Avoid hydration mismatch
   useEffect(() => {
@@ -207,28 +212,28 @@ export function MobileSidebar({
                     </Link>
                   )}
                   {canSeeLeadConfiguration && (
-                    <>
-                      <Link
-                        href="/leads/config"
-                        className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
-                          pathname === "/leads/config"
-                            ? iconColorActive
-                            : `${iconColor} hover:${textColor}`
-                        }`}
-                      >
-                        Configuration
-                      </Link>
-                      <Link
-                        href="/leads/payment-confirmation"
-                        className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
-                          pathname === "/leads/payment-confirmation"
-                            ? iconColorActive
-                            : `${iconColor} hover:${textColor}`
-                        }`}
-                      >
-                        Payment Confirmation
-                      </Link>
-                    </>
+                    <Link
+                      href="/leads/config"
+                      className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
+                        pathname === "/leads/config"
+                          ? iconColorActive
+                          : `${iconColor} hover:${textColor}`
+                      }`}
+                    >
+                      Configuration
+                    </Link>
+                  )}
+                  {canSeePaymentConfirmation && (
+                    <Link
+                      href="/leads/payment-confirmation"
+                      className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium ${
+                        pathname === "/leads/payment-confirmation"
+                          ? iconColorActive
+                          : `${iconColor} hover:${textColor}`
+                      }`}
+                    >
+                      Payment Confirmation
+                    </Link>
                   )}
                 </div>
               )}

--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -32,7 +32,11 @@ interface SidebarNavProps {
  * Handles role-based and feature-based visibility of menu items
  */
 export function SidebarNav({ canReadUsers }: Readonly<SidebarNavProps>) {
-  const { hasAnyRole, isLoading: rolesLoading } = useUserRoles();
+  const {
+    canConfirmPayments,
+    hasAnyRole,
+    isLoading: rolesLoading,
+  } = useUserRoles();
   const { isEnabled } = useFeatureFlags();
 
   // Define submenu items with role and feature restrictions
@@ -53,6 +57,9 @@ export function SidebarNav({ canReadUsers }: Readonly<SidebarNavProps>) {
     isEnabled("leadConfig")
   ) {
     leadsSubMenuItems.push({ label: "Configuration", href: "/leads/config" });
+  }
+
+  if (!rolesLoading && canConfirmPayments) {
     leadsSubMenuItems.push({
       label: "Payment Confirmation",
       href: "/leads/payment-confirmation",

--- a/app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx
+++ b/app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ChangeEvent,
+  DragEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import Papa from "papaparse";
 import {
   Ban,
@@ -8,9 +15,9 @@ import {
   ChevronLeft,
   ChevronRight,
   FileSpreadsheet,
-  Loader2,
   RefreshCw,
   Search,
+  Upload,
   XCircle,
 } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -25,6 +32,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
   SelectContent,
@@ -43,6 +51,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const NONE_VALUE = "__none__";
+const MAX_CSV_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
 type CsvRow = Record<string, string>;
 
@@ -164,6 +173,11 @@ function formatDate(value?: string | null): string {
   }).format(date);
 }
 
+function formatFileSize(bytes: number): string {
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(megabytes >= 10 ? 0 : 1)} MB`;
+}
+
 function normalizeCell(value: unknown): string {
   return typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
 }
@@ -190,6 +204,153 @@ function StatusBadge({ status }: { status?: string | null }) {
     <Badge variant={statusVariant(status)} className="max-w-full">
       {status || "-"}
     </Badge>
+  );
+}
+
+function PaymentConfirmationTableSkeleton({
+  columns,
+  rows = 5,
+}: {
+  columns: number;
+  rows?: number;
+}) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <TableRow key={`payment-confirmation-skeleton-row-${rowIndex}`}>
+          {Array.from({ length: columns }).map((__, columnIndex) => (
+            <TableCell key={`payment-confirmation-skeleton-cell-${rowIndex}-${columnIndex}`}>
+              <Skeleton
+                className={
+                  columnIndex === 0
+                    ? "h-4 w-8"
+                    : columnIndex % 3 === 0
+                      ? "h-4 w-24"
+                      : "h-4 w-32"
+                }
+              />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+function LookupResultsSkeleton() {
+  const tables = [
+    {
+      titleWidth: "w-40",
+      badgeWidth: "w-10",
+      columns: ["", "Reference", "Provider Ref", "Status", "Loan ID", "Client"],
+    },
+    {
+      titleWidth: "w-44",
+      badgeWidth: "w-10",
+      columns: ["", "Reference", "Loan ID", "Client", "Status"],
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-2" aria-busy="true">
+      {tables.map((table, index) => (
+        <Card key={`lookup-results-skeleton-${index}`}>
+          <CardHeader>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4 rounded-full" />
+                <Skeleton className={`h-5 ${table.titleWidth}`} />
+                <Skeleton className={`h-5 ${table.badgeWidth}`} />
+              </div>
+              <Skeleton className="h-9 w-28" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border overflow-auto max-h-[420px]">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {table.columns.map((column, columnIndex) => (
+                      <TableHead key={`${column}-${columnIndex}`}>
+                        {column || <span className="sr-only">Select</span>}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <PaymentConfirmationTableSkeleton
+                    columns={table.columns.length}
+                  />
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function CsvUploadDropzone({
+  file,
+  isDragging,
+  onFileInputChange,
+  onDragEnter,
+  onDragLeave,
+  onDragOver,
+  onDrop,
+}: {
+  file: File | null;
+  isDragging: boolean;
+  onFileInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onDragEnter: (event: DragEvent<HTMLLabelElement>) => void;
+  onDragLeave: (event: DragEvent<HTMLLabelElement>) => void;
+  onDragOver: (event: DragEvent<HTMLLabelElement>) => void;
+  onDrop: (event: DragEvent<HTMLLabelElement>) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Input
+        id="payment-confirmation-file"
+        type="file"
+        accept=".csv,text/csv"
+        className="sr-only"
+        onChange={onFileInputChange}
+      />
+      <Label
+        htmlFor="payment-confirmation-file"
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        className={`flex min-h-44 cursor-pointer flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition-colors ${
+          isDragging
+            ? "border-primary bg-primary/5"
+            : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/30"
+        }`}
+      >
+        <span className="relative mb-5 inline-flex h-14 w-14 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <FileSpreadsheet className="h-8 w-8" />
+          <span className="absolute -right-2 -top-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm">
+            <Upload className="h-4 w-4" />
+          </span>
+        </span>
+        <span className="text-sm font-medium text-foreground">
+          {file ? file.name : "Create or import a payment confirmation CSV"}
+        </span>
+        {file ? (
+          <span className="mt-2 text-xs text-muted-foreground">
+            {formatFileSize(file.size)}
+          </span>
+        ) : (
+          <span className="mt-2 text-xs leading-5 text-muted-foreground">
+            Maximum file size: 50 MB
+            <br />
+            Supported format: .CSV
+          </span>
+        )}
+      </Label>
+    </div>
   );
 }
 
@@ -229,11 +390,7 @@ function AuditTable({
             </TableHeader>
             <TableBody>
               {loading ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="h-24 text-center">
-                    <Loader2 className="mx-auto h-5 w-5 animate-spin text-muted-foreground" />
-                  </TableCell>
-                </TableRow>
+                <PaymentConfirmationTableSkeleton columns={7} />
               ) : page.items.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
@@ -296,6 +453,7 @@ function AuditTable({
 export function PaymentConfirmationClient() {
   const [activeTab, setActiveTab] = useState("upload");
   const [file, setFile] = useState<File | null>(null);
+  const [isDraggingUpload, setIsDraggingUpload] = useState(false);
   const [headers, setHeaders] = useState<string[]>([]);
   const [previewRows, setPreviewRows] = useState<CsvRow[]>([]);
   const [allRows, setAllRows] = useState<CsvRow[]>([]);
@@ -403,13 +561,30 @@ export function PaymentConfirmationClient() {
     setNotice(null);
   }, []);
 
-  const handleFileChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const selected = event.target.files?.[0] || null;
-      setFile(selected);
+  const processCsvFile = useCallback(
+    (selected: File | null) => {
       resetUploadState();
 
-      if (!selected) return;
+      if (!selected) {
+        setFile(null);
+        return;
+      }
+
+      const isCsvFile = selected.name.toLowerCase().endsWith(".csv");
+
+      if (!isCsvFile) {
+        setFile(null);
+        setError("Choose a CSV file");
+        return;
+      }
+
+      if (selected.size > MAX_CSV_FILE_SIZE_BYTES) {
+        setFile(null);
+        setError("CSV file must be 50 MB or smaller");
+        return;
+      }
+
+      setFile(selected);
 
       Papa.parse(selected, {
         header: true,
@@ -460,6 +635,50 @@ export function PaymentConfirmationClient() {
       });
     },
     [resetUploadState]
+  );
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      processCsvFile(event.target.files?.[0] || null);
+    },
+    [processCsvFile]
+  );
+
+  const handleUploadDragEnter = useCallback(
+    (event: DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDraggingUpload(true);
+    },
+    []
+  );
+
+  const handleUploadDragLeave = useCallback(
+    (event: DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDraggingUpload(false);
+    },
+    []
+  );
+
+  const handleUploadDragOver = useCallback(
+    (event: DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDraggingUpload(true);
+    },
+    []
+  );
+
+  const handleUploadDrop = useCallback(
+    (event: DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDraggingUpload(false);
+      processCsvFile(event.dataTransfer.files?.[0] || null);
+    },
+    [processCsvFile]
   );
 
   const updateMapping = (field: keyof ColumnMapping, value: string) => {
@@ -740,26 +959,22 @@ export function PaymentConfirmationClient() {
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-              <div className="space-y-2">
-                <Label htmlFor="payment-confirmation-file">CSV file</Label>
-                <Input
-                  id="payment-confirmation-file"
-                  type="file"
-                  accept=".csv,.txt"
-                  onChange={handleFileChange}
-                />
-              </div>
+              <CsvUploadDropzone
+                file={file}
+                isDragging={isDraggingUpload}
+                onFileInputChange={handleFileChange}
+                onDragEnter={handleUploadDragEnter}
+                onDragLeave={handleUploadDragLeave}
+                onDragOver={handleUploadDragOver}
+                onDrop={handleUploadDrop}
+              />
               <Button
                 type="button"
                 onClick={handleLookup}
                 disabled={lookupLoading || !file || !mapping.referenceColumn}
               >
-                {lookupLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Search className="h-4 w-4" />
-                )}
-                Lookup
+                <Search className="h-4 w-4" />
+                {lookupLoading ? "Looking up..." : "Lookup"}
               </Button>
             </div>
 
@@ -835,7 +1050,9 @@ export function PaymentConfirmationClient() {
           </CardContent>
         </Card>
 
-        {lookup && (
+        {lookupLoading ? (
+          <LookupResultsSkeleton />
+        ) : lookup && (
           <div className="grid gap-4 xl:grid-cols-2">
             <Card>
               <CardHeader>
@@ -850,12 +1067,8 @@ export function PaymentConfirmationClient() {
                     onClick={handleConfirm}
                     disabled={confirmLoading || selectedConfirmRefs.size === 0}
                   >
-                    {confirmLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <CheckCircle2 className="h-4 w-4" />
-                    )}
-                    Confirm
+                    <CheckCircle2 className="h-4 w-4" />
+                    {confirmLoading ? "Confirming..." : "Confirm"}
                   </Button>
                 </div>
               </CardHeader>
@@ -937,12 +1150,8 @@ export function PaymentConfirmationClient() {
                     onClick={handleReject}
                     disabled={rejectLoading || selectedRejectRefs.size === 0}
                   >
-                    {rejectLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <XCircle className="h-4 w-4" />
-                    )}
-                    Reject Loans
+                    <XCircle className="h-4 w-4" />
+                    {rejectLoading ? "Rejecting..." : "Reject Loans"}
                   </Button>
                 </div>
               </CardHeader>

--- a/app/(application)/leads/payment-confirmation/page.tsx
+++ b/app/(application)/leads/payment-confirmation/page.tsx
@@ -1,6 +1,23 @@
+import { ShieldAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { requirePaymentConfirmationPageAccess } from "@/lib/payment-confirmation-access";
 import { PaymentConfirmationClient } from "./components/payment-confirmation-client";
 
-export default function PaymentConfirmationPage() {
+export default async function PaymentConfirmationPage() {
+  const access = await requirePaymentConfirmationPageAccess();
+
+  if (!access.ok) {
+    return (
+      <div className="container mx-auto p-4">
+        <Alert variant="destructive" className="max-w-2xl">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>Access denied</AlertTitle>
+          <AlertDescription>{access.message}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto p-4 space-y-6">
       <div>

--- a/app/(application)/organization/users/components/user-detail-tabs.tsx
+++ b/app/(application)/organization/users/components/user-detail-tabs.tsx
@@ -367,6 +367,10 @@ export function UserDetailTabs({
               value={user.canOverrideInitiatorDisbursement ? "Yes" : "No"}
             />
             <DetailField
+              label="Can Confirm Payments"
+              value={user.canConfirmPayments ? "Yes" : "No"}
+            />
+            <DetailField
               label="Lead Visibility"
               value={
                 restrictLeadVisibilityToBranches

--- a/app/(application)/organization/users/components/user-form.tsx
+++ b/app/(application)/organization/users/components/user-form.tsx
@@ -83,6 +83,7 @@ type FormState = {
   sendPasswordToEmail: boolean;
   passwordNeverExpires: boolean;
   canOverrideInitiatorDisbursement: boolean;
+  canConfirmPayments: boolean;
   officeId: string;
   staffId: string;
   visibleLeadOfficeIds: number[];
@@ -109,6 +110,7 @@ function buildInitialState(
     passwordNeverExpires: initialUser?.passwordNeverExpires ?? false,
     canOverrideInitiatorDisbursement:
       initialUser?.canOverrideInitiatorDisbursement ?? false,
+    canConfirmPayments: initialUser?.canConfirmPayments ?? false,
     officeId: initialUser?.officeId ? String(initialUser.officeId) : "",
     staffId: initialUser?.staff?.id ? String(initialUser.staff.id) : "",
     visibleLeadOfficeIds: initialUser?.visibleLeadOffices.map((office) => office.id) ?? [],
@@ -258,10 +260,11 @@ export function UserForm({
       .filter((office): office is NonNullable<typeof office> => Boolean(office));
   }, [expandedVisibleLeadOfficeSelection, template.allowedOffices]);
   const isHeadOfficeSelection =
-    Boolean(headOffice) && visibleLeadOfficeSelection.includes(headOffice.id);
+    headOffice ? visibleLeadOfficeSelection.includes(headOffice.id) : false;
   const isHeadOfficeDraftSelection =
-    Boolean(headOffice) &&
-    collapsedLeadBranchDraftSelection.includes(headOffice.id);
+    headOffice
+      ? collapsedLeadBranchDraftSelection.includes(headOffice.id)
+      : false;
   const initialVisibleLeadOfficeSelection = useMemo(
     () =>
       collapseVisibleLeadOfficeSelection(
@@ -279,14 +282,10 @@ export function UserForm({
 
   useEffect(() => {
     if (mode !== "edit" || !initialUser?.id) {
-      setSignatureLoading(false);
       return;
     }
 
     let isCancelled = false;
-
-    setSignatureLoading(true);
-    setSignatureError(null);
 
     getUserSignatureAction(initialUser.id)
       .then((result) => {
@@ -316,30 +315,6 @@ export function UserForm({
       isCancelled = true;
     };
   }, [initialUser?.id, mode]);
-
-  useEffect(() => {
-    if (!template.restrictLeadVisibilityToBranches) {
-      return;
-    }
-
-    const normalizedSelection = collapseVisibleLeadOfficeSelection(
-      form.visibleLeadOfficeIds,
-      template.allowedOffices
-    );
-
-    if (areNumberArraysEqual(form.visibleLeadOfficeIds, normalizedSelection)) {
-      return;
-    }
-
-    setForm((current) => ({
-      ...current,
-      visibleLeadOfficeIds: normalizedSelection,
-    }));
-  }, [
-    form.visibleLeadOfficeIds,
-    template.allowedOffices,
-    template.restrictLeadVisibilityToBranches,
-  ]);
 
   const handleChange = <K extends keyof FormState>(key: K, value: FormState[K]) => {
     setForm((current) => ({
@@ -427,8 +402,9 @@ export function UserForm({
       template.allowedOffices
     );
     const hasHeadOfficeSelected =
-      Boolean(headOffice) &&
-      normalizedCurrentSelection.includes(headOffice.id);
+      headOffice
+        ? normalizedCurrentSelection.includes(headOffice.id)
+        : false;
 
     if (headOffice && officeId === headOffice.id) {
       return checked ? [headOffice.id] : [];
@@ -523,9 +499,10 @@ export function UserForm({
       sendPasswordToEmail: form.sendPasswordToEmail,
       passwordNeverExpires: form.passwordNeverExpires,
       canOverrideInitiatorDisbursement: form.canOverrideInitiatorDisbursement,
+      canConfirmPayments: form.canConfirmPayments,
       officeId: form.officeId,
       staffId: form.staffId || null,
-      visibleLeadOfficeIds: form.visibleLeadOfficeIds,
+      visibleLeadOfficeIds: visibleLeadOfficeSelection,
       roles: form.roles,
       password: form.password,
       repeatPassword: form.repeatPassword,
@@ -831,6 +808,22 @@ export function UserForm({
             <span className="font-medium">Can override designated disburser</span>
             <p className="text-sm text-muted-foreground">
               Allow this user to set or change the designated disburser on a lead.
+            </p>
+          </div>
+        </label>
+
+        <label className="flex items-start gap-3 rounded-lg border p-4">
+          <Checkbox
+            checked={form.canConfirmPayments}
+            onCheckedChange={(checked) =>
+              handleChange("canConfirmPayments", checked === true)
+            }
+          />
+          <div className="space-y-1">
+            <span className="font-medium">Can confirm payments</span>
+            <p className="text-sm text-muted-foreground">
+              Allow this user to access payment confirmation uploads, lookups,
+              confirmations, and loan rejection actions.
             </p>
           </div>
         </label>

--- a/app/(application)/organization/users/components/users-page-client.tsx
+++ b/app/(application)/organization/users/components/users-page-client.tsx
@@ -70,6 +70,18 @@ export function UsersPageClient({
       getExportValue: (item) => (item.isBlocked ? "Blocked" : "Active"),
     },
     {
+      id: "canConfirmPayments",
+      header: "Payment Confirmation",
+      accessorKey: "canConfirmPayments",
+      cell: ({ row }) => (
+        <Badge variant={row.original.canConfirmPayments ? "secondary" : "outline"}>
+          {row.original.canConfirmPayments ? "Allowed" : "Not allowed"}
+        </Badge>
+      ),
+      getExportValue: (item) =>
+        item.canConfirmPayments ? "Allowed" : "Not allowed",
+    },
+    {
       id: "officeName",
       header: "Office",
       accessorKey: "officeName",

--- a/app/actions/user-management-actions.ts
+++ b/app/actions/user-management-actions.ts
@@ -73,6 +73,7 @@ const createUserSchema = z
     sendPasswordToEmail: z.boolean().default(true),
     passwordNeverExpires: z.boolean().default(false),
     canOverrideInitiatorDisbursement: z.boolean().default(false),
+    canConfirmPayments: z.boolean().default(false),
     officeId: z.coerce.number().int().positive("Office is required"),
     staffId: z
       .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
@@ -174,6 +175,7 @@ const updateUserSchema = z
       ),
     passwordNeverExpires: z.boolean().default(false),
     canOverrideInitiatorDisbursement: z.boolean().default(false),
+    canConfirmPayments: z.boolean().default(false),
     officeId: z.coerce.number().int().positive("Office is required"),
     staffId: z
       .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
@@ -394,6 +396,7 @@ function mapUserSummary(user: unknown): UserSummary {
     countryCode: undefined,
     isBlocked: false,
     blockedAt: null,
+    canConfirmPayments: false,
     officeId: asNumber(userRecord.officeId),
     officeName: asString(userRecord.officeName) || asString(officeRecord.name),
     roles: selectedRoles
@@ -445,6 +448,7 @@ function mapUserDetail(user: unknown): UserDetail {
     passwordNeverExpires: Boolean(userRecord.passwordNeverExpires),
     isSelfServiceUser: Boolean(userRecord.isSelfServiceUser),
     canOverrideInitiatorDisbursement: false,
+    canConfirmPayments: false,
     visibleLeadOffices: [],
     blockedSource: null,
     blockedNote: null,
@@ -599,6 +603,7 @@ export async function listUsersAction(): Promise<UserSummary[]> {
         countryCode: true,
         isBlocked: true,
         blockedAt: true,
+        canConfirmPayments: true,
       },
     }),
   ]);
@@ -618,6 +623,7 @@ export async function listUsersAction(): Promise<UserSummary[]> {
         countryCode: localLogin?.countryCode || undefined,
         isBlocked: localLogin?.isBlocked ?? false,
         blockedAt: localLogin?.blockedAt?.toISOString() ?? null,
+        canConfirmPayments: localLogin?.canConfirmPayments ?? false,
       };
     })
     .sort((left, right) => left.displayName.localeCompare(right.displayName));
@@ -648,6 +654,7 @@ export async function getUserAction(userId: number): Promise<UserDetail> {
       blockedNote: true,
       blockedByActorName: true,
       canOverrideInitiatorDisbursement: true,
+      canConfirmPayments: true,
       leadBranchAccesses: {
         orderBy: {
           officeId: "asc",
@@ -678,6 +685,7 @@ export async function getUserAction(userId: number): Promise<UserDetail> {
     countryCode: localLogin?.countryCode || undefined,
     canOverrideInitiatorDisbursement:
       localLogin?.canOverrideInitiatorDisbursement ?? false,
+    canConfirmPayments: localLogin?.canConfirmPayments ?? false,
     visibleLeadOffices: collapsedVisibleLeadOfficeIds.map((officeId) =>
       mapVisibleLeadOffice(
         officeId,
@@ -869,6 +877,7 @@ export async function createUserAction(
         countryCode,
         canOverrideInitiatorDisbursement:
           parsed.data.canOverrideInitiatorDisbursement,
+        canConfirmPayments: parsed.data.canConfirmPayments,
       });
 
       if (tenant.restrictLeadVisibilityToBranches) {
@@ -944,6 +953,7 @@ export async function updateUserAction(
         : null,
       canOverrideInitiatorDisbursement:
         parsed.data.canOverrideInitiatorDisbursement,
+      canConfirmPayments: parsed.data.canConfirmPayments,
     });
 
     if (tenant.restrictLeadVisibilityToBranches) {

--- a/app/api/auth/user-roles/route.ts
+++ b/app/api/auth/user-roles/route.ts
@@ -13,7 +13,12 @@ export async function GET() {
     
     if (!session?.user?.userId) {
       return NextResponse.json(
-        { roles: [], isAdmin: false, isSuperAdmin: false },
+        {
+          roles: [],
+          isAdmin: false,
+          isSuperAdmin: false,
+          canConfirmPayments: false,
+        },
         { status: 200 }
       );
     }
@@ -28,22 +33,39 @@ export async function GET() {
 
     if (!tenant) {
       return NextResponse.json(
-        { roles: [], isAdmin: false, isSuperAdmin: false },
+        {
+          roles: [],
+          isAdmin: false,
+          isSuperAdmin: false,
+          canConfirmPayments: false,
+        },
         { status: 200 }
       );
     }
 
-    // Get user's roles from local DB
-    const userRoles = await prisma.userRole.findMany({
-      where: {
-        tenantId: tenant.id,
-        mifosUserId: mifosUserId,
-        isActive: true,
-      },
-      include: {
-        role: true,
-      },
-    });
+    const [userRoles, userLogin] = await Promise.all([
+      prisma.userRole.findMany({
+        where: {
+          tenantId: tenant.id,
+          mifosUserId: mifosUserId,
+          isActive: true,
+        },
+        include: {
+          role: true,
+        },
+      }),
+      prisma.userLogin.findUnique({
+        where: {
+          tenantId_fineractUserId: {
+            tenantId: tenant.id,
+            fineractUserId: mifosUserId,
+          },
+        },
+        select: {
+          canConfirmPayments: true,
+        },
+      }),
+    ]);
 
     // Extract role names
     const roles = userRoles.map((ur) => ur.role.name);
@@ -57,11 +79,17 @@ export async function GET() {
       roles,
       isAdmin,
       isSuperAdmin,
+      canConfirmPayments: userLogin?.canConfirmPayments ?? false,
     });
   } catch (error) {
     console.error("Error fetching user roles:", error);
     return NextResponse.json(
-      { roles: [], isAdmin: false, isSuperAdmin: false },
+      {
+        roles: [],
+        isAdmin: false,
+        isSuperAdmin: false,
+        canConfirmPayments: false,
+      },
       { status: 200 }
     );
   }

--- a/components/role-guard.tsx
+++ b/components/role-guard.tsx
@@ -29,6 +29,7 @@ interface UserRoleResponse {
   roles: string[];
   isAdmin: boolean;
   isSuperAdmin: boolean;
+  canConfirmPayments: boolean;
 }
 
 /**
@@ -104,6 +105,7 @@ export function useUserRoles() {
   const [roles, setRoles] = useState<string[]>([]);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isSuperAdmin, setIsSuperAdmin] = useState(false);
+  const [canConfirmPayments, setCanConfirmPayments] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -118,6 +120,7 @@ export function useUserRoles() {
         setRoles(data.roles);
         setIsAdmin(data.isAdmin);
         setIsSuperAdmin(data.isSuperAdmin);
+        setCanConfirmPayments(data.canConfirmPayments);
       } catch (error) {
         console.error("Error fetching user roles:", error);
       } finally {
@@ -143,6 +146,7 @@ export function useUserRoles() {
     roles,
     isAdmin,
     isSuperAdmin,
+    canConfirmPayments,
     isLoading,
     hasRole,
     hasAnyRole,

--- a/lib/__tests__/payment-confirmation-permission.test.ts
+++ b/lib/__tests__/payment-confirmation-permission.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function readMigration(name: string): string {
+  const migrationPath = path.join(repoRoot, "prisma/migrations", name, "migration.sql");
+  assert.equal(existsSync(migrationPath), true, `${name} migration should exist`);
+  return readFileSync(migrationPath, "utf8");
+}
+
+test("payment confirmation access is controlled by UserLogin.canConfirmPayments", () => {
+  const schema = readRepoFile("prisma/schema.prisma");
+  const permissionMigration = readMigration(
+    "20260704160000_add_user_login_payment_confirmation_access"
+  );
+  const accessSource = readRepoFile("lib/payment-confirmation-access.ts");
+  const pageSource = readRepoFile("app/(application)/leads/payment-confirmation/page.tsx");
+  const roleRouteSource = readRepoFile("app/api/auth/user-roles/route.ts");
+  const roleGuardSource = readRepoFile("components/role-guard.tsx");
+  const desktopSidebarSource = readRepoFile(
+    "app/(application)/components/sidebar-nav.tsx"
+  );
+  const mobileSidebarSource = readRepoFile(
+    "app/(application)/components/mobile-sidebar.tsx"
+  );
+
+  assert.match(schema, /canConfirmPayments\s+Boolean\s+@default\(false\)/);
+  assert.match(
+    permissionMigration,
+    /ALTER TABLE "UserLogin"\s+ADD COLUMN IF NOT EXISTS "canConfirmPayments" BOOLEAN NOT NULL DEFAULT false/
+  );
+  assert.match(accessSource, /canConfirmPayments: true/);
+  assert.doesNotMatch(accessSource, /features\.leadConfig/);
+  assert.match(pageSource, /requirePaymentConfirmationPageAccess/);
+  assert.match(roleRouteSource, /canConfirmPayments/);
+  assert.match(roleGuardSource, /canConfirmPayments/);
+  assert.match(desktopSidebarSource, /canConfirmPayments/);
+  assert.match(mobileSidebarSource, /canConfirmPayments/);
+  assert.doesNotMatch(
+    desktopSidebarSource,
+    /Payment Confirmation[\s\S]{0,120}isEnabled\("leadConfig"\)/
+  );
+});
+
+test("user management exposes and persists payment confirmation permission", () => {
+  const actionsSource = readRepoFile("app/actions/user-management-actions.ts");
+  const userTypesSource = readRepoFile("shared/types/user-management.ts");
+  const userFormSource = readRepoFile(
+    "app/(application)/organization/users/components/user-form.tsx"
+  );
+  const usersPageSource = readRepoFile(
+    "app/(application)/organization/users/components/users-page-client.tsx"
+  );
+  const userDetailTabsSource = readRepoFile(
+    "app/(application)/organization/users/components/user-detail-tabs.tsx"
+  );
+  const userLoginServiceSource = readRepoFile("lib/user-login-service.ts");
+
+  assert.match(actionsSource, /canConfirmPayments: z\.boolean\(\)\.default\(false\)/);
+  assert.match(actionsSource, /canConfirmPayments:\s+localLogin\?\.canConfirmPayments \?\? false/);
+  assert.match(userTypesSource, /canConfirmPayments: boolean/);
+  assert.match(userFormSource, /canConfirmPayments/);
+  assert.match(userFormSource, /Can confirm payments/);
+  assert.match(usersPageSource, /canConfirmPayments/);
+  assert.match(userDetailTabsSource, /Can Confirm Payments/);
+  assert.match(userLoginServiceSource, /canConfirmPayments\?: boolean/);
+  assert.match(userLoginServiceSource, /updateData\.canConfirmPayments/);
+});
+
+test("payment confirmation loading states use skeletons instead of spinner-only loaders", () => {
+  const clientSource = readRepoFile(
+    "app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx"
+  );
+
+  assert.match(clientSource, /PaymentConfirmationTableSkeleton/);
+  assert.match(clientSource, /CsvUploadDropzone/);
+  assert.match(clientSource, /Upload/);
+  assert.doesNotMatch(clientSource, /Loader2 className="mx-auto h-5 w-5 animate-spin/);
+});

--- a/lib/payment-confirmation-access.ts
+++ b/lib/payment-confirmation-access.ts
@@ -2,22 +2,33 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
-import { DEFAULT_FEATURES } from "@/shared/types/tenant";
 
-type PaymentConfirmationAccess =
-  | {
-      ok: true;
-      tenant: NonNullable<Awaited<ReturnType<typeof getTenantFromHeaders>>>;
-      session: NonNullable<Awaited<ReturnType<typeof getSession>>>;
-      actorId: string;
-      actorName: string;
-    }
+type PaymentConfirmationAccessContext = {
+  ok: true;
+  tenant: NonNullable<Awaited<ReturnType<typeof getTenantFromHeaders>>>;
+  session: NonNullable<Awaited<ReturnType<typeof getSession>>>;
+  actorId: string;
+  actorName: string;
+};
+
+type PaymentConfirmationAccessDenied = {
+  ok: false;
+  status: number;
+  message: string;
+};
+
+export type PaymentConfirmationPageAccess =
+  | PaymentConfirmationAccessContext
+  | PaymentConfirmationAccessDenied;
+
+type PaymentConfirmationRouteAccess =
+  | PaymentConfirmationAccessContext
   | {
       ok: false;
       response: NextResponse;
     };
 
-export async function requirePaymentConfirmationAccess(): Promise<PaymentConfirmationAccess> {
+async function getPaymentConfirmationAccess(): Promise<PaymentConfirmationPageAccess> {
   const [tenant, session] = await Promise.all([
     getTenantFromHeaders(),
     getSession(),
@@ -26,52 +37,36 @@ export async function requirePaymentConfirmationAccess(): Promise<PaymentConfirm
   if (!session?.user?.userId) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      status: 401,
+      message: "Unauthorized",
     };
   }
 
   if (!tenant) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Tenant not found" }, { status: 404 }),
+      status: 404,
+      message: "Tenant not found",
     };
   }
 
-  const settings = tenant.settings as unknown as
-    | { features?: Partial<Record<keyof typeof DEFAULT_FEATURES, boolean>> }
-    | null;
-  const features = {
-    ...DEFAULT_FEATURES,
-    ...settings?.features,
-  };
+  const permittedLogin = await prisma.userLogin.findFirst({
+    where: {
+      tenantId: tenant.id,
+      fineractUserId: session.user.userId,
+      canConfirmPayments: true,
+    },
+    select: {
+      id: true,
+    },
+  });
 
-  if (!features.leadConfig) {
+  if (!permittedLogin) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Feature disabled" }, { status: 403 }),
+      status: 403,
+      message: "Payment confirmation access is not enabled for your user.",
     };
-  }
-
-  if (session.user.name !== "mifos") {
-    const superAdminRole = await prisma.userRole.findFirst({
-      where: {
-        tenantId: tenant.id,
-        mifosUserId: session.user.userId,
-        isActive: true,
-        role: {
-          name: "SUPER_ADMIN",
-          isActive: true,
-        },
-      },
-      select: { id: true },
-    });
-
-    if (!superAdminRole) {
-      return {
-        ok: false,
-        response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
-      };
-    }
   }
 
   return {
@@ -81,4 +76,24 @@ export async function requirePaymentConfirmationAccess(): Promise<PaymentConfirm
     actorId: String(session.user.userId),
     actorName: session.user.name || session.user.email || "system",
   };
+}
+
+export async function requirePaymentConfirmationPageAccess(): Promise<PaymentConfirmationPageAccess> {
+  return getPaymentConfirmationAccess();
+}
+
+export async function requirePaymentConfirmationAccess(): Promise<PaymentConfirmationRouteAccess> {
+  const access = await getPaymentConfirmationAccess();
+
+  if (!access.ok) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: access.message },
+        { status: access.status }
+      ),
+    };
+  }
+
+  return access;
 }

--- a/lib/user-login-service.ts
+++ b/lib/user-login-service.ts
@@ -97,6 +97,7 @@ type UpsertUserLoginInput = {
   phone?: string | null;
   countryCode?: string | null;
   canOverrideInitiatorDisbursement?: boolean;
+  canConfirmPayments?: boolean;
   lastLoginAt?: Date | null;
   lastMfaChannel?: string | null;
   lastMfaSentAt?: Date | null;
@@ -111,6 +112,7 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
     phone,
     countryCode,
     canOverrideInitiatorDisbursement,
+    canConfirmPayments,
     lastLoginAt,
     lastMfaChannel,
     lastMfaSentAt,
@@ -163,6 +165,10 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
       canOverrideInitiatorDisbursement;
   }
 
+  if (canConfirmPayments !== undefined) {
+    updateData.canConfirmPayments = canConfirmPayments;
+  }
+
   return prisma.userLogin.upsert({
     where: {
       tenantId_fineractUserId: {
@@ -180,6 +186,7 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
       countryCode: normalizedCountryCode,
       canOverrideInitiatorDisbursement:
         canOverrideInitiatorDisbursement ?? false,
+      canConfirmPayments: canConfirmPayments ?? false,
       lastLoginAt: lastLoginAt ?? null,
       lastMfaChannel: lastMfaChannel ?? null,
       lastMfaSentAt: lastMfaSentAt ?? null,

--- a/prisma/migrations/20260704160000_add_user_login_payment_confirmation_access/migration.sql
+++ b/prisma/migrations/20260704160000_add_user_login_payment_confirmation_access/migration.sql
@@ -1,0 +1,3 @@
+-- Add per-user access for the payment confirmation workspace.
+ALTER TABLE "UserLogin"
+ADD COLUMN IF NOT EXISTS "canConfirmPayments" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1186,6 +1186,7 @@ model UserLogin {
   phone                String?
   countryCode          String?
   canOverrideInitiatorDisbursement Boolean  @default(false)
+  canConfirmPayments   Boolean              @default(false)
   isBlocked            Boolean              @default(false)
   blockedAt            DateTime?
   blockedSource        String?

--- a/shared/types/user-management.ts
+++ b/shared/types/user-management.ts
@@ -26,6 +26,7 @@ export interface UserSummary {
   countryCode?: string;
   isBlocked: boolean;
   blockedAt?: string | null;
+  canConfirmPayments: boolean;
   officeId?: number;
   officeName?: string;
   roles: string[];
@@ -83,6 +84,7 @@ export interface UserFormInput {
   sendPasswordToEmail?: boolean;
   passwordNeverExpires?: boolean;
   canOverrideInitiatorDisbursement?: boolean;
+  canConfirmPayments?: boolean;
   officeId: number | string;
   staffId?: number | string | null;
   visibleLeadOfficeIds?: Array<number | string>;


### PR DESCRIPTION
## Summary
- Add `UserLogin.canConfirmPayments` with a default `false` value and wire it into user create/edit, list, and detail views.
- Move payment confirmation menu visibility and page/API authorization off lead configuration visibility and onto the per-user permission.
- Refresh the payment confirmation upload UX with a CSV drop zone and skeleton loading states.

## Test Plan
- `git diff --check`
- `npx tsx --test lib/__tests__/payment-confirmation-permission.test.ts`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/loan_matrix npx prisma validate`
- `npx eslint "app/(application)/components/mobile-sidebar.tsx" "app/(application)/components/sidebar-nav.tsx" "app/(application)/leads/payment-confirmation/components/payment-confirmation-client.tsx" "app/(application)/leads/payment-confirmation/page.tsx" "app/(application)/organization/users/components/user-detail-tabs.tsx" "app/(application)/organization/users/components/user-form.tsx" "app/(application)/organization/users/components/users-page-client.tsx" app/actions/user-management-actions.ts app/api/auth/user-roles/route.ts components/role-guard.tsx lib/payment-confirmation-access.ts lib/user-login-service.ts shared/types/user-management.ts lib/__tests__/payment-confirmation-permission.test.ts`
- `npx tsc --noEmit --pretty false` exits nonzero from existing unrelated app-wide issues; no errors match touched files.

## Notes
- Targeted eslint reports one pre-existing `@next/next/no-img-element` warning in `app/(application)/components/mobile-sidebar.tsx`.
