### PR TITLE
Add document view support

### DIFF
--- a/app/(application)/clients/[id]/components/client-documents.tsx
+++ b/app/(application)/clients/[id]/components/client-documents.tsx
@@ -38,6 +38,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 import { downloadClientDocumentAttachment } from "@/app/actions/client-document-actions";
 import { formatDateDdMmYyyy } from "@/lib/date-format";
 
@@ -382,7 +383,20 @@ export function ClientDocuments({
                       </span>
                     </TableCell>
                     <TableCell className="text-right">
-                      <div className="flex items-center justify-end">
+                      <div className="flex items-center justify-end gap-2">
+                        <DocumentViewButton
+                          documentUrl={`/api/fineract/clients/${clientId}/documents/${document.id}/attachment`}
+                          fileName={document.fileName || document.name}
+                          contentType={document.type}
+                          documentName={document.name}
+                          className="gap-2"
+                          onFallbackDownload={() =>
+                            handleDownloadDocument(document)
+                          }
+                          disabled={downloadingDocumentId === document.id}
+                          title="View document"
+                          aria-label={`View ${document.name}`}
+                        />
                         <Button
                           type="button"
                           variant="outline"

--- a/app/(application)/clients/[id]/components/client-entity-kyc.tsx
+++ b/app/(application)/clients/[id]/components/client-entity-kyc.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   Building2,
   Download,
+  Eye,
   FileText,
   Landmark,
   ShieldCheck,
@@ -9,6 +10,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 
 type EntityStakeholder = {
   id: string;
@@ -212,11 +214,8 @@ function StakeholderCard({
           ) : (
             <div className="mt-2 space-y-2">
               {uploadedFiles.map((file) => (
-                <Link
+                <div
                   key={file.key}
-                  href={file.href}
-                  target="_blank"
-                  rel="noreferrer"
                   className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2 transition-colors hover:bg-muted/40"
                 >
                   <div className="min-w-0">
@@ -226,8 +225,32 @@ function StakeholderCard({
                       {file.uploadedAt ? ` • ${file.uploadedAt}` : ""}
                     </p>
                   </div>
-                  <Download className="h-4 w-4 shrink-0 text-muted-foreground" />
-                </Link>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <DocumentViewButton
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                      documentUrl={file.href}
+                      fileName={file.fileName}
+                      documentName={file.label}
+                      title="View document"
+                      aria-label={`View ${file.fileName}`}
+                    >
+                      <Eye className="h-4 w-4" />
+                    </DocumentViewButton>
+                    <Link
+                      href={file.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      download={file.fileName}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+                      title="Download document"
+                      aria-label={`Download ${file.fileName}`}
+                    >
+                      <Download className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </div>
               ))}
             </div>
           )}

--- a/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
@@ -51,6 +51,7 @@ import CreateGuarantorModal from "@/components/CreateGuarantorModal";
 import RecoverFromGuarantorModal from "@/components/RecoverFromGuarantorModal";
 import SellLoanModal from "@/components/SellLoanModal";
 import { TransactionsDataTable } from "./transactions-data-table";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 import { downloadLoanDocumentAttachment } from "@/app/actions/loan-document-actions";
 import { formatDateDdMmYyyy } from "@/lib/date-format";
 import { FineractClient, FineractLoan } from "@/shared/types";
@@ -4427,6 +4428,27 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
                           </TableCell>
                           <TableCell className="text-right">
                             <div className="flex items-center justify-end gap-2">
+                              <DocumentViewButton
+                                documentUrl={`/api/fineract/loans/${loanId}/documents/${document.id}/attachment`}
+                                fileName={
+                                  document.fileName ||
+                                  document.name ||
+                                  `document-${document.id}`
+                                }
+                                documentType={document.type}
+                                documentName={document.name}
+                                className="gap-2"
+                                onFallbackDownload={() =>
+                                  handleDownloadDocument(document)
+                                }
+                                disabled={downloadingDocumentId === document.id}
+                                title="View document"
+                                aria-label={`View ${
+                                  document.name ||
+                                  document.fileName ||
+                                  `document ${document.id}`
+                                }`}
+                              />
                               <Button
                                 type="button"
                                 variant="outline"

--- a/app/(application)/leads/[id]/components/comprehensive-lead-details.tsx
+++ b/app/(application)/leads/[id]/components/comprehensive-lead-details.tsx
@@ -37,11 +37,11 @@ import {
   Clock,
   CheckCircle,
   ArrowRight,
-  ExternalLink,
   FileText,
   TrendingUp,
   TrendingDown,
   Minus,
+  Eye,
   User,
   MapPin,
   Hash,
@@ -51,6 +51,7 @@ import {
   Coins,
 } from "lucide-react";
 import { format } from "date-fns";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 import { useCurrency } from "@/contexts/currency-context";
 import { CreditBalanceRefundModal } from "./credit-balance-refund-modal";
 import { TransferFundsModal } from "./transfer-funds-modal";
@@ -880,14 +881,22 @@ export function ComprehensiveLeadDetails({
                               </td>
                               <td className="px-3 py-2">
                                 {invoice.fineractDocumentId && lead?.fineractClientId ? (
-                                  <a
-                                    href={`/api/fineract/clients/${lead.fineractClientId}/documents/${invoice.fineractDocumentId}/attachment`}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="text-blue-600 hover:underline"
+                                  <DocumentViewButton
+                                    variant="link"
+                                    size="sm"
+                                    className="h-auto p-0 text-blue-600 hover:underline"
+                                    documentUrl={`/api/fineract/clients/${lead.fineractClientId}/documents/${invoice.fineractDocumentId}/attachment`}
+                                    fileName={`invoice-${
+                                      invoice.invoiceNumber ||
+                                      invoice.fineractDocumentId
+                                    }`}
+                                    documentName={`Invoice ${
+                                      invoice.invoiceNumber ||
+                                      invoice.fineractDocumentId
+                                    }`}
                                   >
                                     View file
-                                  </a>
+                                  </DocumentViewButton>
                                 ) : (
                                   "N/A"
                                 )}
@@ -2063,6 +2072,49 @@ export function ComprehensiveLeadDetails({
                           >
                             <Download className="h-4 w-4" />
                           </Button>
+                          <DocumentViewButton
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                            documentUrl={`/api/fineract/loans/${
+                              data?.lead?.fineractLoanId ||
+                              data?.fineractLoan?.id
+                            }/documents/${
+                              doc.id ||
+                              doc.documentId ||
+                              doc.resourceId ||
+                              index
+                            }/attachment`}
+                            fileName={
+                              doc.fileName ||
+                              doc.name ||
+                              `document-${
+                                doc.id ||
+                                doc.documentId ||
+                                doc.resourceId ||
+                                index
+                              }`
+                            }
+                            contentType={doc.type}
+                            documentName={doc.name}
+                            onFallbackDownload={() => {
+                              const docId =
+                                doc.id ||
+                                doc.documentId ||
+                                doc.resourceId ||
+                                index;
+                              handleDownloadLoanDocument(
+                                docId.toString(),
+                                doc.fileName || doc.name || `document-${docId}`
+                              );
+                            }}
+                            title="View document"
+                            aria-label={`View ${
+                              doc.name || doc.fileName || `document ${index + 1}`
+                            }`}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </DocumentViewButton>
                         </div>
                       </div>
                     ))}

--- a/app/(application)/leads/[id]/components/lead-documents.tsx
+++ b/app/(application)/leads/[id]/components/lead-documents.tsx
@@ -20,6 +20,7 @@ import {
   AlertCircle,
   Loader2,
 } from "lucide-react";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 
 interface LeadDocumentsProps {
   leadId: string;
@@ -281,6 +282,19 @@ export function LeadDocuments({
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
   };
 
+  const getLeadDocumentUrl = (doc: Document) =>
+    doc.filePath?.trim() || `/api/documents/${encodeURIComponent(doc.id)}`;
+
+  const handleDownloadLeadDocument = (doc: Document) => {
+    const url = getLeadDocumentUrl(doc);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = doc.originalName || doc.name || `document-${doc.id}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
   const handleDownloadLoanDocument = async (
     documentId: string,
     fileName: string
@@ -465,6 +479,27 @@ export function LeadDocuments({
                           Client Document
                         </Badge>
                         <div className="flex items-center">
+                          <DocumentViewButton
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                            documentUrl={`/api/fineract/clients/${fineractClientId}/documents/${doc.id}/attachment`}
+                            fileName={doc.fileName || doc.name}
+                            contentType={doc.type}
+                            documentName={doc.name}
+                            onFallbackDownload={() =>
+                              handleDownloadClientDocument(
+                                doc.id.toString(),
+                                doc.fileName || doc.name
+                              )
+                            }
+                            title="View document"
+                            aria-label={`View ${
+                              doc.name || doc.fileName || `Document ${doc.id}`
+                            }`}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </DocumentViewButton>
                           <Button
                             variant="ghost"
                             size="icon"
@@ -558,6 +593,27 @@ export function LeadDocuments({
                           From Cloud Storage
                         </Badge>
                         <div className="flex items-center">
+                          <DocumentViewButton
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                            documentUrl={`/api/fineract/loans/${fineractLoanId}/documents/${doc.id}/attachment`}
+                            fileName={doc.fileName || doc.name}
+                            contentType={doc.type}
+                            documentName={doc.name}
+                            onFallbackDownload={() =>
+                              handleDownloadLoanDocument(
+                                doc.id.toString(),
+                                doc.fileName || doc.name
+                              )
+                            }
+                            title="View document"
+                            aria-label={`View ${
+                              doc.name || doc.fileName || `Document ${doc.id}`
+                            }`}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </DocumentViewButton>
                           <Button
                             variant="ghost"
                             size="icon"
@@ -697,19 +753,32 @@ export function LeadDocuments({
                                   </Badge>
                                 )}
                                 <div className="flex items-center">
-                                  <Button
+                                  <DocumentViewButton
                                     variant="ghost"
                                     size="icon"
                                     className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                    documentUrl={getLeadDocumentUrl(doc)}
+                                    fileName={doc.originalName || doc.name}
+                                    contentType={doc.mimeType}
+                                    documentType={doc.type}
+                                    documentName={doc.name}
+                                    originalName={doc.originalName}
+                                    onFallbackDownload={() =>
+                                      handleDownloadLeadDocument(doc)
+                                    }
                                     title="View document"
+                                    aria-label={`View ${doc.name}`}
                                   >
                                     <Eye className="h-4 w-4" />
-                                  </Button>
+                                  </DocumentViewButton>
                                   <Button
                                     variant="ghost"
                                     size="icon"
                                     className="h-8 w-8 text-muted-foreground hover:text-foreground"
                                     title="Download document"
+                                    onClick={() =>
+                                      handleDownloadLeadDocument(doc)
+                                    }
                                   >
                                     <Download className="h-4 w-4" />
                                   </Button>

--- a/app/(application)/leads/new/components/client-registration-form.tsx
+++ b/app/(application)/leads/new/components/client-registration-form.tsx
@@ -54,6 +54,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { SearchableSelect } from "@/components/searchable-select";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 
 import {
   Popover,
@@ -1698,34 +1699,6 @@ export function ClientRegistrationForm({
         title: "Download Failed",
         description: err?.message || "Failed to download document",
       });
-    }
-  };
-
-  // State for inline document preview
-  const [previewingDocumentId, setPreviewingDocumentId] = useState<
-    string | null
-  >(null);
-  const [previewingIdentifierId, setPreviewingIdentifierId] = useState<
-    number | null
-  >(null);
-
-  // Handle document view (toggles inline preview)
-  const handleViewDocument = (
-    documentId: string | number,
-    identifierId?: number
-  ) => {
-    const docIdStr = String(documentId);
-    if (
-      previewingDocumentId === docIdStr &&
-      previewingIdentifierId === (identifierId || null)
-    ) {
-      // If already previewing this document, close it
-      setPreviewingDocumentId(null);
-      setPreviewingIdentifierId(null);
-    } else {
-      // Open preview for this document
-      setPreviewingDocumentId(docIdStr);
-      setPreviewingIdentifierId(identifierId || null);
     }
   };
 
@@ -9516,33 +9489,6 @@ export function ClientRegistrationForm({
                                                                     doc: any,
                                                                     docIndex: number
                                                                   ) => {
-                                                                    const isPreviewing =
-                                                                      previewingDocumentId ===
-                                                                        String(
-                                                                          doc.id
-                                                                        ) &&
-                                                                      previewingIdentifierId ===
-                                                                        identifierId;
-                                                                    const isImage =
-                                                                      doc.type?.includes(
-                                                                        "image"
-                                                                      ) ||
-                                                                      doc.name?.match(
-                                                                        /\.(jpg|jpeg|png|gif|webp|bmp)$/i
-                                                                      ) ||
-                                                                      doc.fileName?.match(
-                                                                        /\.(jpg|jpeg|png|gif|webp|bmp)$/i
-                                                                      );
-                                                                    const isPdf =
-                                                                      doc.type?.includes(
-                                                                        "pdf"
-                                                                      ) ||
-                                                                      doc.name?.match(
-                                                                        /\.pdf$/i
-                                                                      ) ||
-                                                                      doc.fileName?.match(
-                                                                        /\.pdf$/i
-                                                                      );
                                                                     // Use identifier documents endpoint for documents linked to identifiers
                                                                     const previewUrl =
                                                                       fineractClientId &&
@@ -9563,13 +9509,7 @@ export function ClientRegistrationForm({
                                                                         <div className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-800 rounded text-xs">
                                                                           <FileText className="h-3 w-3 text-blue-500 flex-shrink-0" />
                                                                           <span
-                                                                            className={`flex-1 ${colors.textColor} truncate cursor-pointer`}
-                                                                            onClick={() =>
-                                                                              handleViewDocument(
-                                                                                doc.id,
-                                                                                identifierId
-                                                                              )
-                                                                            }
+                                                                            className={`flex-1 ${colors.textColor} truncate`}
                                                                             title={
                                                                               doc.name ||
                                                                               doc.fileName ||
@@ -9600,29 +9540,36 @@ export function ClientRegistrationForm({
                                                                             </span>
                                                                           )}
                                                                           <div className="flex items-center gap-1 flex-shrink-0">
-                                                                            <Button
-                                                                              type="button"
+                                                                            <DocumentViewButton
                                                                               variant="ghost"
                                                                               size="sm"
-                                                                              className={`h-6 w-6 p-0 ${
-                                                                                isPreviewing
-                                                                                  ? "bg-blue-100 dark:bg-blue-900"
-                                                                                  : ""
-                                                                              }`}
-                                                                              onClick={() =>
-                                                                                handleViewDocument(
+                                                                              className="h-6 w-6 p-0"
+                                                                              documentUrl={previewUrl}
+                                                                              fileName={
+                                                                                doc.name ||
+                                                                                doc.fileName ||
+                                                                                `document_${doc.id}`
+                                                                              }
+                                                                              contentType={doc.type}
+                                                                              documentName={doc.name}
+                                                                              onFallbackDownload={() =>
+                                                                                handleDownloadDocument(
                                                                                   doc.id,
+                                                                                  doc.name ||
+                                                                                    doc.fileName ||
+                                                                                    `document_${doc.id}`,
                                                                                   identifierId
                                                                                 )
                                                                               }
-                                                                              title={
-                                                                                isPreviewing
-                                                                                  ? "Hide preview"
-                                                                                  : "View document"
-                                                                              }
+                                                                              title="View document"
+                                                                              aria-label={`View ${
+                                                                                doc.name ||
+                                                                                doc.fileName ||
+                                                                                `document ${doc.id}`
+                                                                              }`}
                                                                             >
                                                                               <Eye className="h-3 w-3" />
-                                                                            </Button>
+                                                                            </DocumentViewButton>
                                                                             <Button
                                                                               type="button"
                                                                               variant="ghost"
@@ -9643,92 +9590,6 @@ export function ClientRegistrationForm({
                                                                             </Button>
                                                                           </div>
                                                                         </div>
-
-                                                                        {/* Inline Preview */}
-                                                                        {isPreviewing &&
-                                                                          previewUrl && (
-                                                                            <div className="p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg">
-                                                                              {isImage ? (
-                                                                                <div className="flex items-center justify-center">
-                                                                                  <img
-                                                                                    src={
-                                                                                      previewUrl
-                                                                                    }
-                                                                                    alt={
-                                                                                      doc.name ||
-                                                                                      doc.fileName ||
-                                                                                      "Document preview"
-                                                                                    }
-                                                                                    className="max-w-full max-h-96 object-contain rounded-lg shadow-sm"
-                                                                                    onError={(
-                                                                                      e
-                                                                                    ) => {
-                                                                                      console.error(
-                                                                                        "Error loading image"
-                                                                                      );
-                                                                                      e.currentTarget.style.display =
-                                                                                        "none";
-                                                                                      const errorDiv =
-                                                                                        document.createElement(
-                                                                                          "div"
-                                                                                        );
-                                                                                      errorDiv.className =
-                                                                                        "text-center text-gray-500 p-4 text-sm";
-                                                                                      errorDiv.textContent =
-                                                                                        "Failed to load image. Please try downloading the document.";
-                                                                                      e.currentTarget.parentElement?.appendChild(
-                                                                                        errorDiv
-                                                                                      );
-                                                                                    }}
-                                                                                  />
-                                                                                </div>
-                                                                              ) : isPdf ? (
-                                                                                <div className="w-full h-96">
-                                                                                  <iframe
-                                                                                    src={
-                                                                                      previewUrl
-                                                                                    }
-                                                                                    className="w-full h-full border-0 rounded-lg"
-                                                                                    title={
-                                                                                      doc.name ||
-                                                                                      doc.fileName ||
-                                                                                      "Document preview"
-                                                                                    }
-                                                                                  />
-                                                                                </div>
-                                                                              ) : (
-                                                                                <div className="flex flex-col items-center justify-center h-32 space-y-2">
-                                                                                  <FileText className="h-8 w-8 text-gray-400" />
-                                                                                  <p className="text-gray-500 text-sm text-center">
-                                                                                    Preview
-                                                                                    not
-                                                                                    available
-                                                                                    for
-                                                                                    this
-                                                                                    file
-                                                                                    type.
-                                                                                  </p>
-                                                                                  <Button
-                                                                                    size="sm"
-                                                                                    variant="outline"
-                                                                                    onClick={() =>
-                                                                                      handleDownloadDocument(
-                                                                                        doc.id,
-                                                                                        doc.name ||
-                                                                                          doc.fileName ||
-                                                                                          `document_${doc.id}`
-                                                                                      )
-                                                                                    }
-                                                                                  >
-                                                                                    <Download className="h-3 w-3 mr-2" />
-                                                                                    Download
-                                                                                    to
-                                                                                    View
-                                                                                  </Button>
-                                                                                </div>
-                                                                              )}
-                                                                            </div>
-                                                                          )}
                                                                       </div>
                                                                     );
                                                                   }
@@ -10000,22 +9861,6 @@ export function ClientRegistrationForm({
                                       <div className="space-y-2">
                                         {otherDocuments.map(
                                           (doc: any, docIndex: number) => {
-                                            const isPreviewing =
-                                              previewingDocumentId ===
-                                                String(doc.id) &&
-                                              previewingIdentifierId === null;
-                                            const isImage =
-                                              doc.type?.includes("image") ||
-                                              doc.name?.match(
-                                                /\.(jpg|jpeg|png|gif|webp|bmp)$/i
-                                              ) ||
-                                              doc.fileName?.match(
-                                                /\.(jpg|jpeg|png|gif|webp|bmp)$/i
-                                              );
-                                            const isPdf =
-                                              doc.type?.includes("pdf") ||
-                                              doc.name?.match(/\.pdf$/i) ||
-                                              doc.fileName?.match(/\.pdf$/i);
                                             const previewUrl = fineractClientId
                                               ? `/api/fineract/clients/${fineractClientId}/documents/${doc.id}/attachment`
                                               : null;
@@ -10028,10 +9873,7 @@ export function ClientRegistrationForm({
                                                 <div className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-800 rounded text-xs">
                                                   <FileText className="h-3 w-3 text-blue-500 flex-shrink-0" />
                                                   <span
-                                                    className={`flex-1 ${colors.textColor} truncate cursor-pointer`}
-                                                    onClick={() =>
-                                                      handleViewDocument(doc.id)
-                                                    }
+                                                    className={`flex-1 ${colors.textColor} truncate`}
                                                     title={
                                                       doc.name ||
                                                       doc.fileName ||
@@ -10055,28 +9897,35 @@ export function ClientRegistrationForm({
                                                     </span>
                                                   )}
                                                   <div className="flex items-center gap-1 flex-shrink-0">
-                                                    <Button
-                                                      type="button"
+                                                    <DocumentViewButton
                                                       variant="ghost"
                                                       size="sm"
-                                                      className={`h-6 w-6 p-0 ${
-                                                        isPreviewing
-                                                          ? "bg-blue-100 dark:bg-blue-900"
-                                                          : ""
-                                                      }`}
-                                                      onClick={() =>
-                                                        handleViewDocument(
-                                                          doc.id
+                                                      className="h-6 w-6 p-0"
+                                                      documentUrl={previewUrl}
+                                                      fileName={
+                                                        doc.name ||
+                                                        doc.fileName ||
+                                                        `document_${doc.id}`
+                                                      }
+                                                      contentType={doc.type}
+                                                      documentName={doc.name}
+                                                      onFallbackDownload={() =>
+                                                        handleDownloadDocument(
+                                                          doc.id,
+                                                          doc.name ||
+                                                            doc.fileName ||
+                                                            `document_${doc.id}`
                                                         )
                                                       }
-                                                      title={
-                                                        isPreviewing
-                                                          ? "Hide preview"
-                                                          : "View document"
-                                                      }
+                                                      title="View document"
+                                                      aria-label={`View ${
+                                                        doc.name ||
+                                                        doc.fileName ||
+                                                        `document ${doc.id}`
+                                                      }`}
                                                     >
                                                       <Eye className="h-3 w-3" />
-                                                    </Button>
+                                                    </DocumentViewButton>
                                                     <Button
                                                       type="button"
                                                       variant="ghost"
@@ -10096,78 +9945,6 @@ export function ClientRegistrationForm({
                                                     </Button>
                                                   </div>
                                                 </div>
-
-                                                {/* Inline Preview */}
-                                                {isPreviewing && previewUrl && (
-                                                  <div className="p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg">
-                                                    {isImage ? (
-                                                      <div className="flex items-center justify-center">
-                                                        <img
-                                                          src={previewUrl}
-                                                          alt={
-                                                            doc.name ||
-                                                            doc.fileName ||
-                                                            "Document preview"
-                                                          }
-                                                          className="max-w-full max-h-96 object-contain rounded-lg shadow-sm"
-                                                          onError={(e) => {
-                                                            console.error(
-                                                              "Error loading image"
-                                                            );
-                                                            e.currentTarget.style.display =
-                                                              "none";
-                                                            const errorDiv =
-                                                              document.createElement(
-                                                                "div"
-                                                              );
-                                                            errorDiv.className =
-                                                              "text-center text-gray-500 p-4 text-sm";
-                                                            errorDiv.textContent =
-                                                              "Failed to load image. Please try downloading the document.";
-                                                            e.currentTarget.parentElement?.appendChild(
-                                                              errorDiv
-                                                            );
-                                                          }}
-                                                        />
-                                                      </div>
-                                                    ) : isPdf ? (
-                                                      <div className="w-full h-96">
-                                                        <iframe
-                                                          src={previewUrl}
-                                                          className="w-full h-full border-0 rounded-lg"
-                                                          title={
-                                                            doc.name ||
-                                                            doc.fileName ||
-                                                            "Document preview"
-                                                          }
-                                                        />
-                                                      </div>
-                                                    ) : (
-                                                      <div className="flex flex-col items-center justify-center h-32 space-y-2">
-                                                        <FileText className="h-8 w-8 text-gray-400" />
-                                                        <p className="text-gray-500 text-sm text-center">
-                                                          Preview not available
-                                                          for this file type.
-                                                        </p>
-                                                        <Button
-                                                          size="sm"
-                                                          variant="outline"
-                                                          onClick={() =>
-                                                            handleDownloadDocument(
-                                                              doc.id,
-                                                              doc.name ||
-                                                                doc.fileName ||
-                                                                `document_${doc.id}`
-                                                            )
-                                                          }
-                                                        >
-                                                          <Download className="h-3 w-3 mr-2" />
-                                                          Download to View
-                                                        </Button>
-                                                      </div>
-                                                    )}
-                                                  </div>
-                                                )}
                                               </div>
                                             );
                                           }

--- a/app/(application)/leads/new/components/invoice-discounting-form.tsx
+++ b/app/(application)/leads/new/components/invoice-discounting-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { DocumentViewButton } from "@/components/document/document-view-button";
 import { useCurrency } from "@/contexts/currency-context";
 import { useToast } from "@/hooks/use-toast";
 
@@ -716,15 +717,23 @@ export function InvoiceDiscountingForm({
                             }
                           />
                           {row.fineractDocumentId && fineractClientId ? (
-                            <a
-                              className="inline-flex items-center text-xs text-blue-600 hover:underline"
-                              href={`/api/fineract/clients/${fineractClientId}/documents/${row.fineractDocumentId}/attachment`}
-                              target="_blank"
-                              rel="noreferrer"
+                            <DocumentViewButton
+                              variant="link"
+                              size="sm"
+                              className="h-auto p-0 text-xs text-blue-600 hover:underline"
+                              documentUrl={`/api/fineract/clients/${fineractClientId}/documents/${row.fineractDocumentId}/attachment`}
+                              fileName={
+                                row.documentFile?.name ||
+                                `invoice-${row.invoiceNumber || row.fineractDocumentId}`
+                              }
+                              contentType={row.documentFile?.type}
+                              documentName={`Invoice ${
+                                row.invoiceNumber || row.fineractDocumentId
+                              }`}
                             >
                               View Uploaded File
                               <ExternalLink className="ml-1 h-3 w-3" />
-                            </a>
+                            </DocumentViewButton>
                           ) : null}
                         </div>
                       </TableCell>

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { extractDocumentId } from "@/lib/document-utils";
+import { toInlineContentDisposition } from "@/lib/document-viewing";
 
 /**
  * GET /api/documents/[id]
@@ -43,13 +44,19 @@ export async function GET(
 
     const contentType = res.headers.get("content-type") || "application/octet-stream";
     const contentDisposition = res.headers.get("content-disposition") || "";
+    const responseContentDisposition =
+      request.nextUrl.searchParams.get("disposition") === "inline"
+        ? toInlineContentDisposition(contentDisposition)
+        : contentDisposition;
     const body = await res.arrayBuffer();
 
     return new NextResponse(body, {
       status: 200,
       headers: {
         "Content-Type": contentType,
-        ...(contentDisposition && { "Content-Disposition": contentDisposition }),
+        ...(responseContentDisposition && {
+          "Content-Disposition": responseContentDisposition,
+        }),
       },
     });
   } catch (error) {

--- a/app/api/fineract/client_identifiers/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/client_identifiers/[id]/documents/[documentId]/attachment/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getFineractTenantId } from "@/lib/api";
+import { toInlineContentDisposition } from "@/lib/document-viewing";
 
 export async function GET(
   request: NextRequest,
@@ -102,13 +103,17 @@ export async function GET(
       response.headers.get("content-type") || "application/octet-stream";
     const contentDisposition =
       response.headers.get("content-disposition") || "";
+    const responseContentDisposition =
+      request.nextUrl.searchParams.get("disposition") === "inline"
+        ? toInlineContentDisposition(contentDisposition)
+        : contentDisposition;
 
     // Return the file with appropriate headers
     return new NextResponse(fileBuffer, {
       status: 200,
       headers: {
         "Content-Type": contentType,
-        "Content-Disposition": contentDisposition,
+        "Content-Disposition": responseContentDisposition,
       },
     });
   } catch (error) {
@@ -119,4 +124,3 @@ export async function GET(
     );
   }
 }
-

--- a/app/api/fineract/clients/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/clients/[id]/documents/[documentId]/attachment/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFineractTenantId } from "@/lib/api";
 import { getSearchAuthToken } from "@/lib/fineract-search-auth";
+import { toInlineContentDisposition } from "@/lib/document-viewing";
 
 export async function GET(
   request: NextRequest,
@@ -92,13 +93,17 @@ export async function GET(
       response.headers.get("content-type") || "application/octet-stream";
     const contentDisposition =
       response.headers.get("content-disposition") || "";
+    const responseContentDisposition =
+      request.nextUrl.searchParams.get("disposition") === "inline"
+        ? toInlineContentDisposition(contentDisposition)
+        : contentDisposition;
 
     // Return the file with appropriate headers
     return new NextResponse(fileBuffer, {
       status: 200,
       headers: {
         "Content-Type": contentType,
-        "Content-Disposition": contentDisposition,
+        "Content-Disposition": responseContentDisposition,
       },
     });
   } catch (error) {

--- a/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildFineractRequest } from "@/lib/api";
+import { toInlineContentDisposition } from "@/lib/document-viewing";
 
 export async function GET(
   request: NextRequest,
@@ -115,6 +116,10 @@ export async function GET(
       response.headers.get("content-type") || "application/octet-stream";
     const contentDisposition =
       response.headers.get("content-disposition") || "";
+    const responseContentDisposition =
+      request.nextUrl.searchParams.get("disposition") === "inline"
+        ? toInlineContentDisposition(contentDisposition)
+        : contentDisposition;
 
     console.log("Document downloaded successfully");
     console.log("Content-Type:", contentType);
@@ -126,7 +131,7 @@ export async function GET(
       status: 200,
       headers: {
         "Content-Type": contentType,
-        "Content-Disposition": contentDisposition,
+        "Content-Disposition": responseContentDisposition,
         "Cache-Control": "no-cache",
       },
     });

--- a/components/document/document-view-button.tsx
+++ b/components/document/document-view-button.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ButtonProps } from "@/components/ui/button";
+import {
+  buildInlineDocumentPreviewUrl,
+  isBrowserPreviewableDocument,
+} from "@/lib/document-viewing";
+
+export interface DocumentViewButtonProps extends Omit<ButtonProps, "onClick"> {
+  documentUrl: string | null | undefined;
+  fileName?: string | null;
+  contentType?: string | null;
+  mimeType?: string | null;
+  documentType?: string | null;
+  documentName?: string | null;
+  originalName?: string | null;
+  onFallbackDownload?: () => void | Promise<void>;
+  children?: React.ReactNode;
+}
+
+function triggerBrowserDownload(
+  documentUrl: string,
+  fileName: string | null | undefined
+) {
+  const link = document.createElement("a");
+  link.href = documentUrl;
+  link.download = fileName || "document";
+  link.rel = "noopener noreferrer";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function DocumentViewButton({
+  documentUrl,
+  fileName,
+  contentType,
+  mimeType,
+  documentType,
+  documentName,
+  originalName,
+  onFallbackDownload,
+  variant = "outline",
+  size = "sm",
+  className,
+  children,
+  disabled,
+  ...buttonProps
+}: DocumentViewButtonProps) {
+  const handleClick = () => {
+    if (!documentUrl) return;
+
+    if (
+      isBrowserPreviewableDocument({
+        contentType,
+        mimeType,
+        type: documentType,
+        fileName,
+        name: documentName,
+        originalName,
+        url: documentUrl,
+      })
+    ) {
+      const previewUrl = buildInlineDocumentPreviewUrl(documentUrl);
+      window.open(previewUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    if (onFallbackDownload) {
+      onFallbackDownload?.();
+      return;
+    }
+
+    triggerBrowserDownload(documentUrl, fileName);
+  };
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={handleClick}
+      disabled={disabled || !documentUrl}
+      {...buttonProps}
+    >
+      {children ?? (
+        <>
+          <Eye className="h-4 w-4" />
+          <span>View</span>
+        </>
+      )}
+    </Button>
+  );
+}

--- a/components/document/index.ts
+++ b/components/document/index.ts
@@ -4,3 +4,5 @@ export { DocumentPreviewButton } from "./document-preview-button";
 export type { DocumentPreviewButtonProps } from "./document-preview-button";
 export { DocumentPreviewCard } from "./document-preview-card";
 export type { DocumentPreviewCardProps } from "./document-preview-card";
+export { DocumentViewButton } from "./document-view-button";
+export type { DocumentViewButtonProps } from "./document-view-button";

--- a/lib/__tests__/document-view-button.test.ts
+++ b/lib/__tests__/document-view-button.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("document view button opens previewable files in a new tab and falls back to download", () => {
+  const source = readRepoFile("components/document/document-view-button.tsx");
+
+  assert.match(source, /isBrowserPreviewableDocument/);
+  assert.match(source, /buildInlineDocumentPreviewUrl/);
+  assert.match(source, /window\.open\(previewUrl,\s*"_blank"/);
+  assert.match(source, /onFallbackDownload\?\.\(\)/);
+});

--- a/lib/__tests__/document-view-placements.test.ts
+++ b/lib/__tests__/document-view-placements.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("document screens use the shared document view button", () => {
+  const files = [
+    "app/(application)/clients/[id]/components/client-documents.tsx",
+    "app/(application)/clients/[id]/components/client-entity-kyc.tsx",
+    "app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx",
+    "app/(application)/leads/[id]/components/lead-documents.tsx",
+    "app/(application)/leads/[id]/components/comprehensive-lead-details.tsx",
+    "app/(application)/leads/new/components/client-registration-form.tsx",
+    "app/(application)/leads/new/components/invoice-discounting-form.tsx",
+  ];
+
+  for (const file of files) {
+    assert.match(readRepoFile(file), /DocumentViewButton/, file);
+  }
+});

--- a/lib/__tests__/document-viewing.test.ts
+++ b/lib/__tests__/document-viewing.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("marks PDFs and images as browser previewable", async () => {
+  const { isBrowserPreviewableDocument } = await import("../document-viewing");
+
+  assert.equal(
+    isBrowserPreviewableDocument({ contentType: "application/pdf" }),
+    true
+  );
+  assert.equal(isBrowserPreviewableDocument({ type: "image/png" }), true);
+  assert.equal(
+    isBrowserPreviewableDocument({ fileName: "bank-statement.PDF" }),
+    true
+  );
+  assert.equal(
+    isBrowserPreviewableDocument({
+      url: "/api/documents/abc/attachment?name=selfie.jpeg",
+    }),
+    true
+  );
+});
+
+test("does not mark non-image and non-pdf documents as browser previewable", async () => {
+  const { isBrowserPreviewableDocument } = await import("../document-viewing");
+
+  assert.equal(
+    isBrowserPreviewableDocument({
+      contentType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }),
+    false
+  );
+  assert.equal(
+    isBrowserPreviewableDocument({ fileName: "settlement.xlsx" }),
+    false
+  );
+  assert.equal(
+    isBrowserPreviewableDocument({ fileName: "repayments.csv" }),
+    false
+  );
+  assert.equal(isBrowserPreviewableDocument({ fileName: "document" }), false);
+});
+
+test("builds inline preview URLs without losing existing query params", async () => {
+  const { buildInlineDocumentPreviewUrl } = await import("../document-viewing");
+
+  assert.equal(
+    buildInlineDocumentPreviewUrl("/api/documents/abc"),
+    "/api/documents/abc?disposition=inline"
+  );
+  assert.equal(
+    buildInlineDocumentPreviewUrl("/api/documents/abc?name=selfie.jpeg"),
+    "/api/documents/abc?name=selfie.jpeg&disposition=inline"
+  );
+});
+
+test("converts attachment content disposition to inline", async () => {
+  const { toInlineContentDisposition } = await import("../document-viewing");
+
+  assert.equal(toInlineContentDisposition(""), "inline");
+  assert.equal(
+    toInlineContentDisposition('attachment; filename="selfie.png"'),
+    'inline; filename="selfie.png"'
+  );
+  assert.equal(
+    toInlineContentDisposition("INLINE; filename=statement.pdf"),
+    "INLINE; filename=statement.pdf"
+  );
+});

--- a/lib/document-viewing.ts
+++ b/lib/document-viewing.ts
@@ -1,0 +1,74 @@
+const IMAGE_CONTENT_TYPE_PATTERN = /^image\//i;
+const PDF_CONTENT_TYPE_PATTERN = /(?:^|[/;+.-])pdf(?:$|[/;+.-])/i;
+const IMAGE_FILE_EXTENSION_PATTERN =
+  /\.(?:avif|bmp|gif|heic|heif|jpe?g|png|svg|tiff?|webp)(?:[?#].*)?$/i;
+const PDF_FILE_EXTENSION_PATTERN = /\.pdf(?:[?#].*)?$/i;
+
+export interface BrowserPreviewableDocumentInput {
+  contentType?: string | null;
+  mimeType?: string | null;
+  type?: string | null;
+  fileName?: string | null;
+  name?: string | null;
+  originalName?: string | null;
+  url?: string | null;
+}
+
+function hasPreviewableContentType(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim();
+  return (
+    IMAGE_CONTENT_TYPE_PATTERN.test(normalized) ||
+    PDF_CONTENT_TYPE_PATTERN.test(normalized)
+  );
+}
+
+function hasPreviewableFileExtension(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim();
+  return (
+    IMAGE_FILE_EXTENSION_PATTERN.test(normalized) ||
+    PDF_FILE_EXTENSION_PATTERN.test(normalized)
+  );
+}
+
+export function isBrowserPreviewableDocument({
+  contentType,
+  mimeType,
+  type,
+  fileName,
+  name,
+  originalName,
+  url,
+}: BrowserPreviewableDocumentInput): boolean {
+  return (
+    [contentType, mimeType, type].some(hasPreviewableContentType) ||
+    [fileName, name, originalName, url].some(hasPreviewableFileExtension)
+  );
+}
+
+export function buildInlineDocumentPreviewUrl(
+  url: string | null | undefined
+): string {
+  const trimmed = url?.trim();
+  if (!trimmed) return "";
+
+  const [withoutHash, hash] = trimmed.split("#", 2);
+  const [path, query = ""] = withoutHash.split("?", 2);
+  const params = new URLSearchParams(query);
+  params.set("disposition", "inline");
+
+  return `${path}?${params.toString()}${hash ? `#${hash}` : ""}`;
+}
+
+export function toInlineContentDisposition(
+  contentDisposition: string | null | undefined
+): string {
+  const trimmed = contentDisposition?.trim();
+  if (!trimmed) return "inline";
+  if (/^inline(?:\s*;|$)/i.test(trimmed)) return trimmed;
+  if (/^attachment(?:\s*;|$)/i.test(trimmed)) {
+    return trimmed.replace(/^attachment/i, "inline");
+  }
+  return `inline; ${trimmed}`;
+}


### PR DESCRIPTION
## Summary
- Add a shared document view button that opens previewable PDFs/images inline and falls back to download for other files.
- Wire document view actions into client, lead, KYC, loan, and registration document surfaces.
- Add inline content-disposition handling for document attachment endpoints.

## Tests
- PASS: `./node_modules/.bin/tsx --test lib/__tests__/document-viewing.test.ts lib/__tests__/document-view-button.test.ts lib/__tests__/document-view-placements.test.ts`
- PASS: `./node_modules/.bin/eslint components/document/document-view-button.tsx lib/document-viewing.ts lib/__tests__/document-viewing.test.ts lib/__tests__/document-view-button.test.ts lib/__tests__/document-view-placements.test.ts`
- NOTE: `npm run lint` and a touched-file scoped lint run still fail on the existing repository lint baseline, mostly legacy `any`, `require`, and hook warnings/errors.