### PR TITLE
Show Active toggle on charge create/edit

### DIFF
--- a/app/(application)/products/charges/page.tsx
+++ b/app/(application)/products/charges/page.tsx
@@ -1183,24 +1183,20 @@ export default function ChargeProductsPage() {
                 </div>
               )}
 
-              {/*
-              {editingRecordId != null && (
-                <div
-                  className="flex w-full items-center justify-between rounded-md border p-3 text-left transition-colors hover:bg-muted/40"
-                >
-                  <Label htmlFor="active" className="text-sm font-medium">
-                    Active
-                  </Label>
-                  <Switch
-                    id="active"
-                    checked={form.active}
-                    onCheckedChange={(checked) =>
-                      setForm((prev) => ({ ...prev, active: checked }))
-                    }
-                  />
-                </div>
-              )}
-              */}
+              <div
+                className="flex w-full items-center justify-between rounded-md border p-3 text-left transition-colors hover:bg-muted/40"
+              >
+                <Label htmlFor="active" className="text-sm font-medium">
+                  Active
+                </Label>
+                <Switch
+                  id="active"
+                  checked={form.active}
+                  onCheckedChange={(checked) =>
+                    setForm((prev) => ({ ...prev, active: checked }))
+                  }
+                />
+              </div>
             </div>
 
             {formError && <p className="text-sm text-destructive">{formError}</p>}


### PR DESCRIPTION
## Summary
- The "Active" toggle in the Charges admin dialog was commented out, so every charge was created (and stayed) inactive.
- Fineract only returns *active* charges as attachable options in a loan product's Charges step, so this made it look like attaching new charges to a loan product didn't work.
- Restores the toggle, now visible on both create and edit (previously edit-only even when uncommented), matching mifos-ui behavior.

## Test plan
- [ ] Create a new charge, toggle Active on, save, confirm it's saved as active in Fineract
- [ ] Edit an existing inactive charge, toggle Active on, save, confirm it becomes active
- [ ] Confirm an active charge now appears as an attachable option on a loan product's edit page Charges step

🤖 Generated with [Claude Code](https://claude.com/claude-code)