### PR TITLE
Fix cashier disbursement transaction enrichment

### DIFF
--- a/app/api/tellers/[id]/cashiers/[cashierId]/transactions/route.ts
+++ b/app/api/tellers/[id]/cashiers/[cashierId]/transactions/route.ts
@@ -11,6 +11,11 @@ import {
 import {
   isCashierCounterEntryBlockedByLoanContext,
 } from "@/lib/cashier-txn-reversal-eligibility";
+import {
+  buildCashierTransactionLoanContext,
+  extractLoanIdFromCashierTransactionNotes,
+  matchLoanPayoutForCashierTransaction,
+} from "@/lib/cashier-transaction-enrichment";
 
 type TellerRow = NonNullable<Awaited<ReturnType<typeof prisma.teller.findFirst>>>;
 type CashierRow = NonNullable<Awaited<ReturnType<typeof prisma.cashier.findFirst>>>;
@@ -57,123 +62,6 @@ type CashierSummaryPayload = {
     | CashierTransaction[];
   [key: string]: unknown;
 };
-
-const LOAN_REPAYMENT_NOTE_REGEX = /loan repayment\s*#\s*(\d+)/i;
-
-function extractLoanIdFromNotes(notes: string | null | undefined): number | null {
-  if (!notes) return null;
-  const match = notes.match(LOAN_REPAYMENT_NOTE_REGEX);
-  if (!match) return null;
-  const loanId = Number(match[1]);
-  return Number.isFinite(loanId) ? loanId : null;
-}
-
-function normalizeText(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase();
-}
-
-function getTransactionDate(value: unknown): Date | null {
-  if (Array.isArray(value) && value.length >= 3) {
-    const [year, month, day] = value;
-    if (
-      typeof year === "number" &&
-      typeof month === "number" &&
-      typeof day === "number"
-    ) {
-      return new Date(year, month - 1, day);
-    }
-  }
-
-  if (typeof value === "string") {
-    const parsed = new Date(value);
-    if (!Number.isNaN(parsed.getTime())) {
-      return parsed;
-    }
-  }
-
-  return null;
-}
-
-function isSameCalendarDay(a: Date | null, b: Date | null): boolean {
-  if (!a || !b) return false;
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
-
-function buildLeadFullName(lead: {
-  fullname?: string | null;
-  firstname?: string | null;
-  middlename?: string | null;
-  lastname?: string | null;
-}) {
-  const explicit = lead.fullname?.trim();
-  if (explicit) return explicit;
-
-  const joined = [lead.firstname, lead.middlename, lead.lastname]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
-
-  return joined || null;
-}
-
-function matchLoanPayoutForTransaction(
-  tx: CashierTransaction,
-  payouts: Array<{
-    id: string;
-    fineractLoanId: number;
-    fineractClientId: number;
-    clientName: string;
-    loanAccountNo: string;
-    amount: number;
-    paidAt: Date | null;
-    voidedAt: Date | null;
-    createdAt: Date;
-  }>
-) {
-  const note = String(tx?.txnNote ?? tx?.notes ?? "");
-  const noteLower = normalizeText(note);
-  const looksLoanRelated =
-    noteLower.includes("loan disbursement") ||
-    noteLower.includes("payout") ||
-    noteLower.includes("credit balance refund");
-
-  if (!looksLoanRelated) {
-    return null;
-  }
-
-  const amount = Math.abs(Number(tx?.txnAmount ?? tx?.amount ?? 0));
-  const txDate = getTransactionDate(
-    tx?.txnDate ?? tx?.transactionDate ?? tx?.createdDate
-  );
-
-  let candidates = payouts.filter(
-    (payout) => Math.abs(Math.abs(payout.amount) - amount) < 0.01
-  );
-
-  if (txDate) {
-    const sameDay = candidates.filter((payout) =>
-      isSameCalendarDay(txDate, payout.paidAt ?? payout.voidedAt ?? payout.createdAt)
-    );
-    if (sameDay.length > 0) {
-      candidates = sameDay;
-    }
-  }
-
-  const byNarration = candidates.filter((payout) => {
-    const clientName = normalizeText(payout.clientName);
-    const accountNo = normalizeText(payout.loanAccountNo);
-    return (
-      (!!clientName && noteLower.includes(clientName)) ||
-      (!!accountNo && noteLower.includes(accountNo))
-    );
-  });
-
-  return byNarration[0] ?? candidates[0] ?? null;
-}
 
 function isDuplicateFineractAllocationError(error: unknown) {
   return (
@@ -535,7 +423,9 @@ export async function GET(
 
     const candidateLoanIds = new Set<number>();
     for (const tx of normalizedItems) {
-      const noteLoanId = extractLoanIdFromNotes(tx?.txnNote ?? tx?.notes);
+      const noteLoanId = extractLoanIdFromCashierTransactionNotes(
+        tx?.txnNote ?? tx?.notes
+      );
       if (noteLoanId != null) {
         candidateLoanIds.add(noteLoanId);
       }
@@ -554,7 +444,7 @@ export async function GET(
         }
       }
 
-      const payoutMatch = matchLoanPayoutForTransaction(tx, loanPayouts);
+      const payoutMatch = matchLoanPayoutForCashierTransaction(tx, loanPayouts);
       if (payoutMatch?.fineractLoanId != null) {
         candidateLoanIds.add(payoutMatch.fineractLoanId);
       }
@@ -586,7 +476,9 @@ export async function GET(
     );
 
     const enrichedItems = normalizedItems.map((tx) => {
-      const noteLoanId = extractLoanIdFromNotes(tx?.txnNote ?? tx?.notes);
+      const noteLoanId = extractLoanIdFromCashierTransactionNotes(
+        tx?.txnNote ?? tx?.notes
+      );
       const repaymentLoanId =
         typeof tx?.id === "number" ? repaymentLinkByTxId.get(tx.id) ?? null : null;
 
@@ -596,31 +488,22 @@ export async function GET(
           : null;
 
       if (!payoutMatch) {
-        payoutMatch = matchLoanPayoutForTransaction(tx, loanPayouts);
+        payoutMatch = matchLoanPayoutForCashierTransaction(tx, loanPayouts);
       }
 
       const linkedLoanId =
         noteLoanId ?? repaymentLoanId ?? payoutMatch?.fineractLoanId ?? null;
       const lead = linkedLoanId != null ? leadByLoanId.get(linkedLoanId) ?? null : null;
-      const linkedClientId =
-        lead?.fineractClientId ?? payoutMatch?.fineractClientId ?? null;
-      const linkedFullName =
-        buildLeadFullName(lead ?? {}) ?? payoutMatch?.clientName ?? null;
-      const loanDetailHref =
-        linkedLoanId != null && linkedClientId != null
-          ? `/clients/${linkedClientId}/loans/${linkedLoanId}`
-          : lead?.id
-          ? `/leads/${lead.id}`
-          : null;
+      const loanContext = buildCashierTransactionLoanContext({
+        tx,
+        repaymentLoanId,
+        payoutMatch,
+        lead,
+      });
 
       return {
         ...tx,
-        linkedLoanId,
-        linkedClientId,
-        linkedLeadId: lead?.id ?? null,
-        linkedNrc: lead?.externalId ?? null,
-        linkedFullName,
-        loanDetailHref,
+        ...loanContext,
       };
     });
 

--- a/lib/__tests__/cashier-transaction-enrichment.test.ts
+++ b/lib/__tests__/cashier-transaction-enrichment.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCashierTransactionLoanContext,
+  extractLoanIdFromCashierTransactionNotes,
+  matchLoanPayoutForCashierTransaction,
+} from "../cashier-transaction-enrichment";
+
+test("builds loan display context from a Fineract disbursement cashier note", () => {
+  const context = buildCashierTransactionLoanContext({
+    tx: {
+      id: 1276342,
+      entityType: "loans",
+      txnNote:
+        "DISBURSEMENT, Loan:171704-000171704,Client:30924-DERRICK FUNGAMWANGO",
+    },
+    lead: {
+      id: "lead-171704",
+      fineractLoanId: 171704,
+      fineractClientId: 30924,
+      externalId: "237476/64/1",
+      fullname: "",
+      firstname: "DERRICK",
+      middlename: null,
+      lastname: "FUNGAMWANGO",
+    },
+  });
+
+  assert.deepEqual(context, {
+    linkedLoanId: 171704,
+    linkedClientId: 30924,
+    linkedLeadId: "lead-171704",
+    linkedNrc: "237476/64/1",
+    linkedFullName: "DERRICK FUNGAMWANGO",
+    loanDetailHref: "/clients/30924/loans/171704",
+  });
+});
+
+test("keeps legacy repayment note loan id parsing", () => {
+  assert.equal(
+    extractLoanIdFromCashierTransactionNotes("Loan repayment #169499"),
+    169499
+  );
+});
+
+test("matches loan payout by explicit Fineract loan note before loose amount matching", () => {
+  const payout = matchLoanPayoutForCashierTransaction(
+    {
+      id: 1276342,
+      entityType: "loans",
+      txnAmount: 1000,
+      txnDate: [2026, 7, 16],
+      txnNote:
+        "DISBURSEMENT, Loan:171704-000171704,Client:30924-DERRICK FUNGAMWANGO",
+    },
+    [
+      {
+        id: "payout-171676",
+        fineractLoanId: 171676,
+        fineractClientId: 18533,
+        clientName: "WEBBY MUNGOLE",
+        loanAccountNo: "000171676",
+        amount: 1000,
+        paidAt: new Date(2026, 6, 16),
+        voidedAt: null,
+        createdAt: new Date(2026, 6, 16),
+      },
+      {
+        id: "payout-171704",
+        fineractLoanId: 171704,
+        fineractClientId: 30924,
+        clientName: "DERRICK FUNGAMWANGO",
+        loanAccountNo: "000171704",
+        amount: 1000,
+        paidAt: new Date(2026, 6, 16),
+        voidedAt: null,
+        createdAt: new Date(2026, 6, 16),
+      },
+    ]
+  );
+
+  assert.equal(payout?.id, "payout-171704");
+});

--- a/lib/cashier-transaction-enrichment.ts
+++ b/lib/cashier-transaction-enrichment.ts
@@ -1,0 +1,214 @@
+export type CashierTransactionForLoanContext = {
+  id: number | string;
+  txnAmount?: number | null;
+  amount?: number | null;
+  txnDate?: string | number[] | null;
+  createdDate?: string | number[] | null;
+  transactionDate?: string | number[] | null;
+  txnNote?: string | null;
+  notes?: string | null;
+  entityType?: string | null;
+  [key: string]: unknown;
+};
+
+export type CashierLoanPayoutReference = {
+  id: string;
+  fineractLoanId: number;
+  fineractClientId: number;
+  clientName: string;
+  loanAccountNo: string;
+  amount: number;
+  paidAt: Date | null;
+  voidedAt: Date | null;
+  createdAt: Date;
+};
+
+export type CashierLeadReference = {
+  id: string;
+  fineractLoanId?: number | null;
+  fineractClientId?: number | null;
+  externalId?: string | null;
+  fullname?: string | null;
+  firstname?: string | null;
+  middlename?: string | null;
+  lastname?: string | null;
+};
+
+export type CashierTransactionLoanContext = {
+  linkedLoanId: number | null;
+  linkedClientId: number | null;
+  linkedLeadId: string | null;
+  linkedNrc: string | null;
+  linkedFullName: string | null;
+  loanDetailHref: string | null;
+};
+
+const LOAN_REPAYMENT_NOTE_REGEX = /loan repayment\s*#\s*(\d+)/i;
+const FINERACT_LOAN_NOTE_REGEX = /\bloan\s*:\s*(\d+)(?:\s*[-,]|\b)/i;
+
+export function extractLoanIdFromCashierTransactionNotes(
+  notes: string | null | undefined
+): number | null {
+  if (!notes) return null;
+
+  const match =
+    notes.match(LOAN_REPAYMENT_NOTE_REGEX) ??
+    notes.match(FINERACT_LOAN_NOTE_REGEX);
+  if (!match) return null;
+
+  const loanId = Number(match[1]);
+  return Number.isFinite(loanId) ? loanId : null;
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function getTransactionDate(value: unknown): Date | null {
+  if (Array.isArray(value) && value.length >= 3) {
+    const [year, month, day] = value;
+    if (
+      typeof year === "number" &&
+      typeof month === "number" &&
+      typeof day === "number"
+    ) {
+      return new Date(year, month - 1, day);
+    }
+  }
+
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function isSameCalendarDay(a: Date | null, b: Date | null): boolean {
+  if (!a || !b) return false;
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function buildCashierLeadFullName(
+  lead: Pick<
+    CashierLeadReference,
+    "fullname" | "firstname" | "middlename" | "lastname"
+  >
+): string | null {
+  const explicit = lead.fullname?.trim();
+  if (explicit) return explicit;
+
+  const joined = [lead.firstname, lead.middlename, lead.lastname]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return joined || null;
+}
+
+function isLoanRelatedCashierTransaction(
+  tx: CashierTransactionForLoanContext
+): boolean {
+  const note = String(tx?.txnNote ?? tx?.notes ?? "");
+  const noteLower = normalizeText(note);
+  const entityTypeLower = normalizeText(tx.entityType);
+
+  return (
+    entityTypeLower === "loans" ||
+    noteLower.includes("loan disbursement") ||
+    noteLower.includes("payout") ||
+    noteLower.includes("credit balance refund") ||
+    FINERACT_LOAN_NOTE_REGEX.test(note)
+  );
+}
+
+export function matchLoanPayoutForCashierTransaction(
+  tx: CashierTransactionForLoanContext,
+  payouts: CashierLoanPayoutReference[]
+): CashierLoanPayoutReference | null {
+  const note = String(tx?.txnNote ?? tx?.notes ?? "");
+  const noteLoanId = extractLoanIdFromCashierTransactionNotes(note);
+  if (noteLoanId != null) {
+    const exactPayout = payouts.find(
+      (payout) => payout.fineractLoanId === noteLoanId
+    );
+    if (exactPayout) return exactPayout;
+  }
+
+  if (!isLoanRelatedCashierTransaction(tx)) {
+    return null;
+  }
+
+  const noteLower = normalizeText(note);
+  const amount = Math.abs(Number(tx?.txnAmount ?? tx?.amount ?? 0));
+  const txDate = getTransactionDate(
+    tx?.txnDate ?? tx?.transactionDate ?? tx?.createdDate
+  );
+
+  let candidates = payouts.filter(
+    (payout) => Math.abs(Math.abs(payout.amount) - amount) < 0.01
+  );
+
+  if (txDate) {
+    const sameDay = candidates.filter((payout) =>
+      isSameCalendarDay(txDate, payout.paidAt ?? payout.voidedAt ?? payout.createdAt)
+    );
+    if (sameDay.length > 0) {
+      candidates = sameDay;
+    }
+  }
+
+  const byNarration = candidates.filter((payout) => {
+    const clientName = normalizeText(payout.clientName);
+    const accountNo = normalizeText(payout.loanAccountNo);
+    return (
+      (!!clientName && noteLower.includes(clientName)) ||
+      (!!accountNo && noteLower.includes(accountNo))
+    );
+  });
+
+  return byNarration[0] ?? candidates[0] ?? null;
+}
+
+export function buildCashierTransactionLoanContext({
+  tx,
+  repaymentLoanId = null,
+  payoutMatch = null,
+  lead = null,
+}: {
+  tx: CashierTransactionForLoanContext;
+  repaymentLoanId?: number | null;
+  payoutMatch?: CashierLoanPayoutReference | null;
+  lead?: CashierLeadReference | null;
+}): CashierTransactionLoanContext {
+  const noteLoanId = extractLoanIdFromCashierTransactionNotes(
+    tx?.txnNote ?? tx?.notes
+  );
+  const linkedLoanId =
+    noteLoanId ?? repaymentLoanId ?? payoutMatch?.fineractLoanId ?? null;
+  const linkedClientId =
+    lead?.fineractClientId ?? payoutMatch?.fineractClientId ?? null;
+  const linkedFullName =
+    buildCashierLeadFullName(lead ?? {}) ?? payoutMatch?.clientName?.trim() ?? null;
+  const loanDetailHref =
+    linkedLoanId != null && linkedClientId != null
+      ? `/clients/${linkedClientId}/loans/${linkedLoanId}`
+      : lead?.id
+        ? `/leads/${lead.id}`
+        : null;
+
+  return {
+    linkedLoanId,
+    linkedClientId,
+    linkedLeadId: lead?.id ?? null,
+    linkedNrc: lead?.externalId ?? null,
+    linkedFullName,
+    loanDetailHref,
+  };
+}


### PR DESCRIPTION
## Summary
- Parse Fineract cashier notes like `DISBURSEMENT, Loan:171704-000171704,...` so disbursement transactions can resolve the loan id.
- Reuse one cashier transaction enrichment helper for linked loan/client/lead/NRC/full name fields.
- Match loan payouts by explicit loan id before falling back to amount/date/narration matching.

## Verification
- `node --import tsx --test lib/__tests__/cashier-transaction-enrichment.test.ts lib/loan-repayment-cashier-policy.test.ts lib/loan-disbursement-cashier-policy.test.ts`
- `./node_modules/.bin/eslint lib/cashier-transaction-enrichment.ts lib/__tests__/cashier-transaction-enrichment.test.ts 'app/api/tellers/[id]/cashiers/[cashierId]/transactions/route.ts'`\n- `DATABASE_URL='postgresql://user:pass@localhost:5432/testdb' node --import tsx -e "import('./app/api/tellers/[id]/cashiers/[cashierId]/transactions/route.ts').then(() => console.log('route import ok'))"`