### PR TITLE
Wire USSD forced PIN change request

### DIFF
--- a/app/(application)/ussd-pin-reset/components/ussd-pin-reset-client.tsx
+++ b/app/(application)/ussd-pin-reset/components/ussd-pin-reset-client.tsx
@@ -77,9 +77,17 @@ function formatDateTime(value?: string | null) {
 function StatusBadge({ status }: { status: string }) {
   const normalized = status.toUpperCase();
 
-  if (normalized === "SUCCESS") {
+  if (normalized === "SUCCESS" || normalized === "FLAGGED") {
     return (
       <Badge className="border-transparent bg-green-100 text-green-800">
+        {status}
+      </Badge>
+    );
+  }
+
+  if (normalized === "FLAGGED_SMS_FAILED") {
+    return (
+      <Badge className="border-transparent bg-amber-100 text-amber-800">
         {status}
       </Badge>
     );
@@ -97,7 +105,7 @@ async function fetchResetLogs() {
   const data = await readJson(response);
 
   if (!response.ok) {
-    throw new Error(String(data.error || "Failed to load reset logs"));
+    throw new Error(String(data.error || "Failed to load PIN change logs"));
   }
 
   return Array.isArray(data.logs) ? (data.logs as ResetLog[]) : [];
@@ -127,7 +135,9 @@ export function UssdPinResetClient() {
         type: "error",
         title: "Log refresh failed",
         message:
-          error instanceof Error ? error.message : "Failed to load reset logs",
+          error instanceof Error
+            ? error.message
+            : "Failed to load PIN change logs",
       });
     } finally {
       setIsLoadingLogs(false);
@@ -152,7 +162,7 @@ export function UssdPinResetClient() {
             message:
               error instanceof Error
                 ? error.message
-                : "Failed to load reset logs",
+                : "Failed to load PIN change logs",
           });
         }
       } finally {
@@ -205,7 +215,7 @@ export function UssdPinResetClient() {
       setNotice({
         type: "error",
         title: "No client selected",
-        message: "Search and select a USSD client before resetting.",
+        message: "Search and select a USSD client before requiring a PIN change.",
       });
       return;
     }
@@ -237,22 +247,27 @@ export function UssdPinResetClient() {
       const data = await readJson(response);
 
       if (!response.ok) {
-        throw new Error(String(data.error || "PIN reset failed"));
+        throw new Error(String(data.error || "PIN change request failed"));
       }
 
       setNotice({
         type: "success",
-        title: "Reset requested",
-        message: String(data.message || "USSD reset SMS sent to the client."),
+        title: "PIN change requested",
+        message: String(
+          data.message ||
+            "The client will be prompted to set a new PIN in USSD."
+        ),
       });
       setReason("");
       await loadLogs();
     } catch (error) {
       setNotice({
         type: "error",
-        title: "Reset failed",
+        title: "PIN change request failed",
         message:
-          error instanceof Error ? error.message : "Failed to reset USSD PIN",
+          error instanceof Error
+            ? error.message
+            : "Failed to require USSD PIN change",
       });
       await loadLogs();
     } finally {
@@ -355,7 +370,7 @@ export function UssdPinResetClient() {
                 ) : (
                   <ShieldCheck className="mr-2 h-4 w-4" />
                 )}
-                Reset USSD PIN
+                Require PIN Change
               </Button>
             </div>
           )}
@@ -364,9 +379,9 @@ export function UssdPinResetClient() {
         <section className="space-y-4">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <h3 className="font-semibold">Recent resets</h3>
+              <h3 className="font-semibold">Recent PIN changes</h3>
               <p className="text-sm text-muted-foreground">
-                Staff-initiated USSD PIN reset activity
+                Staff-initiated USSD PIN change activity
               </p>
             </div>
             <Button
@@ -403,7 +418,7 @@ export function UssdPinResetClient() {
                     colSpan={6}
                     className="h-24 text-center text-muted-foreground"
                   >
-                    No reset activity found.
+                    No PIN change activity found.
                   </TableCell>
                 </TableRow>
               ) : (

--- a/app/(application)/ussd-pin-reset/page.tsx
+++ b/app/(application)/ussd-pin-reset/page.tsx
@@ -12,7 +12,7 @@ import { UssdPinResetClient } from "./components/ussd-pin-reset-client";
 
 export const metadata: Metadata = {
   title: "USSD PIN Reset | KENAC Loan Matrix",
-  description: "Reset Goodfellow USSD client PINs",
+  description: "Require Goodfellow USSD clients to change PINs",
 };
 
 export default async function UssdPinResetPage() {
@@ -40,7 +40,7 @@ export default async function UssdPinResetPage() {
             USSD PIN Reset
           </h2>
           <p className="text-muted-foreground">
-            Search a USSD client and request a staff-initiated PIN reset.
+            Search a USSD client and flag a client to change their USSD PIN.
           </p>
         </div>
       </div>

--- a/app/api/ussd-pin-reset/reset/route.ts
+++ b/app/api/ussd-pin-reset/reset/route.ts
@@ -24,9 +24,9 @@ function errorResponse(error: unknown) {
     return NextResponse.json({ error: error.message }, { status: error.status });
   }
 
-  console.error("USSD PIN reset request failed:", error);
+  console.error("USSD PIN change request failed:", error);
   return NextResponse.json(
-    { error: "Failed to reset USSD PIN" },
+    { error: "Failed to require USSD PIN change" },
     { status: 500 }
   );
 }
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
 
     if (!reason) {
       return NextResponse.json(
-        { error: "Reset reason is required" },
+        { error: "PIN change reason is required" },
         { status: 400 }
       );
     }
@@ -102,9 +102,8 @@ export async function POST(request: NextRequest) {
       reason,
     });
 
-    const finalStatus = resetResult.success
-      ? "SUCCESS"
-      : resetResult.status || "FAILED";
+    const finalStatus =
+      resetResult.status || (resetResult.success ? "FLAGGED" : "FAILED");
 
     await prisma.ussdPinResetLog.update({
       where: {
@@ -118,18 +117,26 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return NextResponse.json({
-      success: resetResult.success,
-      status: finalStatus,
-      message: resetResult.message,
-      user: {
-        userId: user.userId,
-        fullName: user.fullName,
-        nationalIdMask: user.nationalIdMask,
-        phoneNumber: user.phoneNumber,
+    const responseStatus = resetResult.success ? 200 : 400;
+
+    return NextResponse.json(
+      {
+        success: resetResult.success,
+        status: finalStatus,
+        message: resetResult.message,
+        resetRequired: resetResult.resetRequired,
+        pinChanged: resetResult.pinChanged,
+        smsAccepted: resetResult.smsAccepted,
+        user: {
+          userId: user.userId,
+          fullName: user.fullName,
+          nationalIdMask: user.nationalIdMask,
+          phoneNumber: user.phoneNumber,
+        },
+        logId: log.id,
       },
-      logId: log.id,
-    });
+      { status: responseStatus }
+    );
   } catch (error) {
     if (logId) {
       await prisma.ussdPinResetLog.update({
@@ -139,7 +146,9 @@ export async function POST(request: NextRequest) {
         data: {
           status: "FAILED",
           errorMessage:
-            error instanceof Error ? error.message : "Unknown reset failure",
+            error instanceof Error
+              ? error.message
+              : "Unknown PIN change request failure",
           completedAt: new Date(),
         },
       });

--- a/docs/superpowers/plans/2026-07-17-ussd-admin-forced-pin-change.md
+++ b/docs/superpowers/plans/2026-07-17-ussd-admin-forced-pin-change.md
@@ -1,0 +1,135 @@
+# USSD Admin Forced PIN Change Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change the admin USSD PIN reset flow so Loan Matrix flags a USSD client for a forced PIN change instead of USSD generating and sending a new PIN by SMS.
+
+**Architecture:** USSD owns the reset-required state, the forced USSD flow, PIN update, and SMS notification. Loan Matrix keeps the admin permission, lookup screen, and audit log, but its reset action becomes "require PIN change" and treats SMS as notification-only.
+
+**Tech Stack:** Loan Matrix Next.js/TypeScript/Prisma; GoodFellow USSD Spring Boot/JPA/JUnit/Mockito; PostgreSQL.
+
+## Global Constraints
+
+- Do not expose or return a generated PIN from any API.
+- SMS delivery must not decide whether the reset request succeeds after the USSD user has been flagged.
+- The forced reset must require NRC/National ID verification before accepting a new PIN.
+- USSD production uses schema validation, so `goodfellow_users` columns must exist before deploying code that maps them.
+- Do not commit changes unless explicitly requested.
+
+---
+
+### Task 1: USSD Reset-Required State and Admin API
+
+**Files:**
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/model/entity/GoodfellowUser.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/service/AdminPinResetService.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/dto/admin/AdminPinResetResponse.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/util/SmsTemplates.java`
+- Test: `USSD/GoodFellowUssd/src/test/java/zw/co/kenac/goodfellow_ussd_app/service/AdminPinResetServiceTest.java`
+
+**Interfaces:**
+- Produces `GoodfellowUser.pinResetRequired: Boolean`, `pinResetRequestedAt: LocalDateTime`, `pinResetRequestedBy: String`, `pinResetReason: String`.
+- Produces `AdminPinResetResponse.resetRequired: Boolean`.
+- Keeps `POST /api/v1/admin/users/pin-reset` stable for Loan Matrix.
+
+- [x] **Step 1: Write failing service tests**
+
+Add tests asserting `resetPin` saves a flag, does not call `GoodfellowUserService.updateUserPin`, sends a notification-only SMS, returns `FLAGGED`, and returns `FLAGGED_SMS_FAILED` with `success=true` when SMS fails.
+
+- [x] **Step 2: Run red tests**
+
+Run: `./mvnw -Dtest=AdminPinResetServiceTest test`
+Expected: FAIL because `GoodfellowUser` has no reset flag fields and the service still updates the PIN.
+
+- [x] **Step 3: Implement state and admin behavior**
+
+Add nullable/defaulted JPA columns to `GoodfellowUser`; update `AdminPinResetService.resetPin` to set the flag metadata and save the user; replace generated-PIN SMS with a notification template.
+
+- [x] **Step 4: Run green tests**
+
+Run: `./mvnw -Dtest=AdminPinResetServiceTest,AdminPinResetControllerTest test`
+Expected: PASS.
+
+### Task 2: USSD Forced Reset Flow
+
+**Files:**
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/enums/Stages.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/enums/Levels.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/model/UserData.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/service/flows/HomeMenuFlowService.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/service/flows/RouterFlowService.java`
+- Modify: `USSD/GoodFellowUssd/src/main/java/zw/co/kenac/goodfellow_ussd_app/service/flows/MyAccountFlowService.java`
+- Test: create `USSD/GoodFellowUssd/src/test/java/zw/co/kenac/goodfellow_ussd_app/service/flows/ForcedPinResetFlowServiceTest.java`
+
+**Interfaces:**
+- Produces `Stages.FORCED_PIN_RESET`.
+- Produces `Levels.ENTER_NATIONAL_ID`, `ENTER_NEW_PIN`, `CONFIRM_NEW_PIN` forced reset progression.
+- Clears `GoodfellowUser.pinResetRequired` only after a successful PIN update.
+
+- [x] **Step 1: Write failing flow tests**
+
+Cover login option for flagged user prompts for NRC; wrong NRC ends safely; correct NRC asks for new PIN; mismatched confirmation ends without clearing the flag; successful confirmation updates the PIN and clears flag metadata.
+
+- [x] **Step 2: Run red flow tests**
+
+Run: `./mvnw -Dtest=ForcedPinResetFlowServiceTest test`
+Expected: FAIL because forced-reset stage handling does not exist.
+
+- [x] **Step 3: Implement forced flow**
+
+Route flagged users from Home login into forced reset before normal PIN entry; implement NRC verification and new PIN confirmation in the account flow; clear flag after `updateUserPin` succeeds.
+
+- [x] **Step 4: Run green flow tests**
+
+Run: `./mvnw -Dtest=ForcedPinResetFlowServiceTest test`
+Expected: PASS.
+
+### Task 3: Loan Matrix Copy and Status Handling
+
+**Files:**
+- Modify: `loan-matrix/lib/ussd-admin-client.ts`
+- Modify: `loan-matrix/app/api/ussd-pin-reset/reset/route.ts`
+- Modify: `loan-matrix/app/(application)/ussd-pin-reset/components/ussd-pin-reset-client.tsx`
+- Test: `loan-matrix/lib/__tests__/ussd-admin-pin-reset.test.ts`
+
+**Interfaces:**
+- Consumes USSD statuses `FLAGGED`, `FLAGGED_SMS_FAILED`, `NOT_FOUND`, `INVALID_PHONE`.
+- Produces Loan Matrix audit statuses matching the USSD status and user-facing copy for “Require PIN change”.
+
+- [x] **Step 1: Write failing Loan Matrix tests**
+
+Update client tests to assert `FLAGGED_SMS_FAILED` is parsed as structured success and no PIN terms appear in the API/UI copy.
+
+- [x] **Step 2: Run red tests**
+
+Run: `npm test -- lib/__tests__/ussd-admin-pin-reset.test.ts`
+Expected: FAIL while copy/status names still describe direct PIN reset.
+
+- [x] **Step 3: Implement Loan Matrix copy/status changes**
+
+Update button, toast, API messages, and audit wording from direct reset to forced PIN change.
+
+- [x] **Step 4: Run green tests**
+
+Run: `npm test -- lib/__tests__/ussd-admin-pin-reset.test.ts`
+Expected: PASS.
+
+### Task 4: Final Verification
+
+**Files:**
+- No new production files.
+
+- [x] **Step 1: Run focused USSD tests**
+
+Run: `./mvnw -Dtest=AdminPinResetServiceTest,AdminPinResetControllerTest,ForcedPinResetFlowServiceTest test`
+Expected: PASS.
+
+- [x] **Step 2: Run focused Loan Matrix tests**
+
+Run: `npm test -- lib/__tests__/ussd-admin-pin-reset.test.ts`
+Expected: PASS.
+
+- [x] **Step 3: Review SQL needed for production**
+
+Prepare an idempotent SQL snippet for `goodfellow_users` columns:
+`pin_reset_required`, `pin_reset_requested_at`, `pin_reset_requested_by`, `pin_reset_reason`.

--- a/lib/__tests__/ussd-admin-pin-reset.test.ts
+++ b/lib/__tests__/ussd-admin-pin-reset.test.ts
@@ -27,7 +27,7 @@ test("USSD admin client uses the dedicated admin key and never the loan-product 
   assert.doesNotMatch(source, /USSD_LOAN_PRODUCT_SYNC_API_KEY/);
 });
 
-test("USSD admin client returns structured reset failures from USSD", async () => {
+test("USSD admin client returns structured forced PIN change notification failures from USSD", async () => {
   process.env.USSD_BASE_URL = "http://localhost:8080/api/v1";
   process.env.USSD_ADMIN_API_KEY = "admin-reset-key";
 
@@ -35,12 +35,16 @@ test("USSD admin client returns structured reset failures from USSD", async () =
   globalThis.fetch = (async () =>
     new Response(
       JSON.stringify({
-        success: false,
-        status: "SMS_FAILED_PIN_CHANGED",
-        message: "PIN was changed but the reset SMS was not accepted",
+        success: true,
+        status: "FLAGGED_SMS_FAILED",
+        message:
+          "PIN change was required, but the notification SMS was not accepted",
+        resetRequired: true,
+        pinChanged: false,
+        smsAccepted: false,
       }),
       {
-        status: 400,
+        status: 200,
         headers: {
           "Content-Type": "application/json",
         },
@@ -56,12 +60,15 @@ test("USSD admin client returns structured reset failures from USSD", async () =
       reason: "Client verified at branch",
     });
 
-    assert.equal(result.success, false);
-    assert.equal(result.status, "SMS_FAILED_PIN_CHANGED");
+    assert.equal(result.success, true);
+    assert.equal(result.status, "FLAGGED_SMS_FAILED");
     assert.equal(
       result.message,
-      "PIN was changed but the reset SMS was not accepted"
+      "PIN change was required, but the notification SMS was not accepted"
     );
+    assert.equal(result.resetRequired, true);
+    assert.equal(result.pinChanged, false);
+    assert.equal(result.smsAccepted, false);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -101,7 +108,7 @@ test("USSD admin client normalizes string lookup user ids from USSD", async () =
   }
 });
 
-test("Loan Matrix audit model records reset attempts without storing PIN values", () => {
+test("Loan Matrix audit model records PIN change requests without storing PIN values", () => {
   const schema = readRepoFile("prisma/schema.prisma");
 
   assert.match(schema, /model UssdPinResetLog/);
@@ -113,14 +120,36 @@ test("Loan Matrix audit model records reset attempts without storing PIN values"
   assert.doesNotMatch(schema, /newPin|temporaryPin|plainPin|pinValue/i);
 });
 
-test("USSD PIN reset API creates and updates a local audit log", () => {
+test("USSD PIN reset API creates and updates a local audit log with USSD statuses", () => {
   const resetRoute = readRepoFile("app/api/ussd-pin-reset/reset/route.ts");
 
   assert.match(resetRoute, /requireUssdPinResetAccess/);
   assert.match(resetRoute, /prisma\.ussdPinResetLog\.create/);
   assert.match(resetRoute, /prisma\.ussdPinResetLog\.update/);
   assert.match(resetRoute, /resetUssdPin/);
+  assert.match(resetRoute, /const finalStatus =\s+resetResult\.status \|\|/);
+  assert.match(
+    resetRoute,
+    /const responseStatus = resetResult\.success \? 200 : 400/
+  );
+  assert.match(resetRoute, /{ status: responseStatus }/);
+  assert.match(resetRoute, /Failed to require USSD PIN change/);
+  assert.doesNotMatch(resetRoute, /\? "SUCCESS"/);
   assert.doesNotMatch(resetRoute, /newPin|temporaryPin|plainPin|pinValue/i);
+});
+
+test("USSD PIN reset screen requests a forced PIN change instead of describing a direct reset", () => {
+  const page = readRepoFile("app/(application)/ussd-pin-reset/page.tsx");
+  const component = readRepoFile(
+    "app/(application)/ussd-pin-reset/components/ussd-pin-reset-client.tsx"
+  );
+
+  assert.match(page, /flag a client to change their USSD PIN/);
+  assert.match(component, /Require PIN Change/);
+  assert.match(component, /PIN change requested/);
+  assert.match(component, /prompted to set a new PIN in USSD/);
+  assert.match(component, /Staff-initiated USSD PIN change activity/);
+  assert.doesNotMatch(component, /USSD reset SMS sent|Reset USSD PIN|PIN reset failed/);
 });
 
 test("USSD PIN reset permission is wired into users and navigation", () => {

--- a/lib/ussd-admin-client.ts
+++ b/lib/ussd-admin-client.ts
@@ -15,6 +15,9 @@ export type UssdAdminResetResult = {
   userId?: number | null;
   fullName?: string | null;
   phoneNumber?: string | null;
+  pinChanged?: boolean | null;
+  smsAccepted?: boolean | null;
+  resetRequired?: boolean | null;
 };
 
 type ResetInput = {
@@ -67,6 +70,10 @@ function optionalString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function optionalBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
 function numericId(value: unknown, fieldName: string): number {
   const id = typeof value === "number" ? value : Number(value);
 
@@ -112,6 +119,9 @@ function parseUssdResetResult(payload: unknown): UssdAdminResetResult | null {
     userId: payload.userId == null ? null : numericId(payload.userId, "userId"),
     fullName: optionalString(payload.fullName),
     phoneNumber: optionalString(payload.phoneNumber),
+    pinChanged: optionalBoolean(payload.pinChanged),
+    smsAccepted: optionalBoolean(payload.smsAccepted),
+    resetRequired: optionalBoolean(payload.resetRequired),
   };
 }
 
@@ -194,14 +204,16 @@ export async function resetUssdPin(
     }
 
     throw new Error(
-      `USSD PIN reset failed (${response.status}): ${body || response.statusText}`
+      `USSD PIN change request failed (${response.status}): ${
+        body || response.statusText
+      }`
     );
   }
 
   const payload = await response.json();
   const resetResult = parseUssdResetResult(payload);
   if (!resetResult) {
-    throw new Error("USSD PIN reset returned invalid reset details");
+    throw new Error("USSD PIN change request returned invalid details");
   }
 
   return resetResult;


### PR DESCRIPTION
## Summary
- Preserve USSD admin reset statuses such as `FLAGGED` and `FLAGGED_SMS_FAILED` in the Loan Matrix audit flow.
- Parse USSD reset flags (`resetRequired`, `pinChanged`, `smsAccepted`) and return appropriate API statuses.
- Update the UI copy from direct PIN reset/SMS delivery to requiring a client PIN change in USSD.
- Add the implementation plan and focused tests.

## Tests
- `node --import tsx --test lib/__tests__/ussd-admin-pin-reset.test.ts`
- `./node_modules/.bin/eslint lib/ussd-admin-client.ts app/api/ussd-pin-reset/reset/route.ts "app/(application)/ussd-pin-reset/page.tsx" "app/(application)/ussd-pin-reset/components/ussd-pin-reset-client.tsx" lib/__tests__/ussd-admin-pin-reset.test.ts`