### PR TITLE
Add loan running balance column

### DIFF
--- a/app/(application)/clients/[id]/components/client-loans.tsx
+++ b/app/(application)/clients/[id]/components/client-loans.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useCurrency } from "@/contexts/currency-context";
 import useSWR from 'swr';
 import {
@@ -9,6 +10,7 @@ import {
   AlertCircle,
   TrendingUp,
   ChevronRight,
+  Search,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
@@ -19,6 +21,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -27,6 +31,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  buildClientLoanSequenceNumbers,
+  CLIENT_LOANS_PAGE_SIZE,
+  filterClientLoans,
+  orderClientLoansLatestFirst,
+  paginateClientLoans,
+} from "@/lib/client-loans-table";
 import { getDisplayLoanStatus } from "@/lib/loan-status";
 import {
   extractTenantSlugFromHostname,
@@ -102,6 +113,7 @@ interface RawClientLoan {
     submittedOnDate?: string;
     approvedOnDate?: string;
     actualDisbursementDate?: string;
+    expectedDisbursementDate?: string;
     expectedMaturityDate?: string;
   };
   summary?: {
@@ -117,16 +129,6 @@ interface RawClientLoan {
     pastDueDays?: number;
     delinquentDays?: number;
     delinquentAmount?: number;
-  };
-}
-
-interface ClientLoanSequenceItem {
-  id: number;
-  timeline?: {
-    submittedOnDate?: string;
-    approvedOnDate?: string;
-    actualDisbursementDate?: string;
-    expectedDisbursementDate?: string;
   };
 }
 
@@ -149,31 +151,18 @@ interface LoanDetailsForTable {
   };
 }
 
-const getLoanSequenceSortTime = (loan: ClientLoanSequenceItem): number => {
-  const candidateDates = [
-    loan.timeline?.submittedOnDate,
-    loan.timeline?.approvedOnDate,
-    loan.timeline?.actualDisbursementDate,
-    loan.timeline?.expectedDisbursementDate,
-  ];
-
-  for (const value of candidateDates) {
-    if (typeof value === "string" && value) {
-      const parsed = new Date(value).getTime();
-      if (!Number.isNaN(parsed)) {
-        return parsed;
-      }
-    }
-  }
-
-  return Number.MAX_SAFE_INTEGER;
-};
-
 // Simple fetcher for SWR
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
 export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
   const router = useRouter();
+  const [loanPageRequest, setLoanPageRequest] = useState({
+    clientId,
+    loanCount: 0,
+    searchQuery: "",
+    page: 1,
+  });
+  const [loanSearchQuery, setLoanSearchQuery] = useState("");
   const tenantSlug =
     typeof globalThis.window !== "undefined"
       ? extractTenantSlugFromHostname(globalThis.location.hostname)
@@ -259,6 +248,7 @@ export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
         submittedOnDate: loan.timeline?.submittedOnDate || "",
         approvedOnDate: loan.timeline?.approvedOnDate || "",
         actualDisbursementDate: loan.timeline?.actualDisbursementDate || "",
+        expectedDisbursementDate: loan.timeline?.expectedDisbursementDate || "",
         expectedMaturityDate: loan.timeline?.expectedMaturityDate || "",
       },
       summary: {
@@ -486,18 +476,19 @@ export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
     const statusLower = loan.displayStatus.toLowerCase();
     return statusLower.includes("active") || statusLower.includes("overdue");
   }).length;
-  const orderedLoans = [...loans].sort((left, right) => {
-    const timeDiff =
-      getLoanSequenceSortTime(left) - getLoanSequenceSortTime(right);
-
-    if (timeDiff !== 0) {
-      return timeDiff;
-    }
-
-    return left.id - right.id;
-  });
-  const loanSequenceNumbers = new Map(
-    orderedLoans.map((loan, index) => [loan.id, index + 1])
+  const displayLoans = orderClientLoansLatestFirst(loans);
+  const filteredLoans = filterClientLoans(displayLoans, loanSearchQuery);
+  const loanSequenceNumbers = buildClientLoanSequenceNumbers(loans);
+  const currentPage =
+    loanPageRequest.clientId === clientId &&
+    loanPageRequest.loanCount === loans.length &&
+    loanPageRequest.searchQuery === loanSearchQuery
+      ? loanPageRequest.page
+      : 1;
+  const paginatedLoans = paginateClientLoans(
+    filteredLoans,
+    currentPage,
+    CLIENT_LOANS_PAGE_SIZE
   );
 
   // Get currency for display - use first loan's currency when all share same currency
@@ -626,7 +617,7 @@ export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
             Complete list of loans for this client
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
           {loans.length === 0 ? (
             <div className="text-center py-8">
               <CreditCard className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
@@ -635,144 +626,244 @@ export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
               </p>
             </div>
           ) : (
-            <div className="rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[72px]"></TableHead>
-                    <TableHead>Loan Product</TableHead>
-                    <TableHead>Account No</TableHead>
-                    <TableHead>Principal</TableHead>
-                    <TableHead>Outstanding</TableHead>
-                    {isOmamaTenant && <TableHead>Overdue By</TableHead>}
-                    <TableHead>Status</TableHead>
-                    {isOmamaTenant && <TableHead>Closed Obligations Met</TableHead>}
-                    <TableHead>Maturity Date</TableHead>
-                    <TableHead className="w-[48px] text-right">Open</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {orderedLoans.map((loan) => {
-                    const overdueDays = isOmamaTenant
-                      ? getOverdueDays(loan)
-                      : null;
-                    const closedObligationsPaidOnTime = isOmamaTenant
-                      ? getClosedObligationsPaidOnTime(loan)
-                      : null;
-
-                    return (
-                    <TableRow
-                      key={loan.id}
-                      className={readOnly ? "" : "cursor-pointer transition-colors hover:bg-muted/50"}
-                      onClick={() => {
-                        if (readOnly) return;
-                        router.push(`/clients/${clientId}/loans/${loan.id}`);
-                      }}
-                      onKeyDown={(event) => {
-                        if (readOnly) return;
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          router.push(`/clients/${clientId}/loans/${loan.id}`);
-                        }
-                      }}
-                      tabIndex={readOnly ? -1 : 0}
-                      role={readOnly ? undefined : "link"}
-                      aria-label={
-                        readOnly
-                          ? undefined
-                          : `Open loan ${loan.accountNo || loan.id} details`
-                      }
-                    >
-                      <TableCell>
-                        <div className="flex justify-center">
-                          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                            {loanSequenceNumbers.get(loan.id) ?? "?"}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <span className="font-medium">
-                              {loan.loanProductName}
-                            </span>
-                            {loan.isTopup && (
-                              <Badge className="bg-amber-500/15 text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 font-medium">
-                                Top-Up
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="text-sm text-muted-foreground">
-                            {loan.interestRatePerPeriod}% •{" "}
-                            {loan.numberOfRepayments} payments
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="font-mono text-sm">
-                          {loan.accountNo}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="font-medium">
-                          {formatCurrency(loan.principal, loan.currency?.code)}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div>
-                          <div className="font-medium">
-                            {formatCurrency(loan.summary.totalOutstanding, loan.currency?.code)}
-                          </div>
-                          {loan.summary.totalOverdue > 0 && (
-                            <div className="text-sm text-red-500">
-                              {formatCurrency(loan.summary.totalOverdue, loan.currency?.code)}{" "}
-                              overdue
-                            </div>
-                          )}
-                        </div>
-                      </TableCell>
-                      {isOmamaTenant && (
-                        <TableCell>
-                          <div className="text-sm">
-                            {loan.summary.totalOverdue > 0
-                              ? formatDayCount(overdueDays)
-                              : "Current"}
-                          </div>
-                        </TableCell>
-                      )}
-                      <TableCell>{getStatusBadge(loan)}</TableCell>
-                      {isOmamaTenant && (
-                        <TableCell>
-                          <div className="text-sm">
-                            {loan.status.closedObligationsMet
-                              ? closedObligationsPaidOnTime === null
-                                ? "Closed in full"
-                                : closedObligationsPaidOnTime
-                                  ? "Paid in full and on time"
-                                  : "Paid in full, but not all on time"
-                              : "—"}
-                          </div>
-                        </TableCell>
-                      )}
-                      <TableCell>
-                        <div className="flex items-center gap-1 text-sm">
-                          <Calendar className="h-3 w-3" />
-                          {loan.timeline.expectedMaturityDate
-                            ? formatDate(loan.timeline.expectedMaturityDate)
-                            : "Not set"}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {!readOnly && (
-                          <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" />
+            <>
+              <div className="relative max-w-md">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={loanSearchQuery}
+                  onChange={(event) => {
+                    const searchQuery = event.target.value;
+                    setLoanSearchQuery(searchQuery);
+                    setLoanPageRequest({
+                      clientId,
+                      loanCount: loans.length,
+                      searchQuery,
+                      page: 1,
+                    });
+                  }}
+                  placeholder="Search by account number or loan product name"
+                  aria-label="Search loans by account number or loan product name"
+                  className="pl-9"
+                />
+              </div>
+              {filteredLoans.length === 0 ? (
+                <div className="rounded-md border px-4 py-8 text-center text-sm text-muted-foreground">
+                  No loans match your search.
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-[72px]"></TableHead>
+                        <TableHead>Loan Product</TableHead>
+                        <TableHead>Account No</TableHead>
+                        <TableHead>Principal</TableHead>
+                        <TableHead>Outstanding</TableHead>
+                        {isOmamaTenant && <TableHead>Overdue By</TableHead>}
+                        <TableHead>Status</TableHead>
+                        {isOmamaTenant && (
+                          <TableHead>Closed Obligations Met</TableHead>
                         )}
-                      </TableCell>
-                    </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
+                        <TableHead>Maturity Date</TableHead>
+                        <TableHead className="w-[48px] text-right">
+                          Open
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {paginatedLoans.pageItems.map((loan) => {
+                        const overdueDays = isOmamaTenant
+                          ? getOverdueDays(loan)
+                          : null;
+                        const closedObligationsPaidOnTime = isOmamaTenant
+                          ? getClosedObligationsPaidOnTime(loan)
+                          : null;
+
+                        return (
+                          <TableRow
+                            key={loan.id}
+                            className={
+                              readOnly
+                                ? ""
+                                : "cursor-pointer transition-colors hover:bg-muted/50"
+                            }
+                            onClick={() => {
+                              if (readOnly) return;
+                              router.push(
+                                `/clients/${clientId}/loans/${loan.id}`
+                              );
+                            }}
+                            onKeyDown={(event) => {
+                              if (readOnly) return;
+                              if (
+                                event.key === "Enter" ||
+                                event.key === " "
+                              ) {
+                                event.preventDefault();
+                                router.push(
+                                  `/clients/${clientId}/loans/${loan.id}`
+                                );
+                              }
+                            }}
+                            tabIndex={readOnly ? -1 : 0}
+                            role={readOnly ? undefined : "link"}
+                            aria-label={
+                              readOnly
+                                ? undefined
+                                : `Open loan ${loan.accountNo || loan.id} details`
+                            }
+                          >
+                            <TableCell>
+                              <div className="flex justify-center">
+                                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                                  {loanSequenceNumbers.get(loan.id) ?? "?"}
+                                </div>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div>
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium">
+                                    {loan.loanProductName}
+                                  </span>
+                                  {loan.isTopup && (
+                                    <Badge className="bg-amber-500/15 text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 font-medium">
+                                      Top-Up
+                                    </Badge>
+                                  )}
+                                </div>
+                                <div className="text-sm text-muted-foreground">
+                                  {loan.interestRatePerPeriod}% •{" "}
+                                  {loan.numberOfRepayments} payments
+                                </div>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="font-mono text-sm">
+                                {loan.accountNo}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="font-medium">
+                                {formatCurrency(
+                                  loan.principal,
+                                  loan.currency?.code
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div>
+                                <div className="font-medium">
+                                  {formatCurrency(
+                                    loan.summary.totalOutstanding,
+                                    loan.currency?.code
+                                  )}
+                                </div>
+                                {loan.summary.totalOverdue > 0 && (
+                                  <div className="text-sm text-red-500">
+                                    {formatCurrency(
+                                      loan.summary.totalOverdue,
+                                      loan.currency?.code
+                                    )}{" "}
+                                    overdue
+                                  </div>
+                                )}
+                              </div>
+                            </TableCell>
+                            {isOmamaTenant && (
+                              <TableCell>
+                                <div className="text-sm">
+                                  {loan.summary.totalOverdue > 0
+                                    ? formatDayCount(overdueDays)
+                                    : "Current"}
+                                </div>
+                              </TableCell>
+                            )}
+                            <TableCell>{getStatusBadge(loan)}</TableCell>
+                            {isOmamaTenant && (
+                              <TableCell>
+                                <div className="text-sm">
+                                  {loan.status.closedObligationsMet
+                                    ? closedObligationsPaidOnTime === null
+                                      ? "Closed in full"
+                                      : closedObligationsPaidOnTime
+                                        ? "Paid in full and on time"
+                                        : "Paid in full, but not all on time"
+                                    : "—"}
+                                </div>
+                              </TableCell>
+                            )}
+                            <TableCell>
+                              <div className="flex items-center gap-1 text-sm">
+                                <Calendar className="h-3 w-3" />
+                                {loan.timeline.expectedMaturityDate
+                                  ? formatDate(
+                                      loan.timeline.expectedMaturityDate
+                                    )
+                                  : "Not set"}
+                              </div>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {!readOnly && (
+                                <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" />
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                  {paginatedLoans.totalPages > 1 && (
+                    <div className="flex flex-col gap-3 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="text-sm text-muted-foreground">
+                        Showing{" "}
+                        {`${paginatedLoans.startItem}-${paginatedLoans.endItem}`}{" "}
+                        of {paginatedLoans.totalItems} loans
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            setLoanPageRequest({
+                              clientId,
+                              loanCount: loans.length,
+                              searchQuery: loanSearchQuery,
+                              page: paginatedLoans.page - 1,
+                            })
+                          }
+                          disabled={!paginatedLoans.canPreviousPage}
+                        >
+                          Previous
+                        </Button>
+                        <span className="text-sm text-muted-foreground">
+                          Page {paginatedLoans.page} of{" "}
+                          {paginatedLoans.totalPages}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            setLoanPageRequest({
+                              clientId,
+                              loanCount: loans.length,
+                              searchQuery: loanSearchQuery,
+                              page: paginatedLoans.page + 1,
+                            })
+                          }
+                          disabled={!paginatedLoans.canNextPage}
+                        >
+                          Next
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx
@@ -137,6 +137,9 @@ const formatLoanSequenceLabel = (position: number): string => {
   }
 };
 
+const loanDetailsTabTriggerClass =
+  "shrink-0 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white";
+
 export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) {
   const router = useRouter();
   const { data: session } = useSession();
@@ -3537,74 +3540,74 @@ export function ClientLoanDetails({ clientId, loanId }: ClientLoanDetailsProps) 
       </Card>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <div className="w-full">
-          <TabsList className="h-12 flex w-max min-w-full bg-muted/50 p-1 rounded-lg gap-1 sm:flex-wrap sm:w-full">
+        <div className="w-full overflow-x-auto overflow-y-hidden pb-1">
+          <TabsList className="h-12 inline-flex min-w-max bg-muted/50 p-1 rounded-lg gap-1">
             <TabsTrigger 
               value="general" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <User className="h-4 w-4" />
               <span className="hidden sm:inline">General</span>
             </TabsTrigger>
             <TabsTrigger 
               value="account-details" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <CreditCard className="h-4 w-4" />
               <span className="hidden sm:inline">Account Details</span>
             </TabsTrigger>
             <TabsTrigger 
               value="schedule" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <Calendar className="h-4 w-4" />
               <span className="hidden sm:inline">Repayment Schedule</span>
             </TabsTrigger>
             <TabsTrigger 
               value="transactions" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <DollarSign className="h-4 w-4" />
               <span className="hidden sm:inline">Transactions</span>
             </TabsTrigger>
             <TabsTrigger 
               value="collateral" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <Shield className="h-4 w-4" />
               <span className="hidden sm:inline">Collateral</span>
             </TabsTrigger>
             <TabsTrigger 
               value="overdue-charges" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <AlertCircle className="h-4 w-4" />
               <span className="hidden sm:inline">Overdue</span>
             </TabsTrigger>
             <TabsTrigger 
               value="charges" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <Coins className="h-4 w-4" />
               <span className="hidden sm:inline">Charges</span>
             </TabsTrigger>
             <TabsTrigger 
               value="loan-reschedules" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <RotateCcw className="h-4 w-4" />
               <span className="hidden sm:inline">Reschedules</span>
             </TabsTrigger>
             <TabsTrigger 
               value="loan-documents" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <FileText className="h-4 w-4" />
               <span className="hidden sm:inline">Documents</span>
             </TabsTrigger>
             <TabsTrigger 
               value="notes" 
-              className="flex-1 flex items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium whitespace-nowrap sm:px-4 sm:text-sm sm:gap-2 data-[state=active]:bg-blue-500 data-[state=active]:text-white"
+              className={loanDetailsTabTriggerClass}
             >
               <StickyNote className="h-4 w-4" />
               <span className="hidden sm:inline">Notes</span>

--- a/app/(application)/clients/[id]/loans/[loanId]/components/transactions-data-table.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/transactions-data-table.tsx
@@ -14,6 +14,7 @@ import { Transaction } from "@/shared/types/transaction";
 import { formatCurrency } from "@/lib/format-currency";
 import { formatDate } from "@/lib/format-date";
 import { getDisplayedTransactionType } from "@/lib/format-transaction";
+import { attachRunningOutstandingBalances } from "@/lib/loan-transaction-running-balance";
 import { GenericDataTable } from "@/components/tables/generic-data-table";
 import { DataTableColumn, DataTableFilter } from "@/shared/types/data-table";
 
@@ -45,6 +46,10 @@ type ChargeItem = {
 
 /** A transaction row with optional charge-split metadata */
 type DisplayRow = Transaction & {
+  /** Running client outstanding balance after this transaction */
+  runningOutstandingBalance?: number;
+  /** Signed transaction movement used to build the running balance */
+  outstandingBalanceMovement?: number;
   /** 0-based charge index within the group; undefined = not a charge-split row */
   _chargeIndex?: number;
   /** Display name of this specific charge */
@@ -104,10 +109,11 @@ export function TransactionsDataTable({
       return [reversalRow, ...transactions];
     })();
 
+    const transactionsWithRunningBalances = attachRunningOutstandingBalances(source);
     const rows: DisplayRow[] = [];
     let txnNumber = 0;
 
-    for (const t of source) {
+    for (const t of transactionsWithRunningBalances) {
       txnNumber++;
       const paidCharges = t.loanChargePaidByList;
       const isMultiCharge =
@@ -328,6 +334,26 @@ export function TransactionsDataTable({
           </span>
         );
       },
+    },
+    {
+      id: "runningOutstandingBalance",
+      header: "Running Balance",
+      accessorKey: "runningOutstandingBalance",
+      cell: ({ row, getValue }) => {
+        const tx = row.original;
+        if (isSubCharge(tx)) {
+          return <span className={getReversedTextClass(tx)} />;
+        }
+        return (
+          <span className={getReversedTextClass(tx)}>
+            {formatCurrency(Number(getValue() ?? 0), currencyCode)}
+          </span>
+        );
+      },
+      getExportValue: (row) =>
+        isSubCharge(row)
+          ? ""
+          : formatCurrency(row.runningOutstandingBalance ?? 0, currencyCode),
     },
     {
       id: "actions",

--- a/lib/__tests__/client-loans-table.test.ts
+++ b/lib/__tests__/client-loans-table.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildClientLoanSequenceNumbers,
+  filterClientLoans,
+  orderClientLoansLatestFirst,
+  paginateClientLoans,
+} from "../client-loans-table";
+
+test("orders client loans newest first while preserving chronological sequence numbers", () => {
+  const loans = [
+    { id: 11, timeline: { submittedOnDate: "2026-01-02" } },
+    { id: 12, timeline: { submittedOnDate: "2026-02-10" } },
+    { id: 13, timeline: { submittedOnDate: "2026-01-20" } },
+  ];
+
+  assert.deepEqual(
+    orderClientLoansLatestFirst(loans).map((loan) => loan.id),
+    [12, 13, 11]
+  );
+
+  const sequenceNumbers = buildClientLoanSequenceNumbers(loans);
+
+  assert.deepEqual(
+    orderClientLoansLatestFirst(loans).map((loan) => sequenceNumbers.get(loan.id)),
+    [3, 2, 1]
+  );
+});
+
+test("places loans without sortable dates after dated loans in latest-first order", () => {
+  const loans = [
+    { id: 21, timeline: { submittedOnDate: "2026-01-02" } },
+    { id: 22, timeline: {} },
+    { id: 23, timeline: { submittedOnDate: "2026-02-10" } },
+  ];
+
+  assert.deepEqual(
+    orderClientLoansLatestFirst(loans).map((loan) => loan.id),
+    [23, 21, 22]
+  );
+});
+
+test("paginates the latest-first client loan rows", () => {
+  const loans = Array.from({ length: 25 }, (_, index) => ({ id: index + 1 }));
+  const page = paginateClientLoans(loans, 2, 10);
+
+  assert.deepEqual(
+    page.pageItems.map((loan) => loan.id),
+    [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+  );
+  assert.equal(page.totalPages, 3);
+  assert.equal(page.page, 2);
+  assert.equal(page.startItem, 11);
+  assert.equal(page.endItem, 20);
+  assert.equal(page.canPreviousPage, true);
+  assert.equal(page.canNextPage, true);
+});
+
+test("filters client loans by account number or loan product name", () => {
+  const loans = [
+    { id: 31, accountNo: "LN-0001", loanProductName: "Nano Loan" },
+    { id: 32, accountNo: "LN-0002", loanProductName: "SME Working Capital" },
+    { id: 33, accountNo: "TOP-5555", loanProductName: "Top Up Loan" },
+  ];
+
+  assert.deepEqual(
+    filterClientLoans(loans, "0002").map((loan) => loan.id),
+    [32]
+  );
+  assert.deepEqual(
+    filterClientLoans(loans, "top").map((loan) => loan.id),
+    [33]
+  );
+  assert.deepEqual(
+    filterClientLoans(loans, "  ").map((loan) => loan.id),
+    [31, 32, 33]
+  );
+});

--- a/lib/__tests__/loan-details-tabs-scroll.test.ts
+++ b/lib/__tests__/loan-details-tabs-scroll.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("loan details tabs use horizontal scrolling instead of wrapped skewed rows", () => {
+  const source = readRepoFile(
+    "app/(application)/clients/[id]/loans/[loanId]/components/client-loan-details.tsx"
+  );
+
+  assert.match(source, /overflow-x-auto/);
+  assert.match(source, /inline-flex min-w-max/);
+  assert.match(source, /const loanDetailsTabTriggerClass =/);
+  assert.match(source, /shrink-0 flex items-center/);
+  assert.doesNotMatch(source, /sm:flex-wrap/);
+});

--- a/lib/__tests__/loan-transaction-running-balance.test.ts
+++ b/lib/__tests__/loan-transaction-running-balance.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  attachRunningOutstandingBalances,
+} from "../loan-transaction-running-balance";
+
+test("builds a running outstanding balance from principal, interest, fees, and refunds", () => {
+  const rows = attachRunningOutstandingBalances([
+    {
+      id: 1,
+      amount: 100,
+      principalPortion: 0,
+      interestPortion: 0,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Disbursement", disbursement: true },
+    },
+    {
+      id: 2,
+      amount: 10,
+      principalPortion: 0,
+      interestPortion: 0,
+      feeChargesPortion: 10,
+      penaltyChargesPortion: 0,
+      type: { value: "Nano Loan Service Fee Production" },
+    },
+    {
+      id: 3,
+      amount: 3.3,
+      principalPortion: 0,
+      interestPortion: 3.3,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Accrual", accrual: true },
+    },
+    {
+      id: 4,
+      amount: 143,
+      principalPortion: 100,
+      interestPortion: 3.3,
+      feeChargesPortion: 10,
+      penaltyChargesPortion: 0,
+      type: { value: "Repayment", repayment: true },
+    },
+    {
+      id: 5,
+      amount: 29.7,
+      principalPortion: 0,
+      interestPortion: 0,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Credit Balance Refund" },
+    },
+  ]);
+
+  assert.deepEqual(
+    rows.map((row) => row.outstandingBalanceMovement),
+    [100, 10, 3.3, -143, 29.7]
+  );
+  assert.deepEqual(
+    rows.map((row) => row.runningOutstandingBalance),
+    [100, 110, 113.3, -29.7, 0]
+  );
+});
+
+test("ignores manually reversed transactions when computing the running outstanding balance", () => {
+  const rows = attachRunningOutstandingBalances([
+    {
+      id: 1,
+      amount: 100,
+      principalPortion: 0,
+      interestPortion: 0,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Disbursement", disbursement: true },
+    },
+    {
+      id: 2,
+      amount: 20,
+      principalPortion: 0,
+      interestPortion: 20,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      manuallyReversed: true,
+      type: { value: "Accrual", accrual: true },
+    },
+  ]);
+
+  assert.deepEqual(
+    rows.map((row) => row.runningOutstandingBalance),
+    [100, 100]
+  );
+});
+
+test("ignores Fineract client-transfer status rows because they are not financial transactions", () => {
+  const rows = attachRunningOutstandingBalances([
+    {
+      id: 1,
+      amount: 1000,
+      principalPortion: 0,
+      interestPortion: 0,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Disbursement", disbursement: true },
+    },
+    {
+      id: 2,
+      amount: 356.86,
+      principalPortion: 0,
+      interestPortion: 356.86,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Accrual", accrual: true },
+    },
+    {
+      id: 3,
+      amount: 1356.86,
+      principalPortion: 1000,
+      interestPortion: 356.86,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Transfer initiated" },
+    },
+    {
+      id: 4,
+      amount: 1356.86,
+      principalPortion: 1000,
+      interestPortion: 356.86,
+      feeChargesPortion: 0,
+      penaltyChargesPortion: 0,
+      type: { value: "Transfer approved" },
+    },
+  ]);
+
+  assert.deepEqual(
+    rows.map((row) => row.outstandingBalanceMovement),
+    [1000, 356.86, 0, 0]
+  );
+  assert.deepEqual(
+    rows.map((row) => row.runningOutstandingBalance),
+    [1000, 1356.86, 1356.86, 1356.86]
+  );
+});

--- a/lib/client-loans-table.ts
+++ b/lib/client-loans-table.ts
@@ -1,0 +1,153 @@
+type ClientLoanDate = string | number[] | null | undefined;
+
+export interface ClientLoanTableItem {
+  id: number;
+  accountNo?: string | number | null;
+  loanProductName?: string | null;
+  timeline?: {
+    submittedOnDate?: ClientLoanDate;
+    approvedOnDate?: ClientLoanDate;
+    actualDisbursementDate?: ClientLoanDate;
+    expectedDisbursementDate?: ClientLoanDate;
+  };
+}
+
+export const CLIENT_LOANS_PAGE_SIZE = 10;
+
+const UNKNOWN_LOAN_DATE = Number.MAX_SAFE_INTEGER;
+
+const parseLoanDateTime = (value: ClientLoanDate): number | null => {
+  if (!value) return null;
+
+  if (Array.isArray(value) && value.length >= 3) {
+    const parsed = new Date(value[0], value[1] - 1, value[2]).getTime();
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  if (typeof value === "string") {
+    const parsed = new Date(value).getTime();
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+};
+
+export const getClientLoanSequenceSortTime = (
+  loan: ClientLoanTableItem
+): number => {
+  const candidateDates = [
+    loan.timeline?.submittedOnDate,
+    loan.timeline?.approvedOnDate,
+    loan.timeline?.actualDisbursementDate,
+    loan.timeline?.expectedDisbursementDate,
+  ];
+
+  for (const value of candidateDates) {
+    const parsed = parseLoanDateTime(value);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+
+  return UNKNOWN_LOAN_DATE;
+};
+
+export function orderClientLoansChronologically<T extends ClientLoanTableItem>(
+  loans: T[]
+): T[] {
+  return [...loans].sort((left, right) => {
+    const timeDiff =
+      getClientLoanSequenceSortTime(left) -
+      getClientLoanSequenceSortTime(right);
+
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+
+    return left.id - right.id;
+  });
+}
+
+export function orderClientLoansLatestFirst<T extends ClientLoanTableItem>(
+  loans: T[]
+): T[] {
+  return [...loans].sort((left, right) => {
+    const leftTime = getClientLoanSequenceSortTime(left);
+    const rightTime = getClientLoanSequenceSortTime(right);
+    const leftHasDate = leftTime !== UNKNOWN_LOAN_DATE;
+    const rightHasDate = rightTime !== UNKNOWN_LOAN_DATE;
+
+    if (leftHasDate !== rightHasDate) {
+      return leftHasDate ? -1 : 1;
+    }
+
+    if (leftTime !== rightTime) {
+      return rightTime - leftTime;
+    }
+
+    return right.id - left.id;
+  });
+}
+
+export function buildClientLoanSequenceNumbers<T extends ClientLoanTableItem>(
+  loans: T[]
+): Map<number, number> {
+  return new Map(
+    orderClientLoansChronologically(loans).map((loan, index) => [
+      loan.id,
+      index + 1,
+    ])
+  );
+}
+
+export function filterClientLoans<T extends ClientLoanTableItem>(
+  loans: T[],
+  searchQuery: string
+): T[] {
+  const query = searchQuery.trim().toLowerCase();
+
+  if (!query) {
+    return loans;
+  }
+
+  return loans.filter((loan) => {
+    const accountNo = String(loan.accountNo ?? "").toLowerCase();
+    const productName = String(loan.loanProductName ?? "").toLowerCase();
+
+    return accountNo.includes(query) || productName.includes(query);
+  });
+}
+
+export function paginateClientLoans<T>(
+  loans: T[],
+  requestedPage: number,
+  requestedPageSize = CLIENT_LOANS_PAGE_SIZE
+) {
+  const pageSize =
+    Number.isFinite(requestedPageSize) && requestedPageSize > 0
+      ? Math.floor(requestedPageSize)
+      : CLIENT_LOANS_PAGE_SIZE;
+  const totalItems = loans.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const requested =
+    Number.isFinite(requestedPage) && requestedPage > 0
+      ? Math.floor(requestedPage)
+      : 1;
+  const page = Math.min(requested, totalPages);
+  const startIndex = (page - 1) * pageSize;
+  const pageItems = loans.slice(startIndex, startIndex + pageSize);
+  const startItem = totalItems === 0 ? 0 : startIndex + 1;
+  const endItem = startIndex + pageItems.length;
+
+  return {
+    pageItems,
+    page,
+    pageSize,
+    totalItems,
+    totalPages,
+    startItem,
+    endItem,
+    canPreviousPage: page > 1,
+    canNextPage: page < totalPages,
+  };
+}

--- a/lib/loan-transaction-running-balance.ts
+++ b/lib/loan-transaction-running-balance.ts
@@ -1,0 +1,145 @@
+type TransactionTypeLike = {
+  value?: string;
+  code?: string;
+  disbursement?: boolean;
+  repayment?: boolean;
+  repaymentAtDisbursement?: boolean;
+  accrual?: boolean;
+};
+
+export type RunningOutstandingBalanceTransaction = {
+  amount?: number | null;
+  principalPortion?: number | null;
+  interestPortion?: number | null;
+  feeChargesPortion?: number | null;
+  penaltyChargesPortion?: number | null;
+  manuallyReversed?: boolean | null;
+  type?: TransactionTypeLike | null;
+  loanChargePaidByList?: Array<{ amount?: number | null }> | null;
+};
+
+export type TransactionWithRunningOutstandingBalance<
+  T extends RunningOutstandingBalanceTransaction,
+> = T & {
+  outstandingBalanceMovement: number;
+  runningOutstandingBalance: number;
+};
+
+const MONEY_SCALE = 100;
+
+const toCents = (value: unknown): number => {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? Math.round(amount * MONEY_SCALE) : 0;
+};
+
+const fromCents = (value: number): number => value / MONEY_SCALE;
+
+const absFirst = (...values: number[]): number => {
+  for (const value of values) {
+    if (value !== 0) return Math.abs(value);
+  }
+  return 0;
+};
+
+const labelFor = (transaction: RunningOutstandingBalanceTransaction): string =>
+  `${transaction.type?.value ?? ""} ${transaction.type?.code ?? ""}`.toLowerCase();
+
+const isClientTransferStatusTransaction = (label: string): boolean =>
+  /^transfer\s+(initiated|approved|rejected|withdrawn|submitted|pending)\b/.test(
+    label.trim()
+  );
+
+const chargeListCents = (
+  transaction: RunningOutstandingBalanceTransaction
+): number =>
+  Array.isArray(transaction.loanChargePaidByList)
+    ? transaction.loanChargePaidByList.reduce(
+        (sum, charge) => sum + Math.abs(toCents(charge.amount)),
+        0
+      )
+    : 0;
+
+export const getOutstandingBalanceMovement = (
+  transaction: RunningOutstandingBalanceTransaction
+): number => {
+  if (transaction.manuallyReversed) return 0;
+
+  const amount = Math.abs(toCents(transaction.amount));
+  const principal = toCents(transaction.principalPortion);
+  const interest = toCents(transaction.interestPortion);
+  const fees = toCents(transaction.feeChargesPortion);
+  const penalties = toCents(transaction.penaltyChargesPortion);
+  const portions = principal + interest + fees + penalties;
+  const chargeList = chargeListCents(transaction);
+  const label = labelFor(transaction);
+  const type = transaction.type;
+
+  if (isClientTransferStatusTransaction(label)) {
+    return 0;
+  }
+
+  if (type?.disbursement || /\bdisburs/.test(label)) {
+    return fromCents(absFirst(principal, amount));
+  }
+
+  if (type?.repaymentAtDisbursement) {
+    return fromCents(absFirst(fees + penalties + interest, chargeList, amount));
+  }
+
+  if (label.includes("credit balance refund")) {
+    return fromCents(amount);
+  }
+
+  if (
+    type?.repayment ||
+    /\brepayment\b/.test(label) ||
+    label.includes("payment")
+  ) {
+    return fromCents(-absFirst(amount, portions));
+  }
+
+  if (type?.accrual || label.includes("accrual")) {
+    return fromCents(absFirst(interest + fees + penalties, amount));
+  }
+
+  if (
+    label.includes("waive") ||
+    label.includes("waiver") ||
+    label.includes("write off") ||
+    label.includes("write-off") ||
+    label.includes("charge off") ||
+    label.includes("charge-off")
+  ) {
+    return fromCents(-absFirst(portions, amount));
+  }
+
+  if (
+    label.includes("fee") ||
+    label.includes("charge") ||
+    label.includes("penalty") ||
+    label.includes("arrears")
+  ) {
+    return fromCents(absFirst(fees + penalties + interest, chargeList, amount));
+  }
+
+  return fromCents(portions);
+};
+
+export const attachRunningOutstandingBalances = <
+  T extends RunningOutstandingBalanceTransaction,
+>(
+  transactions: T[]
+): Array<TransactionWithRunningOutstandingBalance<T>> => {
+  let runningBalanceCents = 0;
+
+  return transactions.map((transaction) => {
+    const movement = getOutstandingBalanceMovement(transaction);
+    runningBalanceCents += toCents(movement);
+
+    return {
+      ...transaction,
+      outstandingBalanceMovement: movement,
+      runningOutstandingBalance: fromCents(runningBalanceCents),
+    };
+  });
+};


### PR DESCRIPTION
Adds a computed Running Balance column to loan transactions, ignores Fineract client-transfer status rows, and makes the loan details tab strip horizontally scrollable.\n\nValidation:\n- node --import tsx --test lib/__tests__/loan-transaction-running-balance.test.ts lib/__tests__/loan-details-tabs-scroll.test.ts lib/__tests__/loan-lifecycle-actions.test.ts\n- npx eslint lib/loan-transaction-running-balance.ts lib/__tests__/loan-transaction-running-balance.test.ts lib/__tests__/loan-details-tabs-scroll.test.ts app/(application)/clients/[id]/loans/[loanId]/components/transactions-data-table.tsx