### PR TITLE
Link manual loans after Fineract creation

### DIFF
--- a/app/api/leads/[id]/create-loan/route.ts
+++ b/app/api/leads/[id]/create-loan/route.ts
@@ -130,7 +130,7 @@ export async function POST(
       graceOnArrearsAgeing: loanData.onArrearsAgeing ?? 0,
       locale: "en",
       dateFormat: "yyyy-MM-dd",
-      // Use lead ID as initial external ID, will be updated to loan ID after creation
+      // Keep the lead ID as Fineract external ID for cross-system correlation.
       externalId: leadId,
       isEqualAmortization: false,
       charges: requestedCharges.map((charge: any) => {
@@ -182,45 +182,30 @@ export async function POST(
       body: JSON.stringify(payload),
     });
 
-    // Set external ID to loan ID for future reference
     if (result && result.resourceId) {
       const loanId = result.resourceId;
+      const loanLinkedAt = new Date();
 
-      // Update the loan with the external ID set to the loan ID
-      try {
-        await fetchFineractAPI(`/loans/${loanId}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            externalId: String(loanId),
-            locale: "en",
-            dateFormat: "yyyy-MM-dd",
-          }),
-        });
-
-        console.log(`Updated loan ${loanId} with external ID set to loan ID`);
-
-        // Update the lead with loan ID, client ID, and submission tracking
-        await prisma.lead.update({
-          where: { id: leadId },
-          data: {
-            fineractLoanId: loanId,
-            loanSubmittedToFineract: true,
-            loanSubmissionDate: new Date(),
-            fineractClientId: loanData.clientId,
-            clientCreatedInFineract: true,
-            clientCreationDate: lead.clientCreationDate || new Date(),
-            stateMetadata: {
-              ...((lead.stateMetadata as any) || {}),
-              loanId: loanId,
-              loanCreatedAt: new Date().toISOString(),
-            },
+      // Persist the local link as soon as Fineract creates the loan. This must
+      // not depend on any secondary Fineract update, otherwise successful loan
+      // creations can be left unlinked in Loan Matrix.
+      await prisma.lead.update({
+        where: { id: leadId },
+        data: {
+          fineractLoanId: loanId,
+          loanSubmittedToFineract: true,
+          loanSubmissionDate: loanLinkedAt,
+          fineractClientId: loanData.clientId,
+          clientCreatedInFineract: true,
+          clientCreationDate: lead.clientCreationDate || loanLinkedAt,
+          stateMetadata: {
+            ...((lead.stateMetadata as any) || {}),
+            loanId: loanId,
+            loanExternalId: leadId,
+            loanCreatedAt: loanLinkedAt.toISOString(),
           },
-        });
-      } catch (updateError) {
-        console.error("Failed to update loan external ID:", updateError);
-        // Don't fail the entire operation if external ID update fails
-      }
+        },
+      });
     }
 
     // Send SMS: loan submitted, pending approval (best-effort)

--- a/lib/__tests__/manual-create-loan-linking.test.ts
+++ b/lib/__tests__/manual-create-loan-linking.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("manual create-loan keeps Fineract external ID lead-linked", () => {
+  const source = readRepoFile("app/api/leads/[id]/create-loan/route.ts");
+
+  assert.match(source, /externalId:\s*leadId/);
+  assert.doesNotMatch(source, /externalId:\s*String\(loanId\)/);
+});
+
+test("manual create-loan saves local loan link before best-effort side effects", () => {
+  const source = readRepoFile("app/api/leads/[id]/create-loan/route.ts");
+  const loanIdIndex = source.indexOf("const loanId = result.resourceId");
+  const leadUpdateIndex = source.indexOf("await prisma.lead.update");
+  const smsIndex = source.indexOf("// Send SMS");
+  const cdeIndex = source.indexOf("// Call CDE");
+
+  assert.ok(loanIdIndex >= 0);
+  assert.ok(leadUpdateIndex > loanIdIndex);
+  assert.ok(smsIndex > leadUpdateIndex);
+  assert.ok(cdeIndex > leadUpdateIndex);
+});


### PR DESCRIPTION
## What changed
- Saves `fineractLoanId`, `loanSubmittedToFineract`, `loanSubmissionDate`, and loan metadata immediately after Fineract `POST /loans` returns `resourceId`.
- Keeps Fineract loan `externalId` as the Loan Matrix lead ID for cross-system correlation.
- Removes the second Fineract `PUT /loans/{loanId}` call that attempted to rewrite `externalId` to the loan ID.
- Adds regression tests for the manual create-loan route behavior.

## Why
The previous flow only updated the local Loan Matrix lead after a secondary Fineract `PUT` succeeded. If Fineract created the loan but the follow-up update failed, the local lead remained unlinked even though loan creation had succeeded.

## Impact
Manual loan creation should now leave Loan Matrix and Fineract linked as soon as Fineract returns the created loan ID. Existing fallback/recovery paths that use Fineract `externalId = leadId` remain intact.

## Validation
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx tsx --test lib/__tests__/manual-create-loan-linking.test.ts lib/__tests__/ussd-lead-conversion.test.ts lib/__tests__/ussd-loan-submission.test.ts`