### PR TITLE
Restore cashier exemption with cash-only enforcement policy

### DIFF
--- a/app/(application)/clients/[id]/loans/[loanId]/components/repayment-modal.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/repayment-modal.tsx
@@ -294,17 +294,20 @@ export function RepaymentModal({
       resolveRepaymentCashierAutoResolveDecision({
         autoResolveApplicable: currentCashierContext?.autoResolveApplicable ?? false,
         isCashier: currentCashierContext?.isCashier ?? false,
-        hasActiveSession: currentCashierContext?.hasActiveSession ?? false,
       }),
     [currentCashierContext]
   );
 
-  // Hide cash payment types from selection entirely once we know cash is
-  // blocked for this user, rather than letting them pick it and then fail.
+  // Non-exempt users under tenant policy are restricted to cash only, whether
+  // or not they turn out to be a resolvable cashier.
+  const paymentTypeLockedToCash =
+    autoResolveDecision.mode === "auto-resolved" ||
+    autoResolveDecision.mode === "blocked";
+
   const visiblePaymentTypeOptions = useMemo(() => {
-    if (autoResolveDecision.mode !== "cash-blocked") return mergedPaymentTypeOptions;
-    return mergedPaymentTypeOptions.filter((option) => !option.isCashPayment);
-  }, [mergedPaymentTypeOptions, autoResolveDecision.mode]);
+    if (!paymentTypeLockedToCash) return mergedPaymentTypeOptions;
+    return mergedPaymentTypeOptions.filter((option) => option.isCashPayment);
+  }, [mergedPaymentTypeOptions, paymentTypeLockedToCash]);
 
   // Default the payment type once we know both the available options and
   // whether auto-resolution applies to this user. Never overrides a choice
@@ -317,10 +320,7 @@ export function RepaymentModal({
     if (formData.paymentTypeId) return;
     if (autoResolveDecision.mode === "manual") return;
 
-    const preferred =
-      autoResolveDecision.mode === "auto-resolved"
-        ? mergedPaymentTypeOptions.find((o) => o.isCashPayment)
-        : mergedPaymentTypeOptions.find((o) => !o.isCashPayment);
+    const preferred = mergedPaymentTypeOptions.find((o) => o.isCashPayment);
 
     if (preferred) {
       setFormData((prev) => ({ ...prev, paymentTypeId: String(preferred.id) }));
@@ -352,7 +352,15 @@ export function RepaymentModal({
     try {
       setSubmitting(true);
       setError(null);
-      
+
+      if (autoResolveDecision.mode === "blocked") {
+        setError(
+          currentCashierContext?.reason ||
+            "You are not linked to a cashier account. Contact your supervisor or system administrator."
+        );
+        return;
+      }
+
       // Validate required fields
       if (!formData.transactionDate || !formData.transactionAmount) {
         setError("Transaction Date and Transaction Amount are required");
@@ -695,6 +703,7 @@ export function RepaymentModal({
               <Label htmlFor="payment-type">Payment Type</Label>
               <Select
                 value={formData.paymentTypeId}
+                disabled={paymentTypeLockedToCash}
                 onValueChange={(value) => {
                   setFormData((prev) => ({ ...prev, paymentTypeId: value }));
                   const option = mergedPaymentTypeOptions.find((o) => o.id.toString() === value);
@@ -722,10 +731,9 @@ export function RepaymentModal({
                   )}
                 </SelectContent>
               </Select>
-              {autoResolveDecision.mode === "cash-blocked" ? (
+              {paymentTypeLockedToCash ? (
                 <p className="text-xs text-muted-foreground">
-                  {currentCashierContext?.reason ||
-                    "Cash payment is unavailable because you are not linked to an active cashier session. Contact your supervisor."}
+                  Payment type is locked to cash by tenant policy.
                 </p>
               ) : (
                 <p className="text-xs text-muted-foreground">
@@ -735,8 +743,25 @@ export function RepaymentModal({
             </div>
 
             {/* Teller and Cashier (for cash payments): auto-resolved from the
-                logged in user's cashier session, or manual pickers otherwise */}
-            {selectedPaymentTypeIsCash && autoResolveDecision.mode === "auto-resolved" ? (
+                logged in user's cashier session, blocked entirely if the user
+                isn't linked to a cashier, or manual pickers otherwise */}
+            {autoResolveDecision.mode === "blocked" ? (
+              <div className="rounded-lg border-2 border-destructive bg-destructive/10 p-4 space-y-2">
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="h-5 w-5 text-destructive shrink-0" />
+                  <span className="text-sm font-semibold text-destructive">
+                    Action Required: Cashier Link Missing
+                  </span>
+                </div>
+                <p className="text-sm text-destructive/90">
+                  {currentCashierContext?.reason ||
+                    "You are not linked to a cashier account."}{" "}
+                  Cash repayments require an active cashier link under tenant
+                  policy — contact your supervisor or system administrator to
+                  resolve this before processing repayments.
+                </p>
+              </div>
+            ) : selectedPaymentTypeIsCash && autoResolveDecision.mode === "auto-resolved" ? (
               <div className="rounded-lg border border-green-200 bg-green-50/60 dark:border-green-800 dark:bg-green-950/30 p-4 space-y-2">
                 <div className="flex items-center gap-2">
                   <Banknote className="h-4 w-4 text-green-600" />
@@ -761,8 +786,14 @@ export function RepaymentModal({
                 </div>
                 <div className="flex justify-between gap-3 text-sm">
                   <span className="text-muted-foreground">Session</span>
-                  <span className="font-medium text-green-700 dark:text-green-400">
-                    Active
+                  <span
+                    className={
+                      currentCashierContext?.hasActiveSession
+                        ? "font-medium text-green-700 dark:text-green-400"
+                        : "font-medium text-amber-600 dark:text-amber-400"
+                    }
+                  >
+                    {currentCashierContext?.hasActiveSession ? "Active" : "Not Active"}
                   </span>
                 </div>
               </div>
@@ -969,6 +1000,7 @@ export function RepaymentModal({
             onClick={handleSubmit}
             disabled={
               submitting ||
+              autoResolveDecision.mode === "blocked" ||
               !formData.transactionDate ||
               !formData.transactionAmount ||
               !formData.paymentTypeId ||

--- a/app/(application)/organization/features/page.tsx
+++ b/app/(application)/organization/features/page.tsx
@@ -117,7 +117,7 @@ const FEATURE_CONFIGS: FeatureConfig[] = [
     key: "autoResolveRepaymentCashier",
     label: "Auto-Resolve Repayment Cashier",
     description:
-      "On the loan repayment modal, default the payment type to cash and auto-fill the teller/cashier from the logged in user's active cashier session instead of manual selection.",
+      "On the loan repayment modal, restrict non-exempt users to cash repayments and auto-fill their teller/cashier from their cashier session, blocking submission if they aren't linked to a cashier. Individual users can be exempted from this restriction on the Users page.",
     tag: "New",
   },
 ];

--- a/app/(application)/organization/users/components/user-detail-tabs.tsx
+++ b/app/(application)/organization/users/components/user-detail-tabs.tsx
@@ -387,6 +387,21 @@ export function UserDetailTabs({
 
         <Card>
           <CardHeader>
+            <CardTitle>Cashier</CardTitle>
+            <CardDescription>
+              Controls how this user is treated by cashier-related automation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <DetailField
+              label="Exempt From Automatic Cashier Resolution"
+              value={user.exemptFromAutoCashierResolution ? "Yes" : "No"}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
             <CardTitle>Visible Lead Branches</CardTitle>
             <CardDescription>
               {restrictLeadVisibilityToBranches

--- a/app/(application)/organization/users/components/user-form.tsx
+++ b/app/(application)/organization/users/components/user-form.tsx
@@ -85,6 +85,7 @@ type FormState = {
   canOverrideInitiatorDisbursement: boolean;
   canConfirmPayments: boolean;
   canResetUssdPin: boolean;
+  exemptFromAutoCashierResolution: boolean;
   officeId: string;
   staffId: string;
   visibleLeadOfficeIds: number[];
@@ -113,6 +114,8 @@ function buildInitialState(
       initialUser?.canOverrideInitiatorDisbursement ?? false,
     canConfirmPayments: initialUser?.canConfirmPayments ?? false,
     canResetUssdPin: initialUser?.canResetUssdPin ?? false,
+    exemptFromAutoCashierResolution:
+      initialUser?.exemptFromAutoCashierResolution ?? false,
     officeId: initialUser?.officeId ? String(initialUser.officeId) : "",
     staffId: initialUser?.staff?.id ? String(initialUser.staff.id) : "",
     visibleLeadOfficeIds: initialUser?.visibleLeadOffices.map((office) => office.id) ?? [],
@@ -503,6 +506,7 @@ export function UserForm({
       canOverrideInitiatorDisbursement: form.canOverrideInitiatorDisbursement,
       canConfirmPayments: form.canConfirmPayments,
       canResetUssdPin: form.canResetUssdPin,
+      exemptFromAutoCashierResolution: form.exemptFromAutoCashierResolution,
       officeId: form.officeId,
       staffId: form.staffId || null,
       visibleLeadOfficeIds: visibleLeadOfficeSelection,
@@ -936,6 +940,36 @@ export function UserForm({
             </p>
           )}
         </div>
+      </div>
+
+      <div className="space-y-4 rounded-xl border p-6">
+        <div className="space-y-1">
+          <h3 className="font-semibold">Cashier</h3>
+          <p className="text-sm text-muted-foreground">
+            Controls how this user is treated by cashier-related automation.
+          </p>
+        </div>
+
+        <label className="flex items-start gap-3 rounded-lg border p-4">
+          <Checkbox
+            checked={form.exemptFromAutoCashierResolution}
+            onCheckedChange={(checked) =>
+              handleChange("exemptFromAutoCashierResolution", checked === true)
+            }
+          />
+          <div className="space-y-1">
+            <span className="font-medium">
+              Exempt from automatic cashier resolution
+            </span>
+            <p className="text-sm text-muted-foreground">
+              When the tenant restricts loan repayments to cash-only for
+              cashiers, this user is exempt and can still select any payment
+              method with manual teller/cashier selection. Non-exempt users
+              are restricted to cash and must be linked to a cashier account
+              to submit repayments.
+            </p>
+          </div>
+        </label>
       </div>
 
       <Dialog

--- a/app/actions/user-management-actions.ts
+++ b/app/actions/user-management-actions.ts
@@ -75,6 +75,7 @@ const createUserSchema = z
     canOverrideInitiatorDisbursement: z.boolean().default(false),
     canConfirmPayments: z.boolean().default(false),
     canResetUssdPin: z.boolean().default(false),
+    exemptFromAutoCashierResolution: z.boolean().default(false),
     officeId: z.coerce.number().int().positive("Office is required"),
     staffId: z
       .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
@@ -178,6 +179,7 @@ const updateUserSchema = z
     canOverrideInitiatorDisbursement: z.boolean().default(false),
     canConfirmPayments: z.boolean().default(false),
     canResetUssdPin: z.boolean().default(false),
+    exemptFromAutoCashierResolution: z.boolean().default(false),
     officeId: z.coerce.number().int().positive("Office is required"),
     staffId: z
       .union([z.coerce.number().int().positive(), z.literal(""), z.null(), z.undefined()])
@@ -452,6 +454,7 @@ function mapUserDetail(user: unknown): UserDetail {
     canOverrideInitiatorDisbursement: false,
     canConfirmPayments: false,
     canResetUssdPin: false,
+    exemptFromAutoCashierResolution: false,
     visibleLeadOffices: [],
     blockedSource: null,
     blockedNote: null,
@@ -659,6 +662,7 @@ export async function getUserAction(userId: number): Promise<UserDetail> {
       canOverrideInitiatorDisbursement: true,
       canConfirmPayments: true,
       canResetUssdPin: true,
+      exemptFromAutoCashierResolution: true,
       leadBranchAccesses: {
         orderBy: {
           officeId: "asc",
@@ -691,6 +695,8 @@ export async function getUserAction(userId: number): Promise<UserDetail> {
       localLogin?.canOverrideInitiatorDisbursement ?? false,
     canConfirmPayments: localLogin?.canConfirmPayments ?? false,
     canResetUssdPin: localLogin?.canResetUssdPin ?? false,
+    exemptFromAutoCashierResolution:
+      localLogin?.exemptFromAutoCashierResolution ?? false,
     visibleLeadOffices: collapsedVisibleLeadOfficeIds.map((officeId) =>
       mapVisibleLeadOffice(
         officeId,
@@ -884,6 +890,8 @@ export async function createUserAction(
           parsed.data.canOverrideInitiatorDisbursement,
         canConfirmPayments: parsed.data.canConfirmPayments,
         canResetUssdPin: parsed.data.canResetUssdPin,
+        exemptFromAutoCashierResolution:
+          parsed.data.exemptFromAutoCashierResolution,
       });
 
       if (tenant.restrictLeadVisibilityToBranches) {
@@ -961,6 +969,8 @@ export async function updateUserAction(
         parsed.data.canOverrideInitiatorDisbursement,
       canConfirmPayments: parsed.data.canConfirmPayments,
       canResetUssdPin: parsed.data.canResetUssdPin,
+      exemptFromAutoCashierResolution:
+        parsed.data.exemptFromAutoCashierResolution,
     });
 
     if (tenant.restrictLeadVisibilityToBranches) {

--- a/app/api/auth/current-cashier/route.ts
+++ b/app/api/auth/current-cashier/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { getSession } from "@/lib/auth";
 import { resolveCurrentUserCashierContext } from "@/lib/current-user-cashier";
+import { isAutoResolveApplicableForUser } from "@/lib/repayment-cashier-auto-resolve-policy";
+import { isUserExemptFromAutoCashierResolution } from "@/lib/repayment-cashier-auto-resolve-access";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getTenantFeatures } from "@/shared/types/tenant";
 
@@ -26,12 +28,15 @@ export async function GET() {
       );
     }
 
-    const context = await resolveCurrentUserCashierContext(
-      tenant.id,
-      session.user.userId
-    );
+    const [context, userExempt] = await Promise.all([
+      resolveCurrentUserCashierContext(tenant.id, session.user.userId),
+      isUserExemptFromAutoCashierResolution(tenant.id, session.user.userId),
+    ]);
 
-    const autoResolveApplicable = getTenantFeatures(tenant).autoResolveRepaymentCashier;
+    const autoResolveApplicable = isAutoResolveApplicableForUser({
+      tenantFeatureEnabled: getTenantFeatures(tenant).autoResolveRepaymentCashier,
+      userExempt,
+    });
 
     return NextResponse.json({ ...context, autoResolveApplicable });
   } catch (error) {

--- a/lib/repayment-cashier-auto-resolve-access.ts
+++ b/lib/repayment-cashier-auto-resolve-access.ts
@@ -1,0 +1,25 @@
+import { prisma } from "@/lib/prisma";
+
+export async function isUserExemptFromAutoCashierResolution(
+  tenantId: string,
+  fineractUserId: string | number | null | undefined
+): Promise<boolean> {
+  const numericUserId = Number(fineractUserId);
+  if (!fineractUserId || Number.isNaN(numericUserId)) {
+    return false;
+  }
+
+  const userLogin = await prisma.userLogin.findUnique({
+    where: {
+      tenantId_fineractUserId: {
+        tenantId,
+        fineractUserId: numericUserId,
+      },
+    },
+    select: {
+      exemptFromAutoCashierResolution: true,
+    },
+  });
+
+  return Boolean(userLogin?.exemptFromAutoCashierResolution);
+}

--- a/lib/repayment-cashier-auto-resolve-policy.test.ts
+++ b/lib/repayment-cashier-auto-resolve-policy.test.ts
@@ -1,45 +1,82 @@
 import assert from "node:assert/strict";
-import { resolveRepaymentCashierAutoResolveDecision } from "./repayment-cashier-auto-resolve-policy";
+import {
+  isAutoResolveApplicableForUser,
+  resolveRepaymentCashierAutoResolveDecision,
+} from "./repayment-cashier-auto-resolve-policy";
 
 function run() {
+  // isAutoResolveApplicableForUser
+  assert.equal(
+    isAutoResolveApplicableForUser({
+      tenantFeatureEnabled: true,
+      userExempt: false,
+    }),
+    true,
+    "applicable when tenant feature is on and user is not exempt"
+  );
+
+  assert.equal(
+    isAutoResolveApplicableForUser({
+      tenantFeatureEnabled: false,
+      userExempt: false,
+    }),
+    false,
+    "not applicable when tenant feature is off, regardless of exemption"
+  );
+
+  assert.equal(
+    isAutoResolveApplicableForUser({
+      tenantFeatureEnabled: true,
+      userExempt: true,
+    }),
+    false,
+    "not applicable when user is exempt, even if tenant feature is on"
+  );
+
+  assert.equal(
+    isAutoResolveApplicableForUser({
+      tenantFeatureEnabled: false,
+      userExempt: true,
+    }),
+    false,
+    "not applicable when both tenant feature is off and user is exempt"
+  );
+
+  // resolveRepaymentCashierAutoResolveDecision
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
       autoResolveApplicable: false,
       isCashier: true,
-      hasActiveSession: true,
     }),
     { mode: "manual" },
-    "falls back to manual pickers when the tenant feature is off, even for a cashier with an active session"
+    "falls back to manual pickers when not applicable, even for a cashier"
+  );
+
+  assert.deepEqual(
+    resolveRepaymentCashierAutoResolveDecision({
+      autoResolveApplicable: false,
+      isCashier: false,
+    }),
+    { mode: "manual" },
+    "falls back to manual pickers when not applicable, for a non-cashier too"
   );
 
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
       autoResolveApplicable: true,
       isCashier: true,
-      hasActiveSession: true,
     }),
     { mode: "auto-resolved" },
-    "auto-resolves when the tenant feature is on and user is a cashier with an active session"
-  );
-
-  assert.deepEqual(
-    resolveRepaymentCashierAutoResolveDecision({
-      autoResolveApplicable: true,
-      isCashier: true,
-      hasActiveSession: false,
-    }),
-    { mode: "cash-blocked" },
-    "blocks cash when the tenant feature is on but the cashier has no active session"
+    "auto-resolves and locks to cash when applicable and the user is a cashier"
   );
 
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
       autoResolveApplicable: true,
       isCashier: false,
-      hasActiveSession: false,
     }),
-    { mode: "cash-blocked" },
-    "blocks cash when the tenant feature is on but the user is not a cashier at all"
+    { mode: "blocked" },
+    "blocks repayment submission entirely when applicable but the user is not a cashier at all"
   );
 }
 

--- a/lib/repayment-cashier-auto-resolve-policy.ts
+++ b/lib/repayment-cashier-auto-resolve-policy.ts
@@ -1,13 +1,23 @@
+export interface RepaymentCashierAutoResolveGateInput {
+  tenantFeatureEnabled: boolean;
+  userExempt: boolean;
+}
+
+export function isAutoResolveApplicableForUser(
+  input: RepaymentCashierAutoResolveGateInput
+): boolean {
+  return input.tenantFeatureEnabled && !input.userExempt;
+}
+
 export interface RepaymentCashierAutoResolveDecisionInput {
   autoResolveApplicable: boolean;
   isCashier: boolean;
-  hasActiveSession: boolean;
 }
 
 export type RepaymentCashierAutoResolveDecision =
   | { mode: "manual" }
   | { mode: "auto-resolved" }
-  | { mode: "cash-blocked" };
+  | { mode: "blocked" };
 
 export function resolveRepaymentCashierAutoResolveDecision(
   input: RepaymentCashierAutoResolveDecisionInput
@@ -15,8 +25,8 @@ export function resolveRepaymentCashierAutoResolveDecision(
   if (!input.autoResolveApplicable) {
     return { mode: "manual" };
   }
-  if (input.isCashier && input.hasActiveSession) {
+  if (input.isCashier) {
     return { mode: "auto-resolved" };
   }
-  return { mode: "cash-blocked" };
+  return { mode: "blocked" };
 }

--- a/lib/user-login-service.ts
+++ b/lib/user-login-service.ts
@@ -99,6 +99,7 @@ type UpsertUserLoginInput = {
   canOverrideInitiatorDisbursement?: boolean;
   canConfirmPayments?: boolean;
   canResetUssdPin?: boolean;
+  exemptFromAutoCashierResolution?: boolean;
   lastLoginAt?: Date | null;
   lastMfaChannel?: string | null;
   lastMfaSentAt?: Date | null;
@@ -115,6 +116,7 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
     canOverrideInitiatorDisbursement,
     canConfirmPayments,
     canResetUssdPin,
+    exemptFromAutoCashierResolution,
     lastLoginAt,
     lastMfaChannel,
     lastMfaSentAt,
@@ -175,6 +177,10 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
     updateData.canResetUssdPin = canResetUssdPin;
   }
 
+  if (exemptFromAutoCashierResolution !== undefined) {
+    updateData.exemptFromAutoCashierResolution = exemptFromAutoCashierResolution;
+  }
+
   return prisma.userLogin.upsert({
     where: {
       tenantId_fineractUserId: {
@@ -194,6 +200,7 @@ export async function upsertUserLogin(input: UpsertUserLoginInput) {
         canOverrideInitiatorDisbursement ?? false,
       canConfirmPayments: canConfirmPayments ?? false,
       canResetUssdPin: canResetUssdPin ?? false,
+      exemptFromAutoCashierResolution: exemptFromAutoCashierResolution ?? false,
       lastLoginAt: lastLoginAt ?? null,
       lastMfaChannel: lastMfaChannel ?? null,
       lastMfaSentAt: lastMfaSentAt ?? null,

--- a/prisma/migrations/20260727210000_add_user_login_exempt_auto_cashier_resolution/migration.sql
+++ b/prisma/migrations/20260727210000_add_user_login_exempt_auto_cashier_resolution/migration.sql
@@ -1,0 +1,3 @@
+-- Per-user opt-out of the tenant-wide auto cashier resolution feature on the loan repayment modal.
+ALTER TABLE "UserLogin"
+ADD COLUMN IF NOT EXISTS "exemptFromAutoCashierResolution" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1215,6 +1215,7 @@ model UserLogin {
   canOverrideInitiatorDisbursement Boolean  @default(false)
   canConfirmPayments   Boolean              @default(false)
   canResetUssdPin      Boolean              @default(false)
+  exemptFromAutoCashierResolution Boolean   @default(false)
   isBlocked            Boolean              @default(false)
   blockedAt            DateTime?
   blockedSource        String?

--- a/shared/types/tenant.ts
+++ b/shared/types/tenant.ts
@@ -32,7 +32,7 @@ export interface TenantFeatures {
   officeScopedAdminLeadsDashboard: boolean;
   /** When showing client active loans for topup, use the foreclosure settlement amount instead of total outstanding (excludes unrealized/future interest) */
   topupLoanBalanceExcludeUnrealizedInterests: boolean;
-  /** Auto-resolve the logged in user's teller/cashier and default payment type to cash on the loan repayment modal, unless the user is individually exempted */
+  /** Restrict non-exempt users to cash-only loan repayments, auto-resolving their teller/cashier from their cashier session (blocking submission if unresolvable), unless the user is individually exempted */
   autoResolveRepaymentCashier: boolean;
   /** When true, MFA is required for tenant logins. Missing or false disables MFA. */
   usesMFA?: boolean;

--- a/shared/types/user-management.ts
+++ b/shared/types/user-management.ts
@@ -58,6 +58,7 @@ export interface UserDetail extends UserSummary {
   isSelfServiceUser: boolean;
   canOverrideInitiatorDisbursement: boolean;
   canResetUssdPin: boolean;
+  exemptFromAutoCashierResolution: boolean;
   visibleLeadOffices: OfficeOption[];
   blockedSource?: UserLoginBlockSource | null;
   blockedNote?: string | null;
@@ -87,6 +88,7 @@ export interface UserFormInput {
   canOverrideInitiatorDisbursement?: boolean;
   canConfirmPayments?: boolean;
   canResetUssdPin?: boolean;
+  exemptFromAutoCashierResolution?: boolean;
   officeId: number | string;
   staffId?: number | string | null;
   visibleLeadOfficeIds?: Array<number | string>;


### PR DESCRIPTION
## Summary
Restores the per-user `UserLogin.exemptFromAutoCashierResolution` column (removed in #543) with a revised business rule per updated client requirement: certain designated users can process repayments with any payment method, while everyone else is restricted to cash-only and must be linked to a cashier account.

**Tenant flag off, or user is exempt** → today's fully manual behavior, unchanged (any payment type, manual teller/cashier for cash).

**Tenant flag on and user is NOT exempt:**
- Payment type is locked to cash only — other payment types are hidden from the dropdown entirely (previously they were just deprioritized/available as a fallback).
- If the user resolves to a cashier (`isCashier === true`) — teller/cashier are auto-filled from their session, shown in a read-only info card (still displays session Active/Not Active for transparency).
- If the user is **not** a cashier at all — repayment submission is blocked entirely (not just cash blocked) with a prominent "Action Required" alert explaining why (surfaces the existing `reason` message, e.g. "Logged in user is not linked to a staff record") and guidance to contact a supervisor/admin. This check is based solely on `isCashier`, not session activeness, per explicit product direction — an inactive-but-linked cashier still gets auto-resolved.

## Test plan
- [x] `npx tsx lib/repayment-cashier-auto-resolve-policy.test.ts` — passes (TDD'd 3-mode decision logic + exemption gate)
- [x] `npx tsx shared/types/tenant.test.ts` — passes
- [x] Full project typecheck and existing `.test.ts` suite show no new errors/failures (same 4 pre-existing unrelated failures as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)