### PR TITLE
Sync client phone updates to USSD

### DIFF
--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -3,9 +3,14 @@ import { fetchFineractAPI } from "@/lib/api";
 import { hasSuperAdminServer } from "@/lib/authorization";
 import {
   formatMobileForFineract,
-  inferAfricanCountryDialCodeFromPhone,
   resolveCountryDialCodeForPhone,
 } from "@/lib/phone-utils";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
+import { normalizeUssdPhoneNumber } from "@/lib/ussd-admin-client";
+import {
+  updateUssdClientPhone,
+  USSD_PHONE_UPDATE_NON_BLOCKING_STATUSES,
+} from "@/lib/ussd-client-sync";
 
 function getErrorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) {
@@ -101,6 +106,9 @@ export async function PUT(
     const outboundBody =
       typeof body === "object" && body !== null ? { ...body } : body;
 
+    let ussdPhoneSyncWarning: { status: string; message: string } | null =
+      null;
+
     if (
       typeof outboundBody === "object" &&
       outboundBody !== null &&
@@ -109,24 +117,69 @@ export async function PUT(
     ) {
       let existingMobileNo: string | null | undefined;
 
-      if (!inferAfricanCountryDialCodeFromPhone(outboundBody.mobileNo)) {
-        try {
-          const currentClient = (await fetchFineractAPI(
-            `/clients/${clientId}`
-          )) as { mobileNo?: string | null };
-          existingMobileNo = currentClient?.mobileNo;
-        } catch (lookupError) {
-          console.warn(
-            `Failed to fetch current client ${clientId} for phone normalization:`,
-            lookupError
-          );
-        }
+      try {
+        const currentClient = (await fetchFineractAPI(
+          `/clients/${clientId}`
+        )) as { mobileNo?: string | null };
+        existingMobileNo = currentClient?.mobileNo;
+      } catch (lookupError) {
+        console.warn(
+          `Failed to fetch current client ${clientId} for phone normalization:`,
+          lookupError
+        );
       }
 
-      outboundBody.mobileNo = formatMobileForFineract(
+      const formattedMobileNo = formatMobileForFineract(
         outboundBody.mobileNo,
         resolveCountryDialCodeForPhone(outboundBody.mobileNo, existingMobileNo)
       );
+      outboundBody.mobileNo = formattedMobileNo;
+
+      const phoneNumberChanged =
+        !!existingMobileNo &&
+        normalizeUssdPhoneNumber(existingMobileNo) !==
+          normalizeUssdPhoneNumber(formattedMobileNo);
+
+      if (phoneNumberChanged) {
+        const tenant = await getTenantFromHeaders();
+        const ussdServiceTenantId = tenant?.ussdServiceTenantId?.trim();
+
+        if (ussdServiceTenantId) {
+          try {
+            const ussdResult = await updateUssdClientPhone({
+              ussdServiceTenantId,
+              externalId: clientId,
+              currentPhoneNumber: existingMobileNo as string,
+              newPhoneNumber: formattedMobileNo,
+            });
+
+            if (
+              !ussdResult.success &&
+              !USSD_PHONE_UPDATE_NON_BLOCKING_STATUSES.has(ussdResult.status)
+            ) {
+              console.warn(
+                `USSD phone sync failed for client ${clientId} (status=${ussdResult.status}); leaving phone number unchanged in Fineract.`
+              );
+              delete outboundBody.mobileNo;
+              ussdPhoneSyncWarning = {
+                status: ussdResult.status,
+                message: ussdResult.message,
+              };
+            }
+          } catch (ussdError) {
+            console.error(
+              `USSD phone sync failed for client ${clientId}:`,
+              ussdError
+            );
+            delete outboundBody.mobileNo;
+            ussdPhoneSyncWarning = {
+              status: "USSD_UNAVAILABLE",
+              message:
+                "Could not reach the USSD service to sync the phone number",
+            };
+          }
+        }
+      }
     }
 
     const data = await fetchFineractAPI(`/clients/${clientId}`, {
@@ -134,6 +187,14 @@ export async function PUT(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(outboundBody),
     });
+
+    if (ussdPhoneSyncWarning) {
+      const responseBody =
+        typeof data === "object" && data !== null
+          ? { ...data, ussdPhoneSync: { success: false, ...ussdPhoneSyncWarning } }
+          : { data, ussdPhoneSync: { success: false, ...ussdPhoneSyncWarning } };
+      return NextResponse.json(responseBody);
+    }
 
     return NextResponse.json(data);
   } catch (error: unknown) {

--- a/lib/__tests__/ussd-client-sync.test.ts
+++ b/lib/__tests__/ussd-client-sync.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/testdb";
+
+test("updateUssdClientPhone sends normalized phone numbers to the external-id phone endpoint", async () => {
+  process.env.USSD_BASE_URL = "http://localhost:8080/api/v1";
+  process.env.USSD_ADMIN_API_KEY = "admin-reset-key";
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    capturedUrl = url;
+    capturedInit = init;
+    return new Response(
+      JSON.stringify({
+        success: true,
+        status: "UPDATED",
+        message: "Phone number updated",
+        userId: "42",
+        externalId: 9911,
+        oldPhoneNumber: "260977123456",
+        newPhoneNumber: "260966654321",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const mod = await import("../ussd-client-sync");
+    const result = await mod.updateUssdClientPhone({
+      ussdServiceTenantId: "goodfellow",
+      externalId: 9911,
+      currentPhoneNumber: "0977 123 456",
+      newPhoneNumber: "0966 654 321",
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.status, "UPDATED");
+    assert.equal(result.oldPhoneNumber, "260977123456");
+    assert.equal(result.newPhoneNumber, "260966654321");
+
+    assert.equal(
+      capturedUrl,
+      "http://localhost:8080/api/v1/admin/users/external/9911/phone"
+    );
+    assert.equal(capturedInit?.method, "PUT");
+    const headers = capturedInit?.headers as Record<string, string>;
+    assert.equal(headers["X-USSD-Admin-Key"], "admin-reset-key");
+    assert.equal(headers["X-USSD-Tenant-Id"], "goodfellow");
+
+    const sentBody = JSON.parse(capturedInit?.body as string);
+    assert.equal(sentBody.currentPhoneNumber, "260977123456");
+    assert.equal(sentBody.newPhoneNumber, "260966654321");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("updateUssdClientPhone returns a structured NOT_FOUND result instead of throwing", async () => {
+  process.env.USSD_BASE_URL = "http://localhost:8080/api/v1";
+  process.env.USSD_ADMIN_API_KEY = "admin-reset-key";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        success: false,
+        status: "NOT_FOUND",
+        message: "No USSD user was found for this client",
+      }),
+      { status: 404, headers: { "Content-Type": "application/json" } }
+    )) as typeof fetch;
+
+  try {
+    const mod = await import("../ussd-client-sync");
+    const result = await mod.updateUssdClientPhone({
+      ussdServiceTenantId: "goodfellow",
+      externalId: 9911,
+      currentPhoneNumber: "0977123456",
+      newPhoneNumber: "0966654321",
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, "NOT_FOUND");
+    assert.ok(mod.USSD_PHONE_UPDATE_NON_BLOCKING_STATUSES.has(result.status));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("updateUssdClientPhone returns a structured PHONE_MISMATCH result that callers must treat as blocking", async () => {
+  process.env.USSD_BASE_URL = "http://localhost:8080/api/v1";
+  process.env.USSD_ADMIN_API_KEY = "admin-reset-key";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        success: false,
+        status: "PHONE_MISMATCH",
+        message: "The phone number on record does not match what was provided",
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    )) as typeof fetch;
+
+  try {
+    const mod = await import("../ussd-client-sync");
+    const result = await mod.updateUssdClientPhone({
+      ussdServiceTenantId: "goodfellow",
+      externalId: 9911,
+      currentPhoneNumber: "0900000000",
+      newPhoneNumber: "0966654321",
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, "PHONE_MISMATCH");
+    assert.equal(
+      mod.USSD_PHONE_UPDATE_NON_BLOCKING_STATUSES.has(result.status),
+      false
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("updateUssdClientPhone throws when USSD returns an error with no parseable body", async () => {
+  process.env.USSD_BASE_URL = "http://localhost:8080/api/v1";
+  process.env.USSD_ADMIN_API_KEY = "admin-reset-key";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("Service Unavailable", { status: 503 })) as typeof fetch;
+
+  try {
+    const mod = await import("../ussd-client-sync");
+    await assert.rejects(
+      mod.updateUssdClientPhone({
+        ussdServiceTenantId: "goodfellow",
+        externalId: 9911,
+        currentPhoneNumber: "0977123456",
+        newPhoneNumber: "0966654321",
+      }),
+      /USSD phone update failed \(503\)/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/lib/ussd-admin-client.ts
+++ b/lib/ussd-admin-client.ts
@@ -33,7 +33,7 @@ type LookupInput = {
   phoneNumber: string;
 };
 
-function getUssdApiBaseUrl(): string {
+export function getUssdApiBaseUrl(): string {
   const baseUrl = (process.env.USSD_BASE_URL ?? "").replace(/\/$/, "");
 
   if (!baseUrl) {
@@ -53,7 +53,7 @@ function getUssdAdminApiKey(): string {
   return apiKey;
 }
 
-function getAdminHeaders(ussdServiceTenantId: string): Record<string, string> {
+export function getAdminHeaders(ussdServiceTenantId: string): Record<string, string> {
   const tenantId = ussdServiceTenantId.trim();
   if (!tenantId) {
     throw new Error("USSD service tenant id is required");
@@ -66,7 +66,7 @@ function getAdminHeaders(ussdServiceTenantId: string): Record<string, string> {
   };
 }
 
-async function readResponseBody(response: Response): Promise<string> {
+export async function readResponseBody(response: Response): Promise<string> {
   try {
     return await response.text();
   } catch {

--- a/lib/ussd-client-sync.ts
+++ b/lib/ussd-client-sync.ts
@@ -1,0 +1,118 @@
+import {
+  getAdminHeaders,
+  getUssdApiBaseUrl,
+  normalizeUssdPhoneNumber,
+  readResponseBody,
+} from "@/lib/ussd-admin-client";
+
+export type UssdPhoneUpdateResult = {
+  success: boolean;
+  status: string;
+  message: string;
+  userId?: string | null;
+  externalId?: number | null;
+  oldPhoneNumber?: string | null;
+  newPhoneNumber?: string | null;
+};
+
+type PhoneUpdateInput = {
+  ussdServiceTenantId: string;
+  externalId: number;
+  currentPhoneNumber: string;
+  newPhoneNumber: string;
+};
+
+/**
+ * Statuses that mean "nothing to sync" rather than a failure — the caller
+ * may safely proceed with the rest of the client update.
+ */
+export const USSD_PHONE_UPDATE_NON_BLOCKING_STATUSES = new Set([
+  "NOT_FOUND",
+  "UNCHANGED",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function optionalNumber(value: unknown): number | null {
+  if (value == null) {
+    return null;
+  }
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function parsePhoneUpdateResult(payload: unknown): UssdPhoneUpdateResult | null {
+  if (
+    !isRecord(payload) ||
+    typeof payload.success !== "boolean" ||
+    typeof payload.status !== "string" ||
+    typeof payload.message !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    success: payload.success,
+    status: payload.status,
+    message: payload.message,
+    userId: optionalString(payload.userId),
+    externalId: optionalNumber(payload.externalId),
+    oldPhoneNumber: optionalString(payload.oldPhoneNumber),
+    newPhoneNumber: optionalString(payload.newPhoneNumber),
+  };
+}
+
+function parsePhoneUpdateResultBody(body: string): UssdPhoneUpdateResult | null {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    return parsePhoneUpdateResult(JSON.parse(body));
+  } catch {
+    return null;
+  }
+}
+
+export async function updateUssdClientPhone(
+  input: PhoneUpdateInput
+): Promise<UssdPhoneUpdateResult> {
+  const response = await fetch(
+    `${getUssdApiBaseUrl()}/admin/users/external/${input.externalId}/phone`,
+    {
+      method: "PUT",
+      headers: getAdminHeaders(input.ussdServiceTenantId),
+      body: JSON.stringify({
+        currentPhoneNumber: normalizeUssdPhoneNumber(input.currentPhoneNumber),
+        newPhoneNumber: normalizeUssdPhoneNumber(input.newPhoneNumber),
+      }),
+    }
+  );
+
+  const body = await readResponseBody(response);
+  const result = parsePhoneUpdateResultBody(body);
+
+  if (!response.ok) {
+    if (result) {
+      return result;
+    }
+
+    throw new Error(
+      `USSD phone update failed (${response.status}): ${
+        body || response.statusText
+      }`
+    );
+  }
+
+  if (!result) {
+    throw new Error("USSD phone update returned invalid details");
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- When a USSD-enabled tenant updates a client's `mobileNo` via `PUT /api/clients/[id]`, push the new number to GoodFellowUssd first (matched by tenant + Fineract client id, cross-checked against the current phone on record).
- If USSD confirms the update, has no matching user yet, or the number already matches, the phone proceeds to Fineract as before.
- If USSD fails for any other reason (mismatch, number already in use, unreachable), `mobileNo` is dropped from the outbound Fineract payload — every other field in the request still saves — and the response includes a non-blocking `ussdPhoneSync: { success: false, status, message }` field.
- Non-USSD tenants and non-phone field updates are unaffected.

Companion PR in GoodFellowUssd (adds the endpoint this calls): https://github.com/Kenac-Innovations/GoodFellowUssd/pull/new/feature/ussd-client-phone-sync

## Test plan
- [x] `node --import tsx --test lib/__tests__/ussd-client-sync.test.ts` — 4/4 passing
- [x] `tsc --noEmit` — no new errors in changed files
- [x] Full `lib/__tests__` suite run — no regressions introduced (pre-existing unrelated failures reproduce identically without these changes)
- [ ] Manual verification against a running USSD instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)