### PR TITLE
Add central reminders UI

### DIFF
--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -204,6 +204,7 @@ export function SidebarNav({
               href: "/system/roles-and-permissions",
             },
             { label: "Manage Jobs", href: "/system/manage-jobs" },
+            { label: "Reminders", href: "/system/reminders" },
             { label: "Audit Trails", href: "/system/audit-trails" },
             {
               label: "Configure Maker Checker Tasks",

--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -204,6 +204,7 @@ export function SidebarNav({
               href: "/system/roles-and-permissions",
             },
             { label: "Manage Jobs", href: "/system/manage-jobs" },
+            { label: "Notifications", href: "/system/notifications" },
             { label: "Reminders", href: "/system/reminders" },
             { label: "Audit Trails", href: "/system/audit-trails" },
             {

--- a/app/(application)/loans/recoveries/recoveries-dashboard.tsx
+++ b/app/(application)/loans/recoveries/recoveries-dashboard.tsx
@@ -559,65 +559,6 @@ export function RecoveriesDashboard() {
     }
   };
 
-  const handleSendReminder = async (row: RecoveryLoanRow) => {
-    const key = `${row.loanId}:reminder`;
-    setActionKey(key);
-    try {
-      const response = await fetch(`/api/recoveries/loans/${row.loanId}/reminder`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ bucket: row.bucket }),
-      });
-      const result = await response.json();
-      if (!response.ok) throw new Error(result.error || result.message || "Failed to send reminder");
-
-      toast({
-        title: "Reminder logged",
-        description: result.message || "Reminder action completed.",
-      });
-      refreshCurrentTab();
-    } catch (error) {
-      toast({
-        title: "Reminder failed",
-        description: error instanceof Error ? error.message : "Failed to send reminder",
-        variant: "destructive",
-      });
-    } finally {
-      setActionKey(null);
-    }
-  };
-
-  const handleTriggerBucket = async () => {
-    if (activeTab !== "30" && activeTab !== "60" && activeTab !== "90") return;
-    const confirmed = window.confirm(`Send ${activeTab === "90" ? "90+" : activeTab}-day reminders for all loans in this bucket?`);
-    if (!confirmed) return;
-
-    setActionKey("trigger");
-    try {
-      const response = await fetch("/api/recoveries/reminders/trigger", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ bucket: activeTab }),
-      });
-      const result = await response.json();
-      if (!response.ok) throw new Error(result.error || "Failed to trigger reminders");
-
-      toast({
-        title: "Reminder trigger completed",
-        description: `${result.sent || 0} SMS sent from ${result.processed || 0} processed loans.`,
-      });
-      refreshCurrentTab();
-    } catch (error) {
-      toast({
-        title: "Reminder trigger failed",
-        description: error instanceof Error ? error.message : "Failed to trigger reminders",
-        variant: "destructive",
-      });
-    } finally {
-      setActionKey(null);
-    }
-  };
-
   const handleSubmitNote = async () => {
     if (!noteTarget || !noteText.trim()) return;
     setActionKey("note");
@@ -784,17 +725,12 @@ export function RecoveriesDashboard() {
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              {(activeTab === "30" || activeTab === "60" || activeTab === "90") && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleTriggerBucket}
-                  disabled={actionKey === "trigger" || loading}
-                >
-                  {actionKey === "trigger" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Bell className="h-4 w-4" />}
-                  Trigger Bucket
-                </Button>
-              )}
+              <Button asChild variant="outline" size="sm">
+                <Link href="/system/reminders">
+                  <Bell className="h-4 w-4" />
+                  Reminder Rules
+                </Link>
+              </Button>
               <Button variant="outline" size="icon" onClick={refreshCurrentTab} disabled={loading || courtLoading}>
                 <RefreshCw className={cn("h-4 w-4", (loading || courtLoading) && "animate-spin")} />
               </Button>
@@ -830,7 +766,6 @@ export function RecoveriesDashboard() {
                 actionKey={actionKey}
                 isNpaView={activeTab === "npa"}
                 onPageChange={setActiveTabPage}
-                onSendReminder={handleSendReminder}
                 onAddNote={(row) => {
                   setNoteTarget(row);
                   setNoteText("");
@@ -1071,7 +1006,6 @@ function ArrearsTable({
   actionKey,
   isNpaView,
   onPageChange,
-  onSendReminder,
   onAddNote,
   onOpenCourtCase,
   onWriteOff,
@@ -1082,7 +1016,6 @@ function ArrearsTable({
   actionKey: string | null;
   isNpaView: boolean;
   onPageChange: (page: number) => void;
-  onSendReminder: (row: RecoveryLoanRow) => void;
   onAddNote: (row: RecoveryLoanRow) => void;
   onOpenCourtCase: (row: RecoveryLoanRow) => void;
   onWriteOff: (row: RecoveryLoanRow) => void;
@@ -1192,16 +1125,11 @@ function ArrearsTable({
                     </>
                   ) : (
                     <>
-                      <DropdownMenuItem
-                        onClick={() => onSendReminder(row)}
-                        disabled={actionKey === `${row.loanId}:reminder`}
-                      >
-                        {actionKey === `${row.loanId}:reminder` ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
+                      <DropdownMenuItem asChild>
+                        <Link href="/system/reminders">
                           <Bell className="h-4 w-4" />
-                        )}
-                        Send reminder SMS
+                          Reminder rules
+                        </Link>
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => onAddNote(row)}>
                         <StickyNote className="h-4 w-4" />

--- a/app/(application)/system/notifications/loading.tsx
+++ b/app/(application)/system/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "../components/system-skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton showBackButton={false} />;
+}

--- a/app/(application)/system/notifications/notifications-client.tsx
+++ b/app/(application)/system/notifications/notifications-client.tsx
@@ -1,0 +1,475 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Loader2,
+  MessageSquareText,
+  RefreshCw,
+  Search,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  getNotificationMessagesPageAction,
+  type NotificationMessagePageFilters,
+} from "@/app/actions/reminder-actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type {
+  NotificationChannel,
+  NotificationMessagePage,
+  NotificationMessageSummary,
+  NotificationSource,
+  NotificationStatus,
+} from "@/shared/types/reminders";
+
+const ALL = "__all";
+const DEFAULT_PAGE_SIZE = 25;
+
+type FilterForm = {
+  status: NotificationStatus | typeof ALL;
+  source: NotificationSource | typeof ALL;
+  channel: NotificationChannel | typeof ALL;
+  sourceType: string;
+};
+
+type NotificationsClientProps = {
+  initialPage: NotificationMessagePage;
+};
+
+const emptyFilters: FilterForm = {
+  status: ALL,
+  source: ALL,
+  channel: ALL,
+  sourceType: "",
+};
+
+const statuses: NotificationStatus[] = [
+  "QUEUED",
+  "ACCEPTED",
+  "SENT",
+  "FAILED",
+  "SUPPRESSED",
+  "SKIPPED",
+];
+
+const sources: NotificationSource[] = [
+  "REMINDER",
+  "RECOVERY",
+  "REPAYMENT_RECEIPT",
+];
+
+const channels: NotificationChannel[] = ["SMS", "EMAIL"];
+
+function compactLabel(value: string) {
+  return value
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function statusBadgeClass(status: string) {
+  if (status === "SENT") {
+    return "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200";
+  }
+  if (status === "FAILED") {
+    return "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950/50 dark:text-red-200";
+  }
+  if (["ACCEPTED", "QUEUED"].includes(status)) {
+    return "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-200";
+  }
+  if (["SUPPRESSED", "SKIPPED"].includes(status)) {
+    return "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200";
+  }
+  return "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300";
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return "N/A";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function toActionFilters(
+  filters: FilterForm,
+  page: number,
+  size: number
+): NotificationMessagePageFilters {
+  return {
+    page,
+    size,
+    status: filters.status === ALL ? undefined : filters.status,
+    source: filters.source === ALL ? undefined : filters.source,
+    channel: filters.channel === ALL ? undefined : filters.channel,
+    sourceType: filters.sourceType.trim() || undefined,
+  };
+}
+
+function messageTimestamp(message: NotificationMessageSummary) {
+  return (
+    message.sentAt ??
+    message.acceptedAt ??
+    message.failedAt ??
+    message.callbackReceivedAt ??
+    message.createdAt
+  );
+}
+
+function pageRange(page: NotificationMessagePage) {
+  if (page.totalElements === 0) {
+    return { start: 0, end: 0 };
+  }
+
+  const start = page.page * page.size + 1;
+  const end = start + page.content.length - 1;
+  return { start, end };
+}
+
+export function NotificationsClient({ initialPage }: NotificationsClientProps) {
+  const [filters, setFilters] = useState<FilterForm>(emptyFilters);
+  const [notificationPage, setNotificationPage] = useState(initialPage);
+  const [pageSize, setPageSize] = useState(initialPage.size || DEFAULT_PAGE_SIZE);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const totalPages = Math.max(1, notificationPage.totalPages);
+  const currentPage = notificationPage.page + 1;
+  const range = pageRange(notificationPage);
+
+  async function loadPage(
+    nextPage = notificationPage.page,
+    nextSize = pageSize,
+    nextFilters = filters
+  ) {
+    setIsLoading(true);
+    try {
+      const result = await getNotificationMessagesPageAction(
+        toActionFilters(nextFilters, nextPage, nextSize)
+      );
+      setNotificationPage(result);
+      setPageSize(result.size);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to load notifications"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleSearch(event: FormEvent) {
+    event.preventDefault();
+    void loadPage(0);
+  }
+
+  function handleReset() {
+    setFilters(emptyFilters);
+    void loadPage(0, pageSize, emptyFilters);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Notifications</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Tenant notification delivery history.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void loadPage(notificationPage.page)}
+          disabled={isLoading}
+        >
+          <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Filter className="h-4 w-4" />
+            Filters
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4 lg:grid-cols-5" onSubmit={handleSearch}>
+            <div className="space-y-2">
+              <Label>Status</Label>
+              <Select
+                value={filters.status}
+                onValueChange={(status: NotificationStatus | typeof ALL) =>
+                  setFilters((current) => ({ ...current, status }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>All statuses</SelectItem>
+                  {statuses.map((status) => (
+                    <SelectItem key={status} value={status}>
+                      {compactLabel(status)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Source</Label>
+              <Select
+                value={filters.source}
+                onValueChange={(source: NotificationSource | typeof ALL) =>
+                  setFilters((current) => ({ ...current, source }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>All sources</SelectItem>
+                  {sources.map((source) => (
+                    <SelectItem key={source} value={source}>
+                      {compactLabel(source)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Channel</Label>
+              <Select
+                value={filters.channel}
+                onValueChange={(channel: NotificationChannel | typeof ALL) =>
+                  setFilters((current) => ({ ...current, channel }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>All channels</SelectItem>
+                  {channels.map((channel) => (
+                    <SelectItem key={channel} value={channel}>
+                      {channel}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="source-type">Source Type</Label>
+              <Input
+                id="source-type"
+                value={filters.sourceType}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    sourceType: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="flex items-end gap-2">
+              <Button type="submit" className="flex-1" disabled={isLoading}>
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="h-4 w-4" />
+                )}
+                Search
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleReset}
+                disabled={isLoading}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <MessageSquareText className="h-4 w-4" />
+            Delivery Ledger
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Rows</span>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(value) => {
+                const nextSize = Number(value);
+                setPageSize(nextSize);
+                void loadPage(0, nextSize);
+              }}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="w-[92px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[10, 25, 50, 100].map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Message</TableHead>
+                  <TableHead>Recipient</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Channel</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Loan</TableHead>
+                  <TableHead>Last Update</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {notificationPage.content.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="h-24 text-center text-sm text-muted-foreground"
+                    >
+                      No notifications found.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  notificationPage.content.map((message) => (
+                    <TableRow key={message.id}>
+                      <TableCell className="min-w-[360px] max-w-[460px]">
+                        <div className="font-medium">
+                          {message.subject || compactLabel(message.sourceType)}
+                        </div>
+                        <div className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                          {message.body}
+                        </div>
+                        {message.errorMessage && (
+                          <div className="mt-1 text-xs text-red-600 dark:text-red-400">
+                            {message.errorMessage}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {message.recipient}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          className={cn(
+                            "border",
+                            statusBadgeClass(message.status)
+                          )}
+                        >
+                          {compactLabel(message.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{message.channel}</TableCell>
+                      <TableCell>
+                        <div>{compactLabel(message.source)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {compactLabel(message.sourceType)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {message.loanAccountNo || message.loanId || "N/A"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {formatDateTime(messageTimestamp(message))}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-muted-foreground">
+              Showing {range.start}-{range.end} of{" "}
+              {notificationPage.totalElements.toLocaleString()} notifications
+            </div>
+            <div className="flex items-center justify-between gap-3 sm:justify-end">
+              <span className="text-sm text-muted-foreground">
+                Page {currentPage} of {totalPages}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    void loadPage(Math.max(0, notificationPage.page - 1))
+                  }
+                  disabled={!notificationPage.hasPrevious || isLoading}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void loadPage(notificationPage.page + 1)}
+                  disabled={!notificationPage.hasNext || isLoading}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(application)/system/notifications/page.tsx
+++ b/app/(application)/system/notifications/page.tsx
@@ -1,0 +1,42 @@
+import { AlertCircle } from "lucide-react";
+import { getNotificationMessagesPageAction } from "@/app/actions/reminder-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { NotificationsClient } from "./notifications-client";
+import type { NotificationMessagePage } from "@/shared/types/reminders";
+
+export default async function NotificationsPage() {
+  let initialPage: NotificationMessagePage | null = null;
+  let loadError: string | null = null;
+
+  try {
+    initialPage = await getNotificationMessagesPageAction({
+      page: 0,
+      size: 25,
+    });
+  } catch (error) {
+    loadError =
+      error instanceof Error ? error.message : "Failed to load notifications";
+  }
+
+  if (loadError || !initialPage) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Notifications</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Tenant notification delivery history.
+          </p>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {loadError ?? "Failed to load notifications"}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return <NotificationsClient initialPage={initialPage} />;
+}

--- a/app/(application)/system/reminders/loading.tsx
+++ b/app/(application)/system/reminders/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "../components/system-skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton showBackButton={false} />;
+}

--- a/app/(application)/system/reminders/page.tsx
+++ b/app/(application)/system/reminders/page.tsx
@@ -1,0 +1,36 @@
+import { AlertCircle } from "lucide-react";
+import { getReminderDashboardAction } from "@/app/actions/reminder-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { RemindersClient } from "./reminders-client";
+
+export default async function RemindersPage() {
+  let data = null;
+  let loadError: string | null = null;
+
+  try {
+    data = await getReminderDashboardAction();
+  } catch (error) {
+    loadError =
+      error instanceof Error ? error.message : "Failed to load reminders";
+  }
+
+  if (loadError || !data) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Reminders</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Central reminder scheduling and delivery history.
+          </p>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{loadError}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return <RemindersClient initialData={data} />;
+}

--- a/app/(application)/system/reminders/reminders-client.tsx
+++ b/app/(application)/system/reminders/reminders-client.tsx
@@ -1,0 +1,1402 @@
+"use client";
+
+import { useMemo, useState, useTransition, type FormEvent, type ReactNode } from "react";
+import Link from "next/link";
+import {
+  AlertCircle,
+  BellRing,
+  CalendarClock,
+  Clock3,
+  Database,
+  Loader2,
+  MessageSquareText,
+  RefreshCw,
+  Save,
+  Send,
+  Settings2,
+  ShieldCheck,
+  SquarePen,
+  XCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  ensureDefaultReminderSetupAction,
+  getNotificationMessagesAction,
+  getReminderDashboardAction,
+  getReminderRunItemsAction,
+  saveReminderRuleAction,
+  saveReminderTemplateAction,
+  saveReminderTenantConfigAction,
+  type SaveReminderRuleInput,
+  type SaveReminderTemplateInput,
+  type SaveReminderTenantConfigInput,
+} from "@/app/actions/reminder-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type {
+  NotificationMessageSummary,
+  NotificationStatus,
+  ReminderDashboardData,
+  ReminderRule,
+  ReminderRunItem,
+  ReminderRunSummary,
+  ReminderTemplate,
+  ReminderType,
+} from "@/shared/types/reminders";
+
+const NONE = "__none";
+
+type RemindersClientProps = {
+  initialData: ReminderDashboardData;
+};
+
+type RuleFormState = SaveReminderRuleInput;
+type TemplateFormState = SaveReminderTemplateInput;
+
+function formatDateTime(value?: string | null) {
+  if (!value) return "N/A";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "N/A";
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleDateString("en-US", {
+    dateStyle: "medium",
+  });
+}
+
+function formatReminderType(type: ReminderType) {
+  return type === "LOAN_REPAYMENT_DUE" ? "Repayment Due" : "Recovery Arrears";
+}
+
+function compactStatus(value: string) {
+  return value
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function statusBadgeClass(status: string) {
+  if (["SENT", "COMPLETED"].includes(status)) {
+    return "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200";
+  }
+  if (["FAILED"].includes(status)) {
+    return "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950/50 dark:text-red-200";
+  }
+  if (["ACCEPTED", "QUEUED", "PROCESSING_REMINDERS", "SCANNING_CANDIDATES", "CANDIDATES_LOADED"].includes(status)) {
+    return "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-200";
+  }
+  if (["SUPPRESSED", "SKIPPED"].includes(status)) {
+    return "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200";
+  }
+  return "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300";
+}
+
+function StatCard({
+  title,
+  value,
+  detail,
+  icon,
+}: {
+  title: string;
+  value: string | number;
+  detail: string;
+  icon: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {title}
+        </CardTitle>
+        <div className="text-muted-foreground">{icon}</div>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tabular-nums">{value}</div>
+        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function emptyTemplateForm(): TemplateFormState {
+  return {
+    code: "",
+    name: "",
+    channel: "SMS",
+    subject: "",
+    body: "",
+    active: true,
+  };
+}
+
+function templateToForm(template: ReminderTemplate): TemplateFormState {
+  return {
+    id: template.id,
+    code: template.code,
+    name: template.name,
+    channel: template.channel,
+    subject: template.subject ?? "",
+    body: template.body,
+    active: template.active,
+  };
+}
+
+function emptyRuleForm(
+  timezone: string,
+  templateId?: string | null
+): RuleFormState {
+  return {
+    code: "",
+    name: "",
+    type: "LOAN_REPAYMENT_DUE",
+    enabled: true,
+    channels: "SMS",
+    templateId: templateId ?? null,
+    reportName: "",
+    sendTime: "09:00",
+    timezone,
+    daysOffset: 0,
+    lookBackDays: 0,
+    lookAheadDays: 0,
+    minDaysPastDue: null,
+    maxDaysPastDue: null,
+    cooldownMinutes: 1440,
+    pageLimit: 100,
+  };
+}
+
+function ruleToForm(rule: ReminderRule): RuleFormState {
+  return {
+    id: rule.id,
+    code: rule.code,
+    name: rule.name,
+    type: rule.type,
+    enabled: rule.enabled,
+    channels: rule.channels || "SMS",
+    templateId: rule.templateId ?? null,
+    reportName: rule.reportName ?? "",
+    sendTime: rule.sendTime?.slice(0, 5) || "09:00",
+    timezone: rule.timezone ?? "",
+    daysOffset: rule.daysOffset,
+    lookBackDays: rule.lookBackDays,
+    lookAheadDays: rule.lookAheadDays,
+    minDaysPastDue: rule.minDaysPastDue ?? null,
+    maxDaysPastDue: rule.maxDaysPastDue ?? null,
+    cooldownMinutes: rule.cooldownMinutes,
+    pageLimit: rule.pageLimit,
+  };
+}
+
+function numberOrNull(value: string) {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function runProgress(run: ReminderRunSummary) {
+  const loadedBase = run.totalCandidateCount || run.loadedCandidateCount || 0;
+  if (run.status === "SCANNING_CANDIDATES" && loadedBase > 0) {
+    return Math.min(100, Math.round((run.loadedCandidateCount / loadedBase) * 100));
+  }
+
+  const processedBase = run.loadedCandidateCount || run.totalCandidateCount || 0;
+  if (processedBase > 0) {
+    return Math.min(100, Math.round((run.processedCount / processedBase) * 100));
+  }
+
+  return run.status === "COMPLETED" ? 100 : 0;
+}
+
+function ruleName(rules: ReminderRule[], ruleId?: string | null) {
+  if (!ruleId) return "N/A";
+  return rules.find((rule) => rule.id === ruleId)?.name ?? ruleId.slice(0, 8);
+}
+
+function templateName(templates: ReminderTemplate[], templateId?: string | null) {
+  if (!templateId) return "None";
+  return templates.find((template) => template.id === templateId)?.name ?? "Unknown";
+}
+
+export function RemindersClient({ initialData }: RemindersClientProps) {
+  const [data, setData] = useState(initialData);
+  const [configForm, setConfigForm] = useState<SaveReminderTenantConfigInput>({
+    enabled: initialData.config.enabled,
+    timezone: initialData.config.timezone || "Africa/Harare",
+    defaultCountryCode: initialData.config.defaultCountryCode || "+263",
+  });
+  const [templateForm, setTemplateForm] = useState<TemplateFormState>(
+    emptyTemplateForm()
+  );
+  const [ruleForm, setRuleForm] = useState<RuleFormState>(
+    emptyRuleForm(initialData.config.timezone || "Africa/Harare")
+  );
+  const [messageStatusFilter, setMessageStatusFilter] = useState<NotificationStatus | "ALL">("ALL");
+  const [selectedRun, setSelectedRun] = useState<ReminderRunSummary | null>(null);
+  const [runItems, setRunItems] = useState<ReminderRunItem[]>([]);
+  const [runItemsLoading, setRunItemsLoading] = useState(false);
+  const [pendingLabel, setPendingLabel] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const activeRules = useMemo(
+    () => data.rules.filter((rule) => rule.enabled).length,
+    [data.rules]
+  );
+  const runningRuns = useMemo(
+    () =>
+      data.runs.filter((run) =>
+        ["CREATED", "SCANNING_CANDIDATES", "CANDIDATES_LOADED", "PROCESSING_REMINDERS"].includes(run.status)
+      ).length,
+    [data.runs]
+  );
+  const deliveredCount = useMemo(
+    () => data.messages.filter((message) => message.status === "SENT").length,
+    [data.messages]
+  );
+  const failedCount = useMemo(
+    () => data.messages.filter((message) => message.status === "FAILED").length,
+    [data.messages]
+  );
+
+  const refreshDashboard = () => {
+    setPendingLabel("refresh");
+    startTransition(async () => {
+      try {
+        const next = await getReminderDashboardAction();
+        setData(next);
+        setConfigForm({
+          enabled: next.config.enabled,
+          timezone: next.config.timezone || "Africa/Harare",
+          defaultCountryCode: next.config.defaultCountryCode || "+263",
+        });
+        toast.success("Reminders refreshed");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to refresh reminders");
+      } finally {
+        setPendingLabel(null);
+      }
+    });
+  };
+
+  const handleSaveConfig = (event: FormEvent) => {
+    event.preventDefault();
+    setPendingLabel("config");
+    startTransition(async () => {
+      const result = await saveReminderTenantConfigAction(configForm);
+      if (!result.success || !result.data) {
+        toast.error(result.error || "Failed to save reminder settings");
+        setPendingLabel(null);
+        return;
+      }
+      setData((current) => ({ ...current, config: result.data! }));
+      toast.success("Reminder settings saved");
+      setPendingLabel(null);
+    });
+  };
+
+  const handleSaveTemplate = (event: FormEvent) => {
+    event.preventDefault();
+    if (!templateForm.code.trim() || !templateForm.name.trim() || !templateForm.body.trim()) {
+      toast.error("Template code, name, and message are required");
+      return;
+    }
+
+    setPendingLabel("template");
+    startTransition(async () => {
+      const result = await saveReminderTemplateAction(templateForm);
+      if (!result.success || !result.data) {
+        toast.error(result.error || "Failed to save template");
+        setPendingLabel(null);
+        return;
+      }
+
+      setData((current) => ({
+        ...current,
+        templates: [
+          result.data!,
+          ...current.templates.filter((template) => template.id !== result.data!.id),
+        ].sort((first, second) => first.name.localeCompare(second.name)),
+      }));
+      setTemplateForm(emptyTemplateForm());
+      toast.success("Reminder template saved");
+      setPendingLabel(null);
+    });
+  };
+
+  const handleSaveRule = (event: FormEvent) => {
+    event.preventDefault();
+    if (!ruleForm.code.trim() || !ruleForm.name.trim() || !ruleForm.sendTime) {
+      toast.error("Rule code, name, and send time are required");
+      return;
+    }
+
+    setPendingLabel("rule");
+    startTransition(async () => {
+      const result = await saveReminderRuleAction(ruleForm);
+      if (!result.success || !result.data) {
+        toast.error(result.error || "Failed to save rule");
+        setPendingLabel(null);
+        return;
+      }
+
+      setData((current) => ({
+        ...current,
+        rules: [
+          result.data!,
+          ...current.rules.filter((rule) => rule.id !== result.data!.id),
+        ].sort((first, second) => first.name.localeCompare(second.name)),
+      }));
+      setRuleForm(emptyRuleForm(data.config.timezone || "Africa/Harare"));
+      toast.success("Reminder rule saved");
+      setPendingLabel(null);
+    });
+  };
+
+  const handleDefaults = () => {
+    setPendingLabel("defaults");
+    startTransition(async () => {
+      const result = await ensureDefaultReminderSetupAction();
+      if (!result.success || !result.data) {
+        toast.error(result.error || "Failed to create default reminders");
+        setPendingLabel(null);
+        return;
+      }
+      setData(result.data);
+      toast.success("Default reminder setup is ready");
+      setPendingLabel(null);
+    });
+  };
+
+  const handleMessageFilter = (status: NotificationStatus | "ALL") => {
+    setMessageStatusFilter(status);
+    setPendingLabel("messages");
+    startTransition(async () => {
+      try {
+        const messages = await getNotificationMessagesAction({
+          status: status === "ALL" ? undefined : status,
+          limit: 50,
+        });
+        setData((current) => ({ ...current, messages }));
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to load messages");
+      } finally {
+        setPendingLabel(null);
+      }
+    });
+  };
+
+  const handleSelectRun = async (run: ReminderRunSummary) => {
+    setSelectedRun(run);
+    setRunItems([]);
+    setRunItemsLoading(true);
+    try {
+      const items = await getReminderRunItemsAction(run.id);
+      setRunItems(items);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to load run items");
+    } finally {
+      setRunItemsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Reminders</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Central scheduling, templates, run progress, and delivery history.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{data.tenant.fineractTenantId}</Badge>
+            {data.tenant.tenantName && (
+              <Badge variant="outline">{data.tenant.tenantName}</Badge>
+            )}
+            <Badge className={cn("border", statusBadgeClass(data.config.enabled ? "SENT" : "SKIPPED"))}>
+              {data.config.enabled ? "Enabled" : "Disabled"}
+            </Badge>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            onClick={refreshDashboard}
+            disabled={isPending}
+          >
+            {pendingLabel === "refresh" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+            Refresh
+          </Button>
+          <Button onClick={handleDefaults} disabled={isPending}>
+            {pendingLabel === "defaults" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ShieldCheck className="h-4 w-4" />
+            )}
+            Use Defaults
+          </Button>
+        </div>
+      </div>
+
+      {!data.config.enabled && (
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Reminder runs will not be created for this tenant until reminders are enabled.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          title="Active Rules"
+          value={activeRules}
+          detail={`${data.rules.length} configured rules`}
+          icon={<CalendarClock className="h-4 w-4" />}
+        />
+        <StatCard
+          title="Running Jobs"
+          value={runningRuns}
+          detail={`${data.runs.length} recent runs loaded`}
+          icon={<Clock3 className="h-4 w-4" />}
+        />
+        <StatCard
+          title="Messages Sent"
+          value={deliveredCount}
+          detail="From the central notification ledger"
+          icon={<Send className="h-4 w-4" />}
+        />
+        <StatCard
+          title="Failures"
+          value={failedCount}
+          detail="Callback or dispatch failures"
+          icon={<XCircle className="h-4 w-4" />}
+        />
+      </div>
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-1 lg:grid-cols-5">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="rules">Rules</TabsTrigger>
+          <TabsTrigger value="templates">Templates</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+          <TabsTrigger value="messages">Messages</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,420px)_1fr]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Settings2 className="h-4 w-4" />
+                  Tenant Settings
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-4" onSubmit={handleSaveConfig}>
+                  <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+                    <div>
+                      <Label className="text-sm font-medium">Reminders</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Tenant-level scheduler switch.
+                      </p>
+                    </div>
+                    <Switch
+                      checked={configForm.enabled}
+                      onCheckedChange={(enabled) =>
+                        setConfigForm((current) => ({ ...current, enabled }))
+                      }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="timezone">Timezone</Label>
+                    <Input
+                      id="timezone"
+                      value={configForm.timezone}
+                      onChange={(event) =>
+                        setConfigForm((current) => ({
+                          ...current,
+                          timezone: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="default-country-code">Default Country Code</Label>
+                    <Input
+                      id="default-country-code"
+                      value={configForm.defaultCountryCode ?? ""}
+                      onChange={(event) =>
+                        setConfigForm((current) => ({
+                          ...current,
+                          defaultCountryCode: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <Button type="submit" disabled={isPending} className="w-full">
+                    {pendingLabel === "config" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Save className="h-4 w-4" />
+                    )}
+                    Save Settings
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <BellRing className="h-4 w-4" />
+                  Recent Runs
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <RunsTable
+                  runs={data.runs.slice(0, 5)}
+                  rules={data.rules}
+                  compact
+                  onSelectRun={handleSelectRun}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="rules" className="space-y-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_420px]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Rules</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Time</TableHead>
+                        <TableHead>Window</TableHead>
+                        <TableHead>Template</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {data.rules.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={7} className="h-24 text-center text-sm text-muted-foreground">
+                            No reminder rules configured.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        data.rules.map((rule) => (
+                          <TableRow key={rule.id ?? rule.code}>
+                            <TableCell>
+                              <div className="font-medium">{rule.name}</div>
+                              <div className="text-xs text-muted-foreground">{rule.code}</div>
+                            </TableCell>
+                            <TableCell>{formatReminderType(rule.type)}</TableCell>
+                            <TableCell className="tabular-nums">
+                              {rule.sendTime?.slice(0, 5)}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {rule.type === "RECOVERY_ARREARS"
+                                ? `${rule.minDaysPastDue ?? 0}+ days${rule.maxDaysPastDue ? ` to ${rule.maxDaysPastDue}` : ""}`
+                                : `${rule.lookBackDays} back / ${rule.lookAheadDays} ahead`}
+                            </TableCell>
+                            <TableCell>{templateName(data.templates, rule.templateId)}</TableCell>
+                            <TableCell>
+                              <Badge className={cn("border", statusBadgeClass(rule.enabled ? "SENT" : "SKIPPED"))}>
+                                {rule.enabled ? "Enabled" : "Disabled"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setRuleForm(ruleToForm(rule))}
+                              >
+                                <SquarePen className="h-4 w-4" />
+                                Edit
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  {ruleForm.id ? "Edit Rule" : "New Rule"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-4" onSubmit={handleSaveRule}>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="rule-code">Code</Label>
+                      <Input
+                        id="rule-code"
+                        value={ruleForm.code}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({ ...current, code: event.target.value }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="rule-time">Send Time</Label>
+                      <Input
+                        id="rule-time"
+                        type="time"
+                        value={ruleForm.sendTime}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({ ...current, sendTime: event.target.value }))
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="rule-name">Name</Label>
+                    <Input
+                      id="rule-name"
+                      value={ruleForm.name}
+                      onChange={(event) =>
+                        setRuleForm((current) => ({ ...current, name: event.target.value }))
+                      }
+                    />
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Type</Label>
+                      <Select
+                        value={ruleForm.type}
+                        onValueChange={(type: ReminderType) =>
+                          setRuleForm((current) => ({ ...current, type }))
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="LOAN_REPAYMENT_DUE">Repayment Due</SelectItem>
+                          <SelectItem value="RECOVERY_ARREARS">Recovery Arrears</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Template</Label>
+                      <Select
+                        value={ruleForm.templateId || NONE}
+                        onValueChange={(templateId) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            templateId: templateId === NONE ? null : templateId,
+                          }))
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NONE}>None</SelectItem>
+                          {data.templates.map((template) => (
+                            <SelectItem key={template.id ?? template.code} value={template.id ?? template.code}>
+                              {template.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="rule-timezone">Timezone</Label>
+                      <Input
+                        id="rule-timezone"
+                        value={ruleForm.timezone ?? ""}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({ ...current, timezone: event.target.value }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="rule-cooldown">Cooldown Minutes</Label>
+                      <Input
+                        id="rule-cooldown"
+                        type="number"
+                        min={0}
+                        value={ruleForm.cooldownMinutes}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            cooldownMinutes: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="days-offset">Days Offset</Label>
+                      <Input
+                        id="days-offset"
+                        type="number"
+                        value={ruleForm.daysOffset}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            daysOffset: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="look-back">Look Back</Label>
+                      <Input
+                        id="look-back"
+                        type="number"
+                        min={0}
+                        value={ruleForm.lookBackDays}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            lookBackDays: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="look-ahead">Look Ahead</Label>
+                      <Input
+                        id="look-ahead"
+                        type="number"
+                        min={0}
+                        value={ruleForm.lookAheadDays}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            lookAheadDays: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="min-days-past-due">Min Past Due</Label>
+                      <Input
+                        id="min-days-past-due"
+                        type="number"
+                        min={0}
+                        value={ruleForm.minDaysPastDue ?? ""}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            minDaysPastDue: numberOrNull(event.target.value),
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="max-days-past-due">Max Past Due</Label>
+                      <Input
+                        id="max-days-past-due"
+                        type="number"
+                        min={0}
+                        value={ruleForm.maxDaysPastDue ?? ""}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            maxDaysPastDue: numberOrNull(event.target.value),
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="page-limit">Page Limit</Label>
+                      <Input
+                        id="page-limit"
+                        type="number"
+                        min={1}
+                        max={500}
+                        value={ruleForm.pageLimit}
+                        onChange={(event) =>
+                          setRuleForm((current) => ({
+                            ...current,
+                            pageLimit: Number(event.target.value) || 1,
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="report-name">Stretchy Report</Label>
+                    <Input
+                      id="report-name"
+                      value={ruleForm.reportName ?? ""}
+                      onChange={(event) =>
+                        setRuleForm((current) => ({ ...current, reportName: event.target.value }))
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+                    <Label className="text-sm font-medium">Enabled</Label>
+                    <Switch
+                      checked={ruleForm.enabled}
+                      onCheckedChange={(enabled) =>
+                        setRuleForm((current) => ({ ...current, enabled }))
+                      }
+                    />
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="submit" disabled={isPending}>
+                      {pendingLabel === "rule" ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Save className="h-4 w-4" />
+                      )}
+                      Save Rule
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        setRuleForm(emptyRuleForm(data.config.timezone || "Africa/Harare"))
+                      }
+                    >
+                      New Rule
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="templates" className="space-y-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_420px]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Templates</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Channel</TableHead>
+                        <TableHead>Message</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {data.templates.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                            No reminder templates configured.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        data.templates.map((template) => (
+                          <TableRow key={template.id ?? template.code}>
+                            <TableCell>
+                              <div className="font-medium">{template.name}</div>
+                              <div className="text-xs text-muted-foreground">{template.code}</div>
+                            </TableCell>
+                            <TableCell>{template.channel}</TableCell>
+                            <TableCell className="max-w-xl truncate">{template.body}</TableCell>
+                            <TableCell>
+                              <Badge className={cn("border", statusBadgeClass(template.active ? "SENT" : "SKIPPED"))}>
+                                {template.active ? "Active" : "Inactive"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setTemplateForm(templateToForm(template))}
+                              >
+                                <SquarePen className="h-4 w-4" />
+                                Edit
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  {templateForm.id ? "Edit Template" : "New Template"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-4" onSubmit={handleSaveTemplate}>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="template-code">Code</Label>
+                      <Input
+                        id="template-code"
+                        value={templateForm.code}
+                        onChange={(event) =>
+                          setTemplateForm((current) => ({ ...current, code: event.target.value }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Channel</Label>
+                      <Select
+                        value={templateForm.channel}
+                        onValueChange={(channel: "SMS" | "EMAIL") =>
+                          setTemplateForm((current) => ({ ...current, channel }))
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="SMS">SMS</SelectItem>
+                          <SelectItem value="EMAIL">Email</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="template-name">Name</Label>
+                    <Input
+                      id="template-name"
+                      value={templateForm.name}
+                      onChange={(event) =>
+                        setTemplateForm((current) => ({ ...current, name: event.target.value }))
+                      }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="template-subject">Subject</Label>
+                    <Input
+                      id="template-subject"
+                      value={templateForm.subject ?? ""}
+                      onChange={(event) =>
+                        setTemplateForm((current) => ({ ...current, subject: event.target.value }))
+                      }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="template-body">Message</Label>
+                    <Textarea
+                      id="template-body"
+                      value={templateForm.body}
+                      rows={7}
+                      onChange={(event) =>
+                        setTemplateForm((current) => ({ ...current, body: event.target.value }))
+                      }
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Variables: {"{{clientName}}"}, {"{{loanAccountNo}}"}, {"{{amountDue}}"}, {"{{dueDate}}"}, {"{{daysPastDue}}"}.
+                    </p>
+                  </div>
+
+                  <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+                    <Label className="text-sm font-medium">Active</Label>
+                    <Switch
+                      checked={templateForm.active}
+                      onCheckedChange={(active) =>
+                        setTemplateForm((current) => ({ ...current, active }))
+                      }
+                    />
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="submit" disabled={isPending}>
+                      {pendingLabel === "template" ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Save className="h-4 w-4" />
+                      )}
+                      Save Template
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setTemplateForm(emptyTemplateForm())}
+                    >
+                      New Template
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="runs" className="space-y-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_460px]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Database className="h-4 w-4" />
+                  Job Progress
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <RunsTable
+                  runs={data.runs}
+                  rules={data.rules}
+                  onSelectRun={handleSelectRun}
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  {selectedRun ? "Run Items" : "Select a Run"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {!selectedRun ? (
+                  <div className="flex min-h-40 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+                    Pick a run to inspect candidates.
+                  </div>
+                ) : runItemsLoading ? (
+                  <div className="flex min-h-40 items-center justify-center">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline">{ruleName(data.rules, selectedRun.ruleId)}</Badge>
+                      <Badge className={cn("border", statusBadgeClass(selectedRun.status))}>
+                        {compactStatus(selectedRun.status)}
+                      </Badge>
+                    </div>
+                    <div className="max-h-[520px] overflow-auto rounded-md border">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Client</TableHead>
+                            <TableHead>Due</TableHead>
+                            <TableHead>Status</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {runItems.length === 0 ? (
+                            <TableRow>
+                              <TableCell colSpan={3} className="h-24 text-center text-sm text-muted-foreground">
+                                No candidates loaded.
+                              </TableCell>
+                            </TableRow>
+                          ) : (
+                            runItems.map((item) => (
+                              <TableRow key={item.id}>
+                                <TableCell>
+                                  <div className="font-medium">{item.clientName || "N/A"}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {item.loanAccountNo || item.loanId || "No loan reference"}
+                                  </div>
+                                </TableCell>
+                                <TableCell>
+                                  <div>{formatDate(item.dueDate)}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {item.daysPastDue ?? 0} days past due
+                                  </div>
+                                </TableCell>
+                                <TableCell>
+                                  <Badge className={cn("border", statusBadgeClass(item.status))}>
+                                    {compactStatus(item.status)}
+                                  </Badge>
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="messages" className="space-y-4">
+          <Card>
+            <CardHeader className="gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <MessageSquareText className="h-4 w-4" />
+                Notification Ledger
+              </CardTitle>
+              <div className="w-full lg:w-56">
+                <Select value={messageStatusFilter} onValueChange={(value) => handleMessageFilter(value as NotificationStatus | "ALL")}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ALL">All statuses</SelectItem>
+                    <SelectItem value="QUEUED">Queued</SelectItem>
+                    <SelectItem value="ACCEPTED">Accepted</SelectItem>
+                    <SelectItem value="SENT">Sent</SelectItem>
+                    <SelectItem value="FAILED">Failed</SelectItem>
+                    <SelectItem value="SUPPRESSED">Suppressed</SelectItem>
+                    <SelectItem value="SKIPPED">Skipped</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {pendingLabel === "messages" ? (
+                <div className="flex h-32 items-center justify-center">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : (
+                <MessagesTable messages={data.messages} rules={data.rules} />
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function RunsTable({
+  runs,
+  rules,
+  compact = false,
+  onSelectRun,
+}: {
+  runs: ReminderRunSummary[];
+  rules: ReminderRule[];
+  compact?: boolean;
+  onSelectRun: (run: ReminderRunSummary) => void;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Rule</TableHead>
+            {!compact && <TableHead>Slot</TableHead>}
+            <TableHead>Status</TableHead>
+            <TableHead>Progress</TableHead>
+            {!compact && <TableHead>Counts</TableHead>}
+            <TableHead className="text-right">Action</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {runs.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={compact ? 4 : 6} className="h-24 text-center text-sm text-muted-foreground">
+                No reminder runs yet.
+              </TableCell>
+            </TableRow>
+          ) : (
+            runs.map((run) => {
+              const progress = runProgress(run);
+              return (
+                <TableRow key={run.id}>
+                  <TableCell>
+                    <div className="font-medium">{ruleName(rules, run.ruleId)}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatReminderType(run.type)}
+                    </div>
+                  </TableCell>
+                  {!compact && (
+                    <TableCell>
+                      <div>{formatDateTime(run.slotStartAt)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        As of {formatDate(run.asOfDate)}
+                      </div>
+                    </TableCell>
+                  )}
+                  <TableCell>
+                    <Badge className={cn("border", statusBadgeClass(run.status))}>
+                      {compactStatus(run.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="min-w-36">
+                    <div className="flex items-center gap-2">
+                      <Progress value={progress} className="h-2" />
+                      <span className="w-10 text-right text-xs tabular-nums text-muted-foreground">
+                        {progress}%
+                      </span>
+                    </div>
+                  </TableCell>
+                  {!compact && (
+                    <TableCell className="text-sm tabular-nums">
+                      {run.processedCount}/{run.loadedCandidateCount || run.totalCandidateCount || 0}
+                      <div className="text-xs text-muted-foreground">
+                        {run.queuedCount} queued, {run.failedCount} failed
+                      </div>
+                    </TableCell>
+                  )}
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onSelectRun(run)}
+                    >
+                      Inspect
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function MessagesTable({
+  messages,
+  rules,
+}: {
+  messages: NotificationMessageSummary[];
+  rules: ReminderRule[];
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Recipient</TableHead>
+            <TableHead>Rule</TableHead>
+            <TableHead>Message</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Sent</TableHead>
+            <TableHead>Loan</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {messages.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                No notification messages found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            messages.map((message) => (
+              <TableRow key={message.id}>
+                <TableCell>
+                  <div className="font-medium">{message.recipient}</div>
+                  <div className="text-xs text-muted-foreground">{message.channel}</div>
+                </TableCell>
+                <TableCell>{ruleName(rules, message.reminderRuleId)}</TableCell>
+                <TableCell className="max-w-xl">
+                  <div className="line-clamp-2 text-sm">{message.body}</div>
+                  {message.errorMessage && (
+                    <div className="mt-1 text-xs text-red-600 dark:text-red-400">
+                      {message.errorMessage}
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Badge className={cn("border", statusBadgeClass(message.status))}>
+                    {compactStatus(message.status)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {formatDateTime(
+                    message.sentAt ||
+                      message.acceptedAt ||
+                      message.callbackReceivedAt ||
+                      message.createdAt
+                  )}
+                </TableCell>
+                <TableCell>
+                  {message.loanId && message.clientId ? (
+                    <Link
+                      href={`/clients/${message.clientId}/loans/${message.loanId}`}
+                      className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {message.loanAccountNo || message.loanId}
+                    </Link>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">N/A</span>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/app/actions/reminder-actions.ts
+++ b/app/actions/reminder-actions.ts
@@ -4,7 +4,10 @@ import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
 import { getTenantAndFineractInfo } from "@/lib/fineract-tenant-service";
 import type {
+  NotificationChannel,
+  NotificationMessagePage,
   NotificationMessageSummary,
+  NotificationSource,
   NotificationStatus,
   ReminderActionResult,
   ReminderDashboardData,
@@ -75,6 +78,17 @@ export type NotificationMessageFilters = {
   reminderRunId?: string;
   reminderRuleId?: string;
   limit?: number;
+};
+
+export type NotificationMessagePageFilters = {
+  page?: number;
+  size?: number;
+  status?: NotificationStatus;
+  source?: NotificationSource;
+  sourceType?: string;
+  channel?: NotificationChannel;
+  reminderRunId?: string;
+  reminderRuleId?: string;
 };
 
 function backendBaseUrl() {
@@ -245,6 +259,25 @@ export async function getNotificationMessagesAction(
       reminderRunId: filters.reminderRunId,
       reminderRuleId: filters.reminderRuleId,
       limit: filters.limit ?? 50,
+    })}`
+  );
+}
+
+export async function getNotificationMessagesPageAction(
+  filters: NotificationMessagePageFilters = {}
+): Promise<NotificationMessagePage> {
+  const context = await requireReminderContext();
+  return backendFetch<NotificationMessagePage>(
+    context,
+    `/api/v1/notifications/messages/page${queryString({
+      page: filters.page ?? 0,
+      size: filters.size ?? 25,
+      status: filters.status,
+      source: filters.source,
+      sourceType: filters.sourceType,
+      channel: filters.channel,
+      reminderRunId: filters.reminderRunId,
+      reminderRuleId: filters.reminderRuleId,
     })}`
   );
 }

--- a/app/actions/reminder-actions.ts
+++ b/app/actions/reminder-actions.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/shared/types/reminders";
 
 const REMINDERS_PATH = "/system/reminders";
+const TENANT_HEADER_NAME = "X-Tenant-Id";
 
 type ReminderContext = {
   tenantId: string;
@@ -121,7 +122,11 @@ async function readError(response: Response) {
   return text || `${response.status} ${response.statusText}`;
 }
 
-async function backendFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+async function backendFetch<T>(
+  context: ReminderContext,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
   const response = await fetch(`${backendBaseUrl()}${path}`, {
     ...init,
     cache: "no-store",
@@ -129,6 +134,7 @@ async function backendFetch<T>(path: string, init: RequestInit = {}): Promise<T>
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
       ...init.headers,
+      [TENANT_HEADER_NAME]: context.fineractTenantId,
     },
   });
 
@@ -167,23 +173,27 @@ function failure<T = unknown>(error: unknown): ReminderActionResult<T> {
 
 export async function getReminderDashboardAction(): Promise<ReminderDashboardData> {
   const context = await requireReminderContext();
-  const tenantId = context.tenantId;
 
   const [config, templates, rules, runs, messages] = await Promise.all([
     backendFetch<ReminderTenantConfig>(
-      `/api/v1/reminders/tenant-config/${encodeURIComponent(tenantId)}`
+      context,
+      "/api/v1/reminders/tenant-config"
     ),
     backendFetch<ReminderTemplate[]>(
-      `/api/v1/reminders/templates${queryString({ tenantId })}`
+      context,
+      "/api/v1/reminders/templates"
     ),
     backendFetch<ReminderRule[]>(
-      `/api/v1/reminders/rules${queryString({ tenantId })}`
+      context,
+      "/api/v1/reminders/rules"
     ),
     backendFetch<ReminderRunSummary[]>(
-      `/api/v1/reminders/runs${queryString({ tenantId, limit: 50 })}`
+      context,
+      `/api/v1/reminders/runs${queryString({ limit: 50 })}`
     ),
     backendFetch<NotificationMessageSummary[]>(
-      `/api/v1/notifications/messages${queryString({ tenantId, limit: 50 })}`
+      context,
+      `/api/v1/notifications/messages${queryString({ limit: 50 })}`
     ),
   ]);
 
@@ -200,10 +210,10 @@ export async function getReminderDashboardAction(): Promise<ReminderDashboardDat
 export async function getReminderRunsAction(
   filters: ReminderRunFilters = {}
 ): Promise<ReminderRunSummary[]> {
-  const { tenantId } = await requireReminderContext();
+  const context = await requireReminderContext();
   return backendFetch<ReminderRunSummary[]>(
+    context,
     `/api/v1/reminders/runs${queryString({
-      tenantId,
       status: filters.status,
       limit: filters.limit ?? 50,
     })}`
@@ -214,8 +224,9 @@ export async function getReminderRunItemsAction(
   runId: string,
   status?: ReminderRunItemStatus
 ): Promise<ReminderRunItem[]> {
-  await requireReminderContext();
+  const context = await requireReminderContext();
   return backendFetch<ReminderRunItem[]>(
+    context,
     `/api/v1/reminders/runs/${encodeURIComponent(runId)}/items${queryString({
       status,
     })}`
@@ -225,10 +236,10 @@ export async function getReminderRunItemsAction(
 export async function getNotificationMessagesAction(
   filters: NotificationMessageFilters = {}
 ): Promise<NotificationMessageSummary[]> {
-  const { tenantId } = await requireReminderContext();
+  const context = await requireReminderContext();
   return backendFetch<NotificationMessageSummary[]>(
+    context,
     `/api/v1/notifications/messages${queryString({
-      tenantId,
       status: filters.status,
       sourceType: filters.sourceType,
       reminderRunId: filters.reminderRunId,
@@ -242,9 +253,10 @@ export async function saveReminderTenantConfigAction(
   input: SaveReminderTenantConfigInput
 ): Promise<ReminderActionResult<ReminderTenantConfig>> {
   try {
-    const { tenantId } = await requireReminderContext();
+    const context = await requireReminderContext();
     const data = await backendFetch<ReminderTenantConfig>(
-      `/api/v1/reminders/tenant-config/${encodeURIComponent(tenantId)}`,
+      context,
+      "/api/v1/reminders/tenant-config",
       {
         method: "PUT",
         body: JSON.stringify({
@@ -265,9 +277,8 @@ export async function saveReminderTemplateAction(
   input: SaveReminderTemplateInput
 ): Promise<ReminderActionResult<ReminderTemplate>> {
   try {
-    const { tenantId } = await requireReminderContext();
+    const context = await requireReminderContext();
     const payload = {
-      tenantId,
       code: input.code.trim(),
       name: input.name.trim(),
       channel: input.channel,
@@ -277,6 +288,7 @@ export async function saveReminderTemplateAction(
     };
 
     const data = await backendFetch<ReminderTemplate>(
+      context,
       input.id
         ? `/api/v1/reminders/templates/${encodeURIComponent(input.id)}`
         : "/api/v1/reminders/templates",
@@ -296,9 +308,8 @@ export async function saveReminderRuleAction(
   input: SaveReminderRuleInput
 ): Promise<ReminderActionResult<ReminderRule>> {
   try {
-    const { tenantId } = await requireReminderContext();
+    const context = await requireReminderContext();
     const payload = {
-      tenantId,
       code: input.code.trim(),
       name: input.name.trim(),
       type: input.type,
@@ -318,6 +329,7 @@ export async function saveReminderRuleAction(
     };
 
     const data = await backendFetch<ReminderRule>(
+      context,
       input.id
         ? `/api/v1/reminders/rules/${encodeURIComponent(input.id)}`
         : "/api/v1/reminders/rules",

--- a/app/actions/reminder-actions.ts
+++ b/app/actions/reminder-actions.ts
@@ -1,0 +1,461 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import { getTenantAndFineractInfo } from "@/lib/fineract-tenant-service";
+import type {
+  NotificationMessageSummary,
+  NotificationStatus,
+  ReminderActionResult,
+  ReminderDashboardData,
+  ReminderRule,
+  ReminderRunItem,
+  ReminderRunItemStatus,
+  ReminderRunStatus,
+  ReminderRunSummary,
+  ReminderTemplate,
+  ReminderTenantConfig,
+  ReminderType,
+} from "@/shared/types/reminders";
+
+const REMINDERS_PATH = "/system/reminders";
+
+type ReminderContext = {
+  tenantId: string;
+  tenantName?: string | null;
+  tenantSlug?: string | null;
+  fineractTenantId: string;
+};
+
+export type SaveReminderTenantConfigInput = {
+  enabled: boolean;
+  timezone: string;
+  defaultCountryCode?: string | null;
+};
+
+export type SaveReminderTemplateInput = {
+  id?: string;
+  code: string;
+  name: string;
+  channel: "SMS" | "EMAIL";
+  subject?: string | null;
+  body: string;
+  active: boolean;
+};
+
+export type SaveReminderRuleInput = {
+  id?: string;
+  code: string;
+  name: string;
+  type: ReminderType;
+  enabled: boolean;
+  channels: string;
+  templateId?: string | null;
+  reportName?: string | null;
+  sendTime: string;
+  timezone?: string | null;
+  daysOffset: number;
+  lookBackDays: number;
+  lookAheadDays: number;
+  minDaysPastDue?: number | null;
+  maxDaysPastDue?: number | null;
+  cooldownMinutes: number;
+  pageLimit: number;
+};
+
+export type ReminderRunFilters = {
+  status?: ReminderRunStatus;
+  limit?: number;
+};
+
+export type NotificationMessageFilters = {
+  status?: NotificationStatus;
+  sourceType?: string;
+  reminderRunId?: string;
+  reminderRuleId?: string;
+  limit?: number;
+};
+
+function backendBaseUrl() {
+  const value = process.env.LOAN_MATRIX_BACKEND_URL?.trim();
+  if (!value) {
+    throw new Error("LOAN_MATRIX_BACKEND_URL is not configured");
+  }
+  return value.replace(/\/+$/, "");
+}
+
+async function requireReminderContext(): Promise<ReminderContext> {
+  const [session, tenantInfo] = await Promise.all([
+    getSession(),
+    getTenantAndFineractInfo(),
+  ]);
+
+  if (!session?.user) {
+    throw new Error("You must be signed in to manage reminders");
+  }
+
+  const tenant = tenantInfo.tenant;
+  const tenantId = tenantInfo.fineractTenantId;
+  if (!tenantId) {
+    throw new Error("Could not resolve tenant for reminders");
+  }
+
+  return {
+    tenantId,
+    tenantName: tenant?.name ?? null,
+    tenantSlug: tenant?.slug ?? null,
+    fineractTenantId: tenantId,
+  };
+}
+
+async function readError(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const data = await response.json().catch(() => null);
+    if (typeof data?.message === "string") return data.message;
+    if (typeof data?.error === "string") return data.error;
+    if (typeof data?.details === "string") return data.details;
+  }
+
+  const text = await response.text().catch(() => "");
+  return text || `${response.status} ${response.statusText}`;
+}
+
+async function backendFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${backendBaseUrl()}${path}`, {
+    ...init,
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function queryString(params: Record<string, string | number | undefined | null>) {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      query.set(key, String(value));
+    }
+  });
+  const value = query.toString();
+  return value ? `?${value}` : "";
+}
+
+function success<T>(data: T): ReminderActionResult<T> {
+  return { success: true, data };
+}
+
+function failure<T = unknown>(error: unknown): ReminderActionResult<T> {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : "Reminder action failed",
+  };
+}
+
+export async function getReminderDashboardAction(): Promise<ReminderDashboardData> {
+  const context = await requireReminderContext();
+  const tenantId = context.tenantId;
+
+  const [config, templates, rules, runs, messages] = await Promise.all([
+    backendFetch<ReminderTenantConfig>(
+      `/api/v1/reminders/tenant-config/${encodeURIComponent(tenantId)}`
+    ),
+    backendFetch<ReminderTemplate[]>(
+      `/api/v1/reminders/templates${queryString({ tenantId })}`
+    ),
+    backendFetch<ReminderRule[]>(
+      `/api/v1/reminders/rules${queryString({ tenantId })}`
+    ),
+    backendFetch<ReminderRunSummary[]>(
+      `/api/v1/reminders/runs${queryString({ tenantId, limit: 50 })}`
+    ),
+    backendFetch<NotificationMessageSummary[]>(
+      `/api/v1/notifications/messages${queryString({ tenantId, limit: 50 })}`
+    ),
+  ]);
+
+  return {
+    tenant: context,
+    config,
+    templates,
+    rules,
+    runs,
+    messages,
+  };
+}
+
+export async function getReminderRunsAction(
+  filters: ReminderRunFilters = {}
+): Promise<ReminderRunSummary[]> {
+  const { tenantId } = await requireReminderContext();
+  return backendFetch<ReminderRunSummary[]>(
+    `/api/v1/reminders/runs${queryString({
+      tenantId,
+      status: filters.status,
+      limit: filters.limit ?? 50,
+    })}`
+  );
+}
+
+export async function getReminderRunItemsAction(
+  runId: string,
+  status?: ReminderRunItemStatus
+): Promise<ReminderRunItem[]> {
+  await requireReminderContext();
+  return backendFetch<ReminderRunItem[]>(
+    `/api/v1/reminders/runs/${encodeURIComponent(runId)}/items${queryString({
+      status,
+    })}`
+  );
+}
+
+export async function getNotificationMessagesAction(
+  filters: NotificationMessageFilters = {}
+): Promise<NotificationMessageSummary[]> {
+  const { tenantId } = await requireReminderContext();
+  return backendFetch<NotificationMessageSummary[]>(
+    `/api/v1/notifications/messages${queryString({
+      tenantId,
+      status: filters.status,
+      sourceType: filters.sourceType,
+      reminderRunId: filters.reminderRunId,
+      reminderRuleId: filters.reminderRuleId,
+      limit: filters.limit ?? 50,
+    })}`
+  );
+}
+
+export async function saveReminderTenantConfigAction(
+  input: SaveReminderTenantConfigInput
+): Promise<ReminderActionResult<ReminderTenantConfig>> {
+  try {
+    const { tenantId } = await requireReminderContext();
+    const data = await backendFetch<ReminderTenantConfig>(
+      `/api/v1/reminders/tenant-config/${encodeURIComponent(tenantId)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          enabled: input.enabled,
+          timezone: input.timezone,
+          defaultCountryCode: input.defaultCountryCode,
+        }),
+      }
+    );
+    revalidatePath(REMINDERS_PATH);
+    return success(data);
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function saveReminderTemplateAction(
+  input: SaveReminderTemplateInput
+): Promise<ReminderActionResult<ReminderTemplate>> {
+  try {
+    const { tenantId } = await requireReminderContext();
+    const payload = {
+      tenantId,
+      code: input.code.trim(),
+      name: input.name.trim(),
+      channel: input.channel,
+      subject: input.subject?.trim() || null,
+      body: input.body.trim(),
+      active: input.active,
+    };
+
+    const data = await backendFetch<ReminderTemplate>(
+      input.id
+        ? `/api/v1/reminders/templates/${encodeURIComponent(input.id)}`
+        : "/api/v1/reminders/templates",
+      {
+        method: input.id ? "PUT" : "POST",
+        body: JSON.stringify(payload),
+      }
+    );
+    revalidatePath(REMINDERS_PATH);
+    return success(data);
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function saveReminderRuleAction(
+  input: SaveReminderRuleInput
+): Promise<ReminderActionResult<ReminderRule>> {
+  try {
+    const { tenantId } = await requireReminderContext();
+    const payload = {
+      tenantId,
+      code: input.code.trim(),
+      name: input.name.trim(),
+      type: input.type,
+      enabled: input.enabled,
+      channels: input.channels || "SMS",
+      templateId: input.templateId || null,
+      reportName: input.reportName?.trim() || null,
+      sendTime: input.sendTime,
+      timezone: input.timezone?.trim() || null,
+      daysOffset: input.daysOffset,
+      lookBackDays: input.lookBackDays,
+      lookAheadDays: input.lookAheadDays,
+      minDaysPastDue: input.minDaysPastDue ?? null,
+      maxDaysPastDue: input.maxDaysPastDue ?? null,
+      cooldownMinutes: input.cooldownMinutes,
+      pageLimit: input.pageLimit,
+    };
+
+    const data = await backendFetch<ReminderRule>(
+      input.id
+        ? `/api/v1/reminders/rules/${encodeURIComponent(input.id)}`
+        : "/api/v1/reminders/rules",
+      {
+        method: input.id ? "PUT" : "POST",
+        body: JSON.stringify(payload),
+      }
+    );
+    revalidatePath(REMINDERS_PATH);
+    return success(data);
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function ensureDefaultReminderSetupAction(): Promise<
+  ReminderActionResult<ReminderDashboardData>
+> {
+  try {
+    const dashboard = await getReminderDashboardAction();
+    const templatesByCode = new Map(
+      dashboard.templates.map((template) => [template.code, template])
+    );
+    const rulesByCode = new Map(dashboard.rules.map((rule) => [rule.code, rule]));
+
+    let repaymentTemplate = templatesByCode.get("repayment_due_sms");
+    if (!repaymentTemplate) {
+      const result = await saveReminderTemplateAction({
+        code: "repayment_due_sms",
+        name: "Repayment Due SMS",
+        channel: "SMS",
+        subject: null,
+        body:
+          "Dear {{clientName}}, your loan {{loanAccountNo}} repayment of {{amountDue}} is due on {{dueDate}}. Please pay on time.",
+        active: true,
+      });
+      if (!result.success || !result.data) throw new Error(result.error);
+      repaymentTemplate = result.data;
+    }
+
+    let recoveryTemplate = templatesByCode.get("recovery_arrears_sms");
+    if (!recoveryTemplate) {
+      const result = await saveReminderTemplateAction({
+        code: "recovery_arrears_sms",
+        name: "Recovery Arrears SMS",
+        channel: "SMS",
+        subject: null,
+        body:
+          "Dear {{clientName}}, your loan {{loanAccountNo}} is {{daysPastDue}} days overdue. Amount due: {{amountDue}}. Please contact us to regularise your account.",
+        active: true,
+      });
+      if (!result.success || !result.data) throw new Error(result.error);
+      recoveryTemplate = result.data;
+    }
+
+    const defaultRules: SaveReminderRuleInput[] = [
+      {
+        code: "repayment_due_today",
+        name: "Repayment Due Today",
+        type: "LOAN_REPAYMENT_DUE",
+        enabled: true,
+        channels: "SMS",
+        templateId: repaymentTemplate.id,
+        reportName: "LM Reminder Repayment Candidates",
+        sendTime: "09:00",
+        timezone: dashboard.config.timezone || "Africa/Harare",
+        daysOffset: 0,
+        lookBackDays: 0,
+        lookAheadDays: 0,
+        cooldownMinutes: 1440,
+        pageLimit: 100,
+      },
+      {
+        code: "recovery_30_days",
+        name: "Recovery 30-59 Days",
+        type: "RECOVERY_ARREARS",
+        enabled: true,
+        channels: "SMS",
+        templateId: recoveryTemplate.id,
+        reportName: "LM Reminder Recovery Candidates",
+        sendTime: "10:00",
+        timezone: dashboard.config.timezone || "Africa/Harare",
+        daysOffset: 0,
+        lookBackDays: 0,
+        lookAheadDays: 0,
+        minDaysPastDue: 30,
+        maxDaysPastDue: 59,
+        cooldownMinutes: 1440,
+        pageLimit: 100,
+      },
+      {
+        code: "recovery_60_days",
+        name: "Recovery 60-89 Days",
+        type: "RECOVERY_ARREARS",
+        enabled: true,
+        channels: "SMS",
+        templateId: recoveryTemplate.id,
+        reportName: "LM Reminder Recovery Candidates",
+        sendTime: "10:30",
+        timezone: dashboard.config.timezone || "Africa/Harare",
+        daysOffset: 0,
+        lookBackDays: 0,
+        lookAheadDays: 0,
+        minDaysPastDue: 60,
+        maxDaysPastDue: 89,
+        cooldownMinutes: 1440,
+        pageLimit: 100,
+      },
+      {
+        code: "recovery_90_plus",
+        name: "Recovery 90+ Days",
+        type: "RECOVERY_ARREARS",
+        enabled: true,
+        channels: "SMS",
+        templateId: recoveryTemplate.id,
+        reportName: "LM Reminder Recovery Candidates",
+        sendTime: "11:00",
+        timezone: dashboard.config.timezone || "Africa/Harare",
+        daysOffset: 0,
+        lookBackDays: 0,
+        lookAheadDays: 0,
+        minDaysPastDue: 90,
+        maxDaysPastDue: null,
+        cooldownMinutes: 1440,
+        pageLimit: 100,
+      },
+    ];
+
+    for (const rule of defaultRules) {
+      if (!rulesByCode.has(rule.code)) {
+        const result = await saveReminderRuleAction(rule);
+        if (!result.success) throw new Error(result.error);
+      }
+    }
+
+    revalidatePath(REMINDERS_PATH);
+    return success(await getReminderDashboardAction());
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/env.example
+++ b/env.example
@@ -36,6 +36,7 @@ NODE_ENV=development
 
 # Notifications Service Configuration
 NOTIFICATION_SERVICE_URL=http://kenac-notification-service-dev.10.10.0.24.nip.io:31778
+LOAN_MATRIX_BACKEND_URL=http://loan-matrix-be-uat.10.10.0.24.nip.io
 TENANT_ID=goodfellow
 EMAIL_NOTIFICATION_SERVICE_URL=
 EMAIL_NOTIFICATION_SERVICE_PATH=/api/v1/notifications/email

--- a/shared/types/reminders.ts
+++ b/shared/types/reminders.ts
@@ -152,6 +152,16 @@ export interface NotificationMessageSummary {
   updatedAt?: string;
 }
 
+export interface NotificationMessagePage {
+  content: NotificationMessageSummary[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
 export interface ReminderTenantContext {
   tenantId: string;
   tenantName?: string | null;

--- a/shared/types/reminders.ts
+++ b/shared/types/reminders.ts
@@ -1,0 +1,175 @@
+export type NotificationChannel = "SMS" | "EMAIL";
+export type NotificationSource = "REMINDER" | "RECOVERY" | "REPAYMENT_RECEIPT";
+export type NotificationStatus =
+  | "QUEUED"
+  | "ACCEPTED"
+  | "SENT"
+  | "FAILED"
+  | "SUPPRESSED"
+  | "SKIPPED";
+
+export type ReminderType = "LOAN_REPAYMENT_DUE" | "RECOVERY_ARREARS";
+export type ReminderRunStatus =
+  | "CREATED"
+  | "SCANNING_CANDIDATES"
+  | "CANDIDATES_LOADED"
+  | "PROCESSING_REMINDERS"
+  | "COMPLETED"
+  | "FAILED";
+
+export type ReminderRunItemStatus =
+  | "PICKED"
+  | "PROCESSING"
+  | "QUEUED"
+  | "SUPPRESSED"
+  | "FAILED";
+
+export interface ReminderTenantConfig {
+  id?: string;
+  tenantId: string;
+  enabled: boolean;
+  timezone: string;
+  defaultCountryCode?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReminderTemplate {
+  id?: string;
+  tenantId: string;
+  code: string;
+  name: string;
+  channel: NotificationChannel;
+  subject?: string | null;
+  body: string;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReminderRule {
+  id?: string;
+  tenantId: string;
+  code: string;
+  name: string;
+  type: ReminderType;
+  enabled: boolean;
+  channels: string;
+  templateId?: string | null;
+  reportName?: string | null;
+  sendTime: string;
+  timezone?: string | null;
+  daysOffset: number;
+  lookBackDays: number;
+  lookAheadDays: number;
+  minDaysPastDue?: number | null;
+  maxDaysPastDue?: number | null;
+  cooldownMinutes: number;
+  pageLimit: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReminderRunSummary {
+  id: string;
+  tenantId: string;
+  ruleId: string;
+  idempotencyKey: string;
+  type: ReminderType;
+  status: ReminderRunStatus;
+  slotStartAt: string;
+  asOfDate: string;
+  pageLimit: number;
+  pageOffset: number;
+  hasMore: boolean;
+  totalCandidateCount: number;
+  loadedCandidateCount: number;
+  pickedCount: number;
+  processedCount: number;
+  queuedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  startedAt?: string | null;
+  scanStartedAt?: string | null;
+  scanCompletedAt?: string | null;
+  processingStartedAt?: string | null;
+  finishedAt?: string | null;
+  lockedBy?: string | null;
+  lockedUntil?: string | null;
+  lastError?: string | null;
+}
+
+export interface ReminderRunItem {
+  id: string;
+  runId: string;
+  tenantId: string;
+  ruleId: string;
+  candidateKey: string;
+  globalDedupeKey: string;
+  loanId?: number | null;
+  clientId?: number | null;
+  loanAccountNo?: string | null;
+  clientName?: string | null;
+  recipientPhone?: string | null;
+  dueDate?: string | null;
+  amountDue?: number | string | null;
+  daysPastDue?: number | null;
+  status: ReminderRunItemStatus;
+  skipReason?: string | null;
+  errorMessage?: string | null;
+  notificationMessageId?: string | null;
+  rawCandidatePayload?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface NotificationMessageSummary {
+  id: string;
+  tenantId: string;
+  messageId: string;
+  source: NotificationSource;
+  sourceType: string;
+  channel: NotificationChannel;
+  recipient: string;
+  subject?: string | null;
+  body: string;
+  status: NotificationStatus;
+  templateId?: string | null;
+  reminderRuleId?: string | null;
+  reminderRunId?: string | null;
+  reminderRunItemId?: string | null;
+  loanId?: number | null;
+  clientId?: number | null;
+  loanAccountNo?: string | null;
+  dueDate?: string | null;
+  scheduledFor?: string | null;
+  acceptedAt?: string | null;
+  sentAt?: string | null;
+  failedAt?: string | null;
+  callbackReceivedAt?: string | null;
+  errorMessage?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReminderTenantContext {
+  tenantId: string;
+  tenantName?: string | null;
+  tenantSlug?: string | null;
+  fineractTenantId: string;
+}
+
+export interface ReminderDashboardData {
+  tenant: ReminderTenantContext;
+  config: ReminderTenantConfig;
+  rules: ReminderRule[];
+  templates: ReminderTemplate[];
+  runs: ReminderRunSummary[];
+  messages: NotificationMessageSummary[];
+}
+
+export interface ReminderActionResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

- Add a central `/system/reminders` UI for tenant settings, rules, templates, run progress, run items, and notification history.
- Add a separate `/system/notifications` page with paginated notification delivery history from `loan-matrix-be`.
- Route reminder and notification management through Server Actions backed by `LOAN_MATRIX_BACKEND_URL`, and move recovery reminder actions to the central reminders page.
- Send `X-Tenant-Id` with every reminder/notification backend request; tenant is no longer sent as a reminder query/path/body value.

## Validation

- `npx eslint app/actions/reminder-actions.ts app/(application)/system/reminders/page.tsx app/(application)/system/reminders/loading.tsx app/(application)/system/reminders/reminders-client.tsx app/(application)/system/notifications/page.tsx app/(application)/system/notifications/loading.tsx app/(application)/system/notifications/notifications-client.tsx app/(application)/components/sidebar-nav.tsx app/(application)/loans/recoveries/recoveries-dashboard.tsx shared/types/reminders.ts`
- `npx tsc --noEmit --pretty false` remains blocked by existing unrelated TypeScript errors outside the reminder/notification page files; touched files are clean when filtered.
