### PR TITLE
Decouple cashier auto-resolution from exemption; restore session gate

### DIFF
--- a/app/(application)/clients/[id]/loans/[loanId]/components/repayment-modal.tsx
+++ b/app/(application)/clients/[id]/loans/[loanId]/components/repayment-modal.tsx
@@ -83,7 +83,8 @@ interface CurrentCashierContext {
   tellerId: string | null;
   tellerName: string | null;
   tellerOfficeName: string | null;
-  autoResolveApplicable: boolean;
+  tenantFeatureEnabled: boolean;
+  paymentTypeLockedToCash: boolean;
   reason?: string;
 }
 
@@ -289,20 +290,21 @@ export function RepaymentModal({
     return !!option?.isCashPayment;
   }, [formData.paymentTypeId, mergedPaymentTypeOptions]);
 
+  // Gated ONLY by the tenant flag — applies to every user once it's on,
+  // regardless of their exemption setting. Exemption only affects which
+  // payment types are selectable (see paymentTypeLockedToCash below).
   const autoResolveDecision = useMemo(
     () =>
       resolveRepaymentCashierAutoResolveDecision({
-        autoResolveApplicable: currentCashierContext?.autoResolveApplicable ?? false,
+        tenantFeatureEnabled: currentCashierContext?.tenantFeatureEnabled ?? false,
         isCashier: currentCashierContext?.isCashier ?? false,
+        hasActiveSession: currentCashierContext?.hasActiveSession ?? false,
       }),
     [currentCashierContext]
   );
 
-  // Non-exempt users under tenant policy are restricted to cash only, whether
-  // or not they turn out to be a resolvable cashier.
   const paymentTypeLockedToCash =
-    autoResolveDecision.mode === "auto-resolved" ||
-    autoResolveDecision.mode === "blocked";
+    currentCashierContext?.paymentTypeLockedToCash ?? false;
 
   const visiblePaymentTypeOptions = useMemo(() => {
     if (!paymentTypeLockedToCash) return mergedPaymentTypeOptions;
@@ -353,10 +355,10 @@ export function RepaymentModal({
       setSubmitting(true);
       setError(null);
 
-      if (autoResolveDecision.mode === "blocked") {
+      if (selectedPaymentTypeIsCash && autoResolveDecision.mode === "blocked") {
         setError(
           currentCashierContext?.reason ||
-            "You are not linked to a cashier account. Contact your supervisor or system administrator."
+            "Your cashier session is not active. Start a session before processing repayments."
         );
         return;
       }
@@ -731,35 +733,27 @@ export function RepaymentModal({
                   )}
                 </SelectContent>
               </Select>
-              {paymentTypeLockedToCash ? (
-                <p className="text-xs text-muted-foreground">
-                  Payment type is locked to cash by tenant policy.
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Required. Select a cash payment method to update the teller balance.
-                </p>
-              )}
+              <p className="text-xs text-muted-foreground">
+                Required. Select a cash payment method to update the teller balance.
+              </p>
             </div>
 
             {/* Teller and Cashier (for cash payments): auto-resolved from the
-                logged in user's cashier session, blocked entirely if the user
-                isn't linked to a cashier, or manual pickers otherwise */}
-            {autoResolveDecision.mode === "blocked" ? (
-              <div className="rounded-lg border-2 border-destructive bg-destructive/10 p-4 space-y-2">
-                <div className="flex items-center gap-2">
-                  <AlertCircle className="h-5 w-5 text-destructive shrink-0" />
-                  <span className="text-sm font-semibold text-destructive">
-                    Action Required: Cashier Link Missing
-                  </span>
+                logged in user's cashier session, blocked entirely if their
+                session isn't active, or manual pickers otherwise */}
+            {selectedPaymentTypeIsCash && autoResolveDecision.mode === "blocked" ? (
+              <div className="rounded-lg border-2 border-destructive bg-destructive/10 p-4 flex items-start gap-2">
+                <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-destructive">
+                    No active cashier session
+                  </p>
+                  <p className="text-sm text-destructive/90">
+                    {currentCashierContext?.reason ||
+                      "Your cashier session is not active."}{" "}
+                    Start a session to process cash repayments.
+                  </p>
                 </div>
-                <p className="text-sm text-destructive/90">
-                  {currentCashierContext?.reason ||
-                    "You are not linked to a cashier account."}{" "}
-                  Cash repayments require an active cashier link under tenant
-                  policy — contact your supervisor or system administrator to
-                  resolve this before processing repayments.
-                </p>
               </div>
             ) : selectedPaymentTypeIsCash && autoResolveDecision.mode === "auto-resolved" ? (
               <div className="rounded-lg border border-green-200 bg-green-50/60 dark:border-green-800 dark:bg-green-950/30 p-4 space-y-2">
@@ -786,19 +780,14 @@ export function RepaymentModal({
                 </div>
                 <div className="flex justify-between gap-3 text-sm">
                   <span className="text-muted-foreground">Session</span>
-                  <span
-                    className={
-                      currentCashierContext?.hasActiveSession
-                        ? "font-medium text-green-700 dark:text-green-400"
-                        : "font-medium text-amber-600 dark:text-amber-400"
-                    }
-                  >
-                    {currentCashierContext?.hasActiveSession ? "Active" : "Not Active"}
+                  <span className="font-medium text-green-700 dark:text-green-400">
+                    Active
                   </span>
                 </div>
               </div>
             ) : (
-              selectedPaymentTypeIsCash && (
+              selectedPaymentTypeIsCash &&
+              autoResolveDecision.mode === "manual" && (
                 <div className="space-y-4 p-4 border rounded-lg bg-muted/30">
                   <Label className="text-sm font-medium">
                     Cash till location (required for teller balance)
@@ -1000,7 +989,7 @@ export function RepaymentModal({
             onClick={handleSubmit}
             disabled={
               submitting ||
-              autoResolveDecision.mode === "blocked" ||
+              (selectedPaymentTypeIsCash && autoResolveDecision.mode === "blocked") ||
               !formData.transactionDate ||
               !formData.transactionAmount ||
               !formData.paymentTypeId ||

--- a/app/api/auth/current-cashier/route.ts
+++ b/app/api/auth/current-cashier/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { getSession } from "@/lib/auth";
 import { resolveCurrentUserCashierContext } from "@/lib/current-user-cashier";
-import { isAutoResolveApplicableForUser } from "@/lib/repayment-cashier-auto-resolve-policy";
+import { isPaymentTypeLockedToCashForUser } from "@/lib/repayment-cashier-auto-resolve-policy";
 import { isUserExemptFromAutoCashierResolution } from "@/lib/repayment-cashier-auto-resolve-access";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { getTenantFeatures } from "@/shared/types/tenant";
@@ -33,12 +33,17 @@ export async function GET() {
       isUserExemptFromAutoCashierResolution(tenant.id, session.user.userId),
     ]);
 
-    const autoResolveApplicable = isAutoResolveApplicableForUser({
-      tenantFeatureEnabled: getTenantFeatures(tenant).autoResolveRepaymentCashier,
+    const tenantFeatureEnabled = getTenantFeatures(tenant).autoResolveRepaymentCashier;
+    const paymentTypeLockedToCash = isPaymentTypeLockedToCashForUser({
+      tenantFeatureEnabled,
       userExempt,
     });
 
-    return NextResponse.json({ ...context, autoResolveApplicable });
+    return NextResponse.json({
+      ...context,
+      tenantFeatureEnabled,
+      paymentTypeLockedToCash,
+    });
   } catch (error) {
     console.error("Error resolving current cashier context:", error);
     return NextResponse.json(

--- a/lib/repayment-cashier-auto-resolve-policy.test.ts
+++ b/lib/repayment-cashier-auto-resolve-policy.test.ts
@@ -1,82 +1,90 @@
 import assert from "node:assert/strict";
 import {
-  isAutoResolveApplicableForUser,
+  isPaymentTypeLockedToCashForUser,
   resolveRepaymentCashierAutoResolveDecision,
 } from "./repayment-cashier-auto-resolve-policy";
 
 function run() {
-  // isAutoResolveApplicableForUser
+  // isPaymentTypeLockedToCashForUser: only gates which payment types are
+  // selectable. It must NOT affect whether teller/cashier get auto-resolved.
   assert.equal(
-    isAutoResolveApplicableForUser({
+    isPaymentTypeLockedToCashForUser({
       tenantFeatureEnabled: true,
       userExempt: false,
     }),
     true,
-    "applicable when tenant feature is on and user is not exempt"
+    "locked to cash when tenant feature is on and user is not exempt"
   );
 
   assert.equal(
-    isAutoResolveApplicableForUser({
-      tenantFeatureEnabled: false,
-      userExempt: false,
-    }),
-    false,
-    "not applicable when tenant feature is off, regardless of exemption"
-  );
-
-  assert.equal(
-    isAutoResolveApplicableForUser({
+    isPaymentTypeLockedToCashForUser({
       tenantFeatureEnabled: true,
       userExempt: true,
     }),
     false,
-    "not applicable when user is exempt, even if tenant feature is on"
+    "not locked (free choice of payment methods) when user is exempt, even if tenant feature is on"
   );
 
   assert.equal(
-    isAutoResolveApplicableForUser({
+    isPaymentTypeLockedToCashForUser({
+      tenantFeatureEnabled: false,
+      userExempt: false,
+    }),
+    false,
+    "not locked when tenant feature is off"
+  );
+
+  assert.equal(
+    isPaymentTypeLockedToCashForUser({
       tenantFeatureEnabled: false,
       userExempt: true,
     }),
     false,
-    "not applicable when both tenant feature is off and user is exempt"
+    "not locked when tenant feature is off, regardless of exemption"
   );
 
-  // resolveRepaymentCashierAutoResolveDecision
+  // resolveRepaymentCashierAutoResolveDecision: gated ONLY by the tenant
+  // feature flag. Exemption must have no bearing here — auto-resolution
+  // (or blocking) of teller/cashier applies to every user once the tenant
+  // flag is on, exempt or not.
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
-      autoResolveApplicable: false,
+      tenantFeatureEnabled: false,
       isCashier: true,
+      hasActiveSession: true,
     }),
     { mode: "manual" },
-    "falls back to manual pickers when not applicable, even for a cashier"
+    "manual pickers when the tenant feature is off"
   );
 
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
-      autoResolveApplicable: false,
-      isCashier: false,
-    }),
-    { mode: "manual" },
-    "falls back to manual pickers when not applicable, for a non-cashier too"
-  );
-
-  assert.deepEqual(
-    resolveRepaymentCashierAutoResolveDecision({
-      autoResolveApplicable: true,
+      tenantFeatureEnabled: true,
       isCashier: true,
+      hasActiveSession: true,
     }),
     { mode: "auto-resolved" },
-    "auto-resolves and locks to cash when applicable and the user is a cashier"
+    "auto-resolves when the tenant feature is on, user is a cashier, and their session is active"
   );
 
   assert.deepEqual(
     resolveRepaymentCashierAutoResolveDecision({
-      autoResolveApplicable: true,
-      isCashier: false,
+      tenantFeatureEnabled: true,
+      isCashier: true,
+      hasActiveSession: false,
     }),
     { mode: "blocked" },
-    "blocks repayment submission entirely when applicable but the user is not a cashier at all"
+    "blocks when the tenant feature is on and the cashier's session is not active"
+  );
+
+  assert.deepEqual(
+    resolveRepaymentCashierAutoResolveDecision({
+      tenantFeatureEnabled: true,
+      isCashier: false,
+      hasActiveSession: false,
+    }),
+    { mode: "blocked" },
+    "blocks when the tenant feature is on and the user is not a cashier at all"
   );
 }
 

--- a/lib/repayment-cashier-auto-resolve-policy.ts
+++ b/lib/repayment-cashier-auto-resolve-policy.ts
@@ -1,17 +1,23 @@
-export interface RepaymentCashierAutoResolveGateInput {
+export interface PaymentTypeLockGateInput {
   tenantFeatureEnabled: boolean;
   userExempt: boolean;
 }
 
-export function isAutoResolveApplicableForUser(
-  input: RepaymentCashierAutoResolveGateInput
+/**
+ * Whether this user's payment type choice should be locked to cash only.
+ * This gates payment-method visibility ONLY — it has no bearing on whether
+ * teller/cashier get auto-resolved (see resolveRepaymentCashierAutoResolveDecision).
+ */
+export function isPaymentTypeLockedToCashForUser(
+  input: PaymentTypeLockGateInput
 ): boolean {
   return input.tenantFeatureEnabled && !input.userExempt;
 }
 
 export interface RepaymentCashierAutoResolveDecisionInput {
-  autoResolveApplicable: boolean;
+  tenantFeatureEnabled: boolean;
   isCashier: boolean;
+  hasActiveSession: boolean;
 }
 
 export type RepaymentCashierAutoResolveDecision =
@@ -19,13 +25,18 @@ export type RepaymentCashierAutoResolveDecision =
   | { mode: "auto-resolved" }
   | { mode: "blocked" };
 
+/**
+ * Whether a cash repayment's teller/cashier should be auto-resolved,
+ * blocked, or left to manual selection. Gated ONLY by the tenant feature
+ * flag — applies to every user once the tenant has it on, exempt or not.
+ */
 export function resolveRepaymentCashierAutoResolveDecision(
   input: RepaymentCashierAutoResolveDecisionInput
 ): RepaymentCashierAutoResolveDecision {
-  if (!input.autoResolveApplicable) {
+  if (!input.tenantFeatureEnabled) {
     return { mode: "manual" };
   }
-  if (input.isCashier) {
+  if (input.isCashier && input.hasActiveSession) {
     return { mode: "auto-resolved" };
   }
   return { mode: "blocked" };


### PR DESCRIPTION
## Summary
Follow-up correction to #546 after further review of the requirement:

- **Teller/cashier auto-resolution for cash repayments now applies to every user once the tenant flag (`autoResolveRepaymentCashier`) is on, regardless of their exemption setting.** Previously exemption also disabled auto-resolution; now it only controls which payment methods are selectable.
- **Exemption's only remaining effect**: locks the payment-type dropdown to cash-only for non-exempt users, while exempt users can pick any payment method.
- **Session activeness is checked again.** A user linked to a cashier account but without an active session is now blocked from submitting a cash repayment, same as a user with no cashier link at all. This had been intentionally left out in an earlier iteration; it's back in per updated direction.
- Simplified the blocking alert copy to foreground "no active cashier session" rather than "cashier link missing" (the latter is an implicit, rarer case still surfaced via the existing `reason` text).
- Removed the "Payment type is locked to cash by tenant policy." helper line.
- All three teller/cashier UI states (blocked / auto-resolved / manual-picker fallback) are now correctly gated on `selectedPaymentTypeIsCash`, so an exempt user who picks a non-cash method never sees any cashier-related UI or blocking.

## Test plan
- [x] `npx tsx lib/repayment-cashier-auto-resolve-policy.test.ts` — passes (TDD'd: decision logic now takes `tenantFeatureEnabled` directly instead of an exemption-gated `autoResolveApplicable`, and rechecks `hasActiveSession`)
- [x] `npx tsx shared/types/tenant.test.ts` — passes
- [x] Full project typecheck and existing `.test.ts` suite show no new errors/failures (same pre-existing unrelated failures as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)