### PR TITLE
Add maker-checker authorization: Checker Inbox & Tasks

### DIFF
--- a/app/(application)/checker-inbox/[id]/loading.tsx
+++ b/app/(application)/checker-inbox/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "../../system/components/system-skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/app/(application)/checker-inbox/[id]/page.tsx
+++ b/app/(application)/checker-inbox/[id]/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { AlertCircle, ArrowLeft } from "lucide-react";
+import { getAuditTrailAction } from "@/app/actions/system-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CheckerInboxDetailActions } from "../components/checker-inbox-detail-actions";
+import {
+  formatFineractDate,
+  formatSystemLabel,
+} from "../../system/components/system-helpers";
+import type { AuditTrail } from "@/shared/types/system";
+
+type CheckerInboxDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+function prettyJson(value?: string) {
+  if (!value) return "N/A";
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}
+
+export default async function CheckerInboxDetailPage({
+  params,
+}: CheckerInboxDetailPageProps) {
+  const { id } = await params;
+  const auditId = Number(id);
+  if (!Number.isFinite(auditId)) notFound();
+
+  let audit: AuditTrail | null = null;
+  let loadError: string | null = null;
+
+  try {
+    audit = await getAuditTrailAction(auditId);
+  } catch (error) {
+    loadError =
+      error instanceof Error ? error.message : "Failed to load entry";
+  }
+
+  if (loadError) {
+    return (
+      <div className="space-y-6">
+        <Button asChild variant="outline" className="w-fit">
+          <Link href="/checker-inbox">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Checker Inbox
+          </Link>
+        </Button>
+
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{loadError}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!audit?.id) notFound();
+
+  const isAwaitingApproval = (audit.processingResult ?? "")
+    .toLowerCase()
+    .includes("awaiting");
+
+  const detailRows = [
+    ["Action", formatSystemLabel(audit.actionName)],
+    ["Entity", formatSystemLabel(audit.entityName)],
+    ["Resource ID", String(audit.resourceId ?? "N/A")],
+    ["Processing Result", formatSystemLabel(audit.processingResult)],
+    ["Maker", audit.maker || "N/A"],
+    ["Made On", formatFineractDate(audit.madeOnDate)],
+    ["Office", audit.officeName || "N/A"],
+    ["Client", audit.clientName || "N/A"],
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Button asChild variant="outline" className="w-fit">
+        <Link href="/checker-inbox">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Checker Inbox
+        </Link>
+      </Button>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Checker Entry #{audit.id}
+          </h1>
+          <Badge variant="outline">
+            {formatSystemLabel(audit.processingResult)}
+          </Badge>
+        </div>
+
+        {isAwaitingApproval && (
+          <CheckerInboxDetailActions auditId={audit.id} />
+        )}
+      </div>
+
+      <Card className="rounded-lg">
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {detailRows.map(([label, value]) => (
+              <div key={label} className="rounded-md border p-3">
+                <dt className="text-xs font-medium uppercase text-muted-foreground">
+                  {label}
+                </dt>
+                <dd className="mt-1 break-words text-sm">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-lg">
+        <CardHeader>
+          <CardTitle>Command JSON</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="max-h-[520px] overflow-auto rounded-md bg-muted p-4 text-xs leading-5">
+            {prettyJson(audit.commandAsJson)}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(application)/checker-inbox/components/checker-inbox-client.tsx
+++ b/app/(application)/checker-inbox/components/checker-inbox-client.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { Check, Loader2, RotateCcw, Trash2, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  approveMakerCheckerEntryAction,
+  deleteMakerCheckerEntryAction,
+  listMakerCheckerEntriesAction,
+  rejectMakerCheckerEntryAction,
+} from "@/app/actions/system-actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SearchableSelect, type Option } from "@/components/searchable-select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  AuditTrail,
+  AuditTrailSearchTemplate,
+  MakerCheckerSearchInput,
+} from "@/shared/types/system";
+import {
+  formatFineractDate,
+  formatSystemLabel,
+} from "../../system/components/system-helpers";
+
+type CheckerInboxClientProps = {
+  template: AuditTrailSearchTemplate;
+  initialEntries: AuditTrail[];
+};
+
+const allValue = "__all";
+
+type FilterForm = {
+  actionName: string;
+  entityName: string;
+  resourceId: string;
+  makerDateTimeFrom: string;
+  makerDateTimeTo: string;
+};
+
+const emptyFilters: FilterForm = {
+  actionName: allValue,
+  entityName: allValue,
+  resourceId: "",
+  makerDateTimeFrom: "",
+  makerDateTimeTo: "",
+};
+
+function toSearchInput(filters: FilterForm): MakerCheckerSearchInput {
+  return {
+    actionName: filters.actionName === allValue ? undefined : filters.actionName,
+    entityName: filters.entityName === allValue ? undefined : filters.entityName,
+    resourceId: filters.resourceId.trim() || undefined,
+    makerDateTimeFrom: filters.makerDateTimeFrom || undefined,
+    makerDateTimeTo: filters.makerDateTimeTo || undefined,
+  };
+}
+
+type BulkAction = "approve" | "reject" | "delete" | null;
+
+export function CheckerInboxClient({
+  template,
+  initialEntries,
+}: CheckerInboxClientProps) {
+  const [entries, setEntries] = useState(initialEntries);
+  const [filters, setFilters] = useState(emptyFilters);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [isSearching, setIsSearching] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<BulkAction>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const actionOptions = useMemo<Option[]>(
+    () => [
+      { value: allValue, label: "All actions" },
+      ...template.actionNames.map((actionName) => ({
+        value: actionName,
+        label: formatSystemLabel(actionName),
+      })),
+    ],
+    [template.actionNames]
+  );
+  const entityOptions = useMemo<Option[]>(
+    () => [
+      { value: allValue, label: "All entities" },
+      ...template.entityNames.map((entityName) => ({
+        value: entityName,
+        label: formatSystemLabel(entityName),
+      })),
+    ],
+    [template.entityNames]
+  );
+
+  const allSelected = entries.length > 0 && selected.size === entries.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(entries.map((e) => e.id)));
+  }
+
+  function toggleOne(id: number) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  async function runSearch() {
+    setIsSearching(true);
+    try {
+      const next = await listMakerCheckerEntriesAction(
+        toSearchInput(filters)
+      );
+      setEntries(next);
+      setSelected(new Set());
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to search entries"
+      );
+    } finally {
+      setIsSearching(false);
+    }
+  }
+
+  async function resetFilters() {
+    setFilters(emptyFilters);
+    setIsSearching(true);
+    try {
+      const next = await listMakerCheckerEntriesAction();
+      setEntries(next);
+      setSelected(new Set());
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to reset entries"
+      );
+    } finally {
+      setIsSearching(false);
+    }
+  }
+
+  function refresh() {
+    startTransition(async () => {
+      try {
+        const next = await listMakerCheckerEntriesAction(
+          toSearchInput(filters)
+        );
+        setEntries(next);
+        setSelected(new Set());
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to refresh entries"
+        );
+      }
+    });
+  }
+
+  function runBulkAction() {
+    const action = confirmAction;
+    if (!action) return;
+    setConfirmAction(null);
+
+    const ids = Array.from(selected);
+    const actionFn =
+      action === "approve"
+        ? approveMakerCheckerEntryAction
+        : action === "reject"
+          ? rejectMakerCheckerEntryAction
+          : deleteMakerCheckerEntryAction;
+
+    startTransition(async () => {
+      const results = await Promise.all(ids.map((id) => actionFn(id)));
+      const failures = results.filter((result) => !result.success);
+
+      if (failures.length > 0) {
+        toast.error(
+          `${failures.length} of ${ids.length} entries failed: ${
+            failures[0].error ?? "Unknown error"
+          }`
+        );
+      } else {
+        toast.success(
+          `${ids.length} ${ids.length === 1 ? "entry" : "entries"} ${
+            action === "approve"
+              ? "approved"
+              : action === "reject"
+                ? "rejected"
+                : "deleted"
+          }`
+        );
+      }
+
+      refresh();
+    });
+  }
+
+  const confirmCopy: Record<
+    NonNullable<BulkAction>,
+    { title: string; description: string }
+  > = {
+    approve: {
+      title: "Approve selected entries?",
+      description:
+        "This will approve and execute every selected pending request. This cannot be undone.",
+    },
+    reject: {
+      title: "Reject selected entries?",
+      description:
+        "This will reject every selected pending request. The requests will not be applied.",
+    },
+    delete: {
+      title: "Delete selected entries?",
+      description:
+        "This will permanently remove the selected pending requests without executing or rejecting them.",
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="rounded-lg">
+        <CardHeader>
+          <CardTitle>Search</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div className="grid gap-2">
+              <Label>Action</Label>
+              <SearchableSelect
+                value={filters.actionName}
+                options={actionOptions}
+                placeholder="All actions"
+                emptyMessage="No actions found."
+                onValueChange={(value) =>
+                  setFilters((current) => ({ ...current, actionName: value }))
+                }
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label>Entity</Label>
+              <SearchableSelect
+                value={filters.entityName}
+                options={entityOptions}
+                placeholder="All entities"
+                emptyMessage="No entities found."
+                onValueChange={(value) =>
+                  setFilters((current) => ({ ...current, entityName: value }))
+                }
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="resource-id">Resource ID</Label>
+              <Input
+                id="resource-id"
+                value={filters.resourceId}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    resourceId: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="made-on-from">Made on (from)</Label>
+              <Input
+                id="made-on-from"
+                type="date"
+                value={filters.makerDateTimeFrom}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    makerDateTimeFrom: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="made-on-to">Made on (to)</Label>
+              <Input
+                id="made-on-to"
+                type="date"
+                value={filters.makerDateTimeTo}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    makerDateTimeTo: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <Button onClick={runSearch} disabled={isSearching}>
+              {isSearching ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Search
+            </Button>
+            <Button
+              variant="outline"
+              onClick={resetFilters}
+              disabled={isSearching}
+            >
+              Reset
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-lg">
+        <CardHeader className="gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle>Pending Entries</CardTitle>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{entries.length} pending</Badge>
+            <Button variant="outline" size="sm" onClick={refresh} disabled={isPending}>
+              {isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-2 h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {selected.size > 0 && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+              <span className="text-sm text-muted-foreground">
+                {selected.size} selected
+              </span>
+              <Button
+                size="sm"
+                onClick={() => setConfirmAction("approve")}
+                disabled={isPending}
+              >
+                <Check className="mr-2 h-4 w-4" />
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setConfirmAction("reject")}
+                disabled={isPending}
+              >
+                <X className="mr-2 h-4 w-4" />
+                Reject
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setConfirmAction("delete")}
+                disabled={isPending}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            </div>
+          )}
+
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={allSelected || (someSelected ? "indeterminate" : false)}
+                    onCheckedChange={toggleAll}
+                    aria-label="Select all"
+                  />
+                </TableHead>
+                <TableHead>ID</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Entity</TableHead>
+                <TableHead>Resource ID</TableHead>
+                <TableHead>Office</TableHead>
+                <TableHead>Maker</TableHead>
+                <TableHead>Made On</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map((entry) => (
+                <TableRow key={entry.id}>
+                  <TableCell onClick={(event) => event.stopPropagation()}>
+                    <Checkbox
+                      checked={selected.has(entry.id)}
+                      onCheckedChange={() => toggleOne(entry.id)}
+                      aria-label={`Select entry ${entry.id}`}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/checker-inbox/${entry.id}`}
+                      className="text-primary hover:underline"
+                    >
+                      {entry.id}
+                    </Link>
+                  </TableCell>
+                  <TableCell>{formatSystemLabel(entry.actionName)}</TableCell>
+                  <TableCell>{formatSystemLabel(entry.entityName)}</TableCell>
+                  <TableCell>{entry.resourceId ?? "N/A"}</TableCell>
+                  <TableCell>{entry.officeName || "N/A"}</TableCell>
+                  <TableCell>{entry.maker || "N/A"}</TableCell>
+                  <TableCell>{formatFineractDate(entry.madeOnDate)}</TableCell>
+                </TableRow>
+              ))}
+
+              {entries.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={8}
+                    className="py-10 text-center text-sm text-muted-foreground"
+                  >
+                    Nothing is waiting on your approval right now.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={confirmAction !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAction(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction ? confirmCopy[confirmAction].title : ""}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction ? confirmCopy[confirmAction].description : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={runBulkAction}>
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/app/(application)/checker-inbox/components/checker-inbox-detail-actions.tsx
+++ b/app/(application)/checker-inbox/components/checker-inbox-detail-actions.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  approveMakerCheckerEntryAction,
+  rejectMakerCheckerEntryAction,
+} from "@/app/actions/system-actions";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type CheckerInboxDetailActionsProps = {
+  auditId: number;
+};
+
+type ConfirmAction = "approve" | "reject" | null;
+
+export function CheckerInboxDetailActions({
+  auditId,
+}: CheckerInboxDetailActionsProps) {
+  const router = useRouter();
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function run() {
+    const action = confirmAction;
+    if (!action) return;
+    setConfirmAction(null);
+
+    const actionFn =
+      action === "approve"
+        ? approveMakerCheckerEntryAction
+        : rejectMakerCheckerEntryAction;
+
+    startTransition(async () => {
+      const result = await actionFn(auditId);
+      if (!result.success) {
+        toast.error(result.error ?? `Failed to ${action} entry`);
+        return;
+      }
+
+      toast.success(action === "approve" ? "Entry approved" : "Entry rejected");
+      router.push("/checker-inbox");
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button onClick={() => setConfirmAction("approve")} disabled={isPending}>
+          {isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="mr-2 h-4 w-4" />
+          )}
+          Approve
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => setConfirmAction("reject")}
+          disabled={isPending}
+        >
+          <X className="mr-2 h-4 w-4" />
+          Reject
+        </Button>
+      </div>
+
+      <AlertDialog
+        open={confirmAction !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAction(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction === "approve" ? "Approve this entry?" : "Reject this entry?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction === "approve"
+                ? "This will approve and execute the pending request. This cannot be undone."
+                : "This will reject the pending request. It will not be applied."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={run}>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/(application)/checker-inbox/components/checker-inbox-tasks-client.tsx
+++ b/app/(application)/checker-inbox/components/checker-inbox-tasks-client.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { AccessRestricted } from "@/components/access-restricted";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type {
+  AuditTrail,
+  AuditTrailSearchTemplate,
+  LoadFailure,
+  RescheduleLoanRequest,
+} from "@/shared/types/system";
+import { CheckerInboxClient } from "./checker-inbox-client";
+import { RescheduleLoanTab } from "./reschedule-loan-tab";
+
+type CheckerInboxTasksClientProps = {
+  template: AuditTrailSearchTemplate;
+  initialEntries: AuditTrail[];
+  checkerInboxError: LoadFailure | null;
+  initialRescheduleRequests: RescheduleLoanRequest[];
+  rescheduleError: LoadFailure | null;
+};
+
+function ErrorState({ error }: { error: LoadFailure }) {
+  if (error.status === 403) {
+    return (
+      <AccessRestricted description="Your account doesn't have permission to view this. Ask an administrator to grant the relevant permission if you need access." />
+    );
+  }
+
+  return (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertDescription>{error.message}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function CheckerInboxTasksClient({
+  template,
+  initialEntries,
+  checkerInboxError,
+  initialRescheduleRequests,
+  rescheduleError,
+}: CheckerInboxTasksClientProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">
+          Checker Inbox &amp; Tasks
+        </h1>
+        <p className="mt-1 text-muted-foreground">
+          Review and act on maker-checker entries and other pending back-office
+          tasks awaiting your approval.
+        </p>
+      </div>
+
+      <Tabs defaultValue="checker-inbox" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="checker-inbox">Checker Inbox</TabsTrigger>
+          <TabsTrigger value="reschedule-loan">Reschedule Loan</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="checker-inbox" className="space-y-4">
+          {checkerInboxError ? (
+            <ErrorState error={checkerInboxError} />
+          ) : (
+            <CheckerInboxClient
+              template={template}
+              initialEntries={initialEntries}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="reschedule-loan" className="space-y-4">
+          {rescheduleError ? (
+            <ErrorState error={rescheduleError} />
+          ) : (
+            <RescheduleLoanTab initialRequests={initialRescheduleRequests} />
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/(application)/checker-inbox/components/reschedule-loan-tab.tsx
+++ b/app/(application)/checker-inbox/components/reschedule-loan-tab.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, Loader2, RotateCcw, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  approveRescheduleLoanAction,
+  listPendingRescheduleLoansAction,
+  rejectRescheduleLoanAction,
+} from "@/app/actions/system-actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { RescheduleLoanRequest } from "@/shared/types/system";
+import { formatFineractDate } from "../../system/components/system-helpers";
+
+type RescheduleLoanTabProps = {
+  initialRequests: RescheduleLoanRequest[];
+};
+
+type BulkAction = "approve" | "reject" | null;
+
+export function RescheduleLoanTab({
+  initialRequests,
+}: RescheduleLoanTabProps) {
+  const [requests, setRequests] = useState(initialRequests);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [confirmAction, setConfirmAction] = useState<BulkAction>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const allSelected = requests.length > 0 && selected.size === requests.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(requests.map((r) => r.id)));
+  }
+
+  function toggleOne(id: number) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function refresh() {
+    startTransition(async () => {
+      try {
+        const next = await listPendingRescheduleLoansAction();
+        setRequests(next);
+        setSelected(new Set());
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to refresh reschedule requests"
+        );
+      }
+    });
+  }
+
+  function runBulkAction() {
+    const action = confirmAction;
+    if (!action) return;
+    setConfirmAction(null);
+
+    const ids = Array.from(selected);
+    const actionFn =
+      action === "approve" ? approveRescheduleLoanAction : rejectRescheduleLoanAction;
+
+    startTransition(async () => {
+      const results = await Promise.all(ids.map((id) => actionFn(id)));
+      const failures = results.filter((result) => !result.success);
+
+      if (failures.length > 0) {
+        toast.error(
+          `${failures.length} of ${ids.length} requests failed: ${
+            failures[0].error ?? "Unknown error"
+          }`
+        );
+      } else {
+        toast.success(
+          `${ids.length} reschedule ${ids.length === 1 ? "request" : "requests"} ${
+            action === "approve" ? "approved" : "rejected"
+          }`
+        );
+      }
+
+      refresh();
+    });
+  }
+
+  const confirmCopy: Record<
+    NonNullable<BulkAction>,
+    { title: string; description: string }
+  > = {
+    approve: {
+      title: "Approve selected reschedule requests?",
+      description:
+        "This will approve and apply every selected loan reschedule request. This cannot be undone.",
+    },
+    reject: {
+      title: "Reject selected reschedule requests?",
+      description:
+        "This will reject every selected loan reschedule request. The original schedule stays unchanged.",
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="rounded-lg">
+        <CardHeader className="gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle>Pending Reschedule Requests</CardTitle>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{requests.length} pending</Badge>
+            <Button variant="outline" size="sm" onClick={refresh} disabled={isPending}>
+              {isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-2 h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {selected.size > 0 && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+              <span className="text-sm text-muted-foreground">
+                {selected.size} selected
+              </span>
+              <Button
+                size="sm"
+                onClick={() => setConfirmAction("approve")}
+                disabled={isPending}
+              >
+                <Check className="mr-2 h-4 w-4" />
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setConfirmAction("reject")}
+                disabled={isPending}
+              >
+                <X className="mr-2 h-4 w-4" />
+                Reject
+              </Button>
+            </div>
+          )}
+
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={allSelected || (someSelected ? "indeterminate" : false)}
+                    onCheckedChange={toggleAll}
+                    aria-label="Select all"
+                  />
+                </TableHead>
+                <TableHead>Client</TableHead>
+                <TableHead>Loan Account No.</TableHead>
+                <TableHead>Reason</TableHead>
+                <TableHead>Submitted By</TableHead>
+                <TableHead>Submitted On</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {requests.map((request) => (
+                <TableRow key={request.id}>
+                  <TableCell onClick={(event) => event.stopPropagation()}>
+                    <Checkbox
+                      checked={selected.has(request.id)}
+                      onCheckedChange={() => toggleOne(request.id)}
+                      aria-label={`Select reschedule request ${request.id}`}
+                    />
+                  </TableCell>
+                  <TableCell>{request.clientName || "N/A"}</TableCell>
+                  <TableCell>{request.loanAccountNumber || "N/A"}</TableCell>
+                  <TableCell>
+                    {request.rescheduleReasonName ||
+                      request.rescheduleReasonComment ||
+                      "N/A"}
+                  </TableCell>
+                  <TableCell>{request.submittedByUsername || "N/A"}</TableCell>
+                  <TableCell>
+                    {formatFineractDate(request.submittedOnDate)}
+                  </TableCell>
+                </TableRow>
+              ))}
+
+              {requests.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={6}
+                    className="py-10 text-center text-sm text-muted-foreground"
+                  >
+                    No loan reschedule requests are pending right now.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={confirmAction !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAction(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction ? confirmCopy[confirmAction].title : ""}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction ? confirmCopy[confirmAction].description : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={runBulkAction}>
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/app/(application)/checker-inbox/loading.tsx
+++ b/app/(application)/checker-inbox/loading.tsx
@@ -1,0 +1,5 @@
+import { CheckerInboxSkeleton } from "../system/components/system-skeletons";
+
+export default function Loading() {
+  return <CheckerInboxSkeleton />;
+}

--- a/app/(application)/checker-inbox/page.tsx
+++ b/app/(application)/checker-inbox/page.tsx
@@ -1,0 +1,62 @@
+import { getFineractErrorStatus } from "@/lib/api";
+import {
+  getMakerCheckerSearchTemplateAction,
+  listMakerCheckerEntriesAction,
+  listPendingRescheduleLoansAction,
+} from "@/app/actions/system-actions";
+import { CheckerInboxTasksClient } from "./components/checker-inbox-tasks-client";
+import type {
+  AuditTrail,
+  AuditTrailSearchTemplate,
+  LoadFailure,
+  RescheduleLoanRequest,
+} from "@/shared/types/system";
+
+function toLoadFailure(error: unknown, fallback: string): LoadFailure {
+  return {
+    status: getFineractErrorStatus(error),
+    message: error instanceof Error ? error.message : fallback,
+  };
+}
+
+export default async function CheckerInboxPage() {
+  let template: AuditTrailSearchTemplate = {
+    appUsers: [],
+    actionNames: [],
+    entityNames: [],
+    processingResults: [],
+  };
+  let entries: AuditTrail[] = [];
+  let checkerInboxError: LoadFailure | null = null;
+
+  try {
+    [template, entries] = await Promise.all([
+      getMakerCheckerSearchTemplateAction(),
+      listMakerCheckerEntriesAction(),
+    ]);
+  } catch (error) {
+    checkerInboxError = toLoadFailure(error, "Failed to load checker inbox");
+  }
+
+  let rescheduleRequests: RescheduleLoanRequest[] = [];
+  let rescheduleError: LoadFailure | null = null;
+
+  try {
+    rescheduleRequests = await listPendingRescheduleLoansAction();
+  } catch (error) {
+    rescheduleError = toLoadFailure(
+      error,
+      "Failed to load loan reschedule requests"
+    );
+  }
+
+  return (
+    <CheckerInboxTasksClient
+      template={template}
+      initialEntries={entries}
+      checkerInboxError={checkerInboxError}
+      initialRescheduleRequests={rescheduleRequests}
+      rescheduleError={rescheduleError}
+    />
+  );
+}

--- a/app/(application)/components/sidebar-nav.tsx
+++ b/app/(application)/components/sidebar-nav.tsx
@@ -5,6 +5,7 @@ import {
   BarChart3,
   Bot,
   Building2,
+  ClipboardCheck,
   CreditCard,
   FileText,
   Receipt,
@@ -214,6 +215,14 @@ export function SidebarNav({
           ]}
         />
       )}
+
+      <Link
+        href="/checker-inbox"
+        className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        <ClipboardCheck className="h-4 w-4" />
+        Checker Inbox &amp; Tasks
+      </Link>
 
       {isEnabled("reports") && (
         <Link

--- a/app/(application)/organization/users/components/user-form.tsx
+++ b/app/(application)/organization/users/components/user-form.tsx
@@ -567,7 +567,11 @@ export function UserForm({
       }
 
       toast({
-        title: mode === "create" ? "User created" : "User updated",
+        title: result.pending
+          ? "Submitted for approval"
+          : mode === "create"
+            ? "User created"
+            : "User updated",
         description: toastDescription,
         variant: toastVariant,
       });

--- a/app/(application)/system/components/role-detail-client.tsx
+++ b/app/(application)/system/components/role-detail-client.tsx
@@ -163,6 +163,12 @@ export function RoleDetailClient({ initialRole }: RoleDetailClientProps) {
         return;
       }
 
+      if (result.pending) {
+        toast.info("Submitted - awaiting checker approval");
+        setIsEditingPermissions(false);
+        return;
+      }
+
       toast.success("Role permissions updated");
       setIsEditingPermissions(false);
       const nextRole = await getSystemRoleAction(role.id);
@@ -180,6 +186,12 @@ export function RoleDetailClient({ initialRole }: RoleDetailClientProps) {
 
       if (!result.success) {
         toast.error(result.error ?? "Failed to update role");
+        return;
+      }
+
+      if (result.pending) {
+        toast.info("Submitted - awaiting checker approval");
+        setIsEditRoleOpen(false);
         return;
       }
 
@@ -203,12 +215,18 @@ export function RoleDetailClient({ initialRole }: RoleDetailClientProps) {
         return;
       }
 
+      setConfirmAction(null);
+
+      if (result.pending) {
+        toast.info("Submitted - awaiting checker approval");
+        return;
+      }
+
       toast.success(
         confirmAction === "delete"
           ? "Role deleted"
           : `Role ${confirmAction === "enable" ? "enabled" : "disabled"}`
       );
-      setConfirmAction(null);
 
       if (confirmAction === "delete") {
         router.push("/system/roles-and-permissions");

--- a/app/(application)/system/components/roles-and-permissions-client.tsx
+++ b/app/(application)/system/components/roles-and-permissions-client.tsx
@@ -87,9 +87,15 @@ export function RolesAndPermissionsClient({
         return;
       }
 
-      toast.success("Role created");
       setCreateForm(emptyCreateForm);
       setIsCreateOpen(false);
+
+      if (result.pending) {
+        toast.info("Submitted - awaiting checker approval");
+        return;
+      }
+
+      toast.success("Role created");
       setRoles(await listSystemRolesAction());
     });
   }

--- a/app/(application)/system/components/system-skeletons.tsx
+++ b/app/(application)/system/components/system-skeletons.tsx
@@ -163,6 +163,23 @@ export function MakerCheckerSkeleton() {
   );
 }
 
+export function CheckerInboxSkeleton() {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton actions={1} />
+      <Card className="rounded-lg">
+        <CardHeader className="gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-6 w-28" />
+        </CardHeader>
+        <CardContent>
+          <TableSkeleton columns={6} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export function AuditTrailsSkeleton() {
   return (
     <div className="space-y-6">

--- a/app/actions/system-actions.ts
+++ b/app/actions/system-actions.ts
@@ -2,7 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { fetchFineractAPIAsCurrentUser } from "@/lib/api";
+import {
+  fetchFineractAPIAsCurrentUser,
+  isFineractCommandPendingApproval,
+} from "@/lib/api";
 import { hasFineractPermissionServer } from "@/lib/authorization";
 import type {
   AuditTrail,
@@ -12,6 +15,8 @@ import type {
   AvailableWorkflowJobSteps,
   CobCatchUpStatus,
   LockedLoansPage,
+  MakerCheckerSearchInput,
+  RescheduleLoanRequest,
   SchedulerJob,
   SchedulerRunHistory,
   SchedulerStatus,
@@ -24,8 +29,58 @@ import type {
   WorkflowJobStep,
   WorkflowJobSteps,
 } from "@/shared/types/system";
+import { format } from "date-fns";
 
 type LooseObject = Record<string, unknown>;
+
+/**
+ * Loan Matrix wraps a handful of Fineract tasks with its own bookkeeping (auto-
+ * disbursement trail, teller/cashier cash movements, LoanPayout records, lead/client
+ * linkage) that assumes the Fineract command executed immediately. Enabling maker-
+ * checker on these would silently desync that bookkeeping, since Fineract would queue
+ * the command instead of running it. These are hidden from the Configure Maker
+ * Checker Tasks page and stripped server-side even if a client tries to enable them
+ * directly.
+ *
+ * Loan approval and disbursement (app/api/fineract/loans/[id]/approve,
+ * .../disburse, .../undodisbursal, .../undoapproval) are the only loan-lifecycle
+ * actions with bespoke wrappers today - everything else under the loan/
+ * transaction_loan grouping (repayment, reject, withdraw, writeoff, waive, close,
+ * reschedule, ...) is a thin passthrough and safe to leave toggleable.
+ *
+ * Extend this list if a new bespoke workflow is added around a Fineract task.
+ */
+const BLOCKED_MAKER_CHECKER_CODES = new Set([
+  "CREATE_CLIENT",
+  "UPDATE_CLIENT",
+  "REJECT_CLIENT",
+  // Approval (incl. undo-approval and the "in past" variant)
+  "APPROVE_LOAN",
+  "APPROVE_LOAN_CHECKER",
+  "APPROVEINPAST_LOAN",
+  "APPROVEINPAST_LOAN_CHECKER",
+  "APPROVALUNDO_LOAN",
+  "APPROVALUNDO_LOAN_CHECKER",
+  // Disbursement (incl. undo-disbursal and the "in past" variant)
+  "DISBURSE_LOAN",
+  "DISBURSE_LOAN_CHECKER",
+  "DISBURSEINPAST_LOAN",
+  "DISBURSEINPAST_LOAN_CHECKER",
+  "DISBURSALUNDO_LOAN",
+  "DISBURSALUNDO_LOAN_CHECKER",
+]);
+
+function isBlockedMakerCheckerTask(permission: SystemPermission): boolean {
+  return BLOCKED_MAKER_CHECKER_CODES.has(permission.code);
+}
+
+const makerCheckerIdSchema = z.object({
+  id: z.coerce.number().int().positive("Entry id is required"),
+});
+
+const rescheduleLoanIdSchema = z.object({
+  id: z.coerce.number().int().positive("Reschedule request id is required"),
+});
 
 const roleCreateSchema = z.object({
   name: z.string().trim().min(1, "Role name is required"),
@@ -151,6 +206,10 @@ function ok<T>(data?: T): SystemActionResult<T> {
   return { success: true, data };
 }
 
+function pendingApproval<T>(): SystemActionResult<T> {
+  return { success: true, pending: true };
+}
+
 function fail<T = undefined>(
   error: unknown,
   fallback: string
@@ -256,6 +315,26 @@ function mapAuditPage(value: unknown): AuditTrailPage {
   };
 }
 
+function mapRescheduleLoanRequest(value: unknown): RescheduleLoanRequest {
+  const record = asObject(value);
+  const reasonCodeValue = asObject(record.rescheduleReasonCodeValue);
+  const timeline = asObject(record.timeline);
+
+  return {
+    id: asNumber(record.id) ?? 0,
+    loanId: asNumber(record.loanId),
+    clientId: asNumber(record.clientId),
+    clientName: asString(record.clientName),
+    loanAccountNumber: asString(record.loanAccountNumber),
+    rescheduleReasonComment: asString(record.rescheduleReasonComment),
+    rescheduleReasonName: asString(reasonCodeValue.name),
+    submittedOnDate:
+      (timeline.submittedOnDate as RescheduleLoanRequest["submittedOnDate"]) ??
+      null,
+    submittedByUsername: asString(timeline.submittedByUsername),
+  };
+}
+
 function mapRunHistory(value: unknown): SchedulerRunHistory {
   const record = asObject(value);
 
@@ -332,6 +411,7 @@ function revalidateSystemPaths() {
   revalidatePath("/system/configure-mc-tasks");
   revalidatePath("/system/manage-jobs");
   revalidatePath("/system/audit-trails");
+  revalidatePath("/checker-inbox");
 }
 
 export async function getSystemPermissionFlagsAction(): Promise<SystemPermissionFlags> {
@@ -381,6 +461,11 @@ export async function createSystemRoleAction(
       body: JSON.stringify(parsed.data),
     });
     revalidateSystemPaths();
+
+    if (isFineractCommandPendingApproval(response)) {
+      return pendingApproval();
+    }
+
     return ok(mapRoleSummary({ ...parsed.data, id: asNumber(asObject(response).resourceId) }));
   } catch (error) {
     return fail(error, "Failed to create role");
@@ -396,11 +481,16 @@ export async function updateSystemRoleAction(
   }
 
   try {
-    await fetchFineractAPIAsCurrentUser(`/roles/${parsed.data.id}`, {
+    const response = await fetchFineractAPIAsCurrentUser(`/roles/${parsed.data.id}`, {
       method: "PUT",
       body: JSON.stringify({ description: parsed.data.description }),
     });
     revalidateSystemPaths();
+
+    if (isFineractCommandPendingApproval(response)) {
+      return pendingApproval();
+    }
+
     return ok();
   } catch (error) {
     return fail(error, "Failed to update role");
@@ -416,7 +506,7 @@ export async function updateSystemRolePermissionsAction(
   }
 
   try {
-    await fetchFineractAPIAsCurrentUser(
+    const response = await fetchFineractAPIAsCurrentUser(
       `/roles/${parsed.data.roleId}/permissions`,
       {
         method: "PUT",
@@ -424,6 +514,11 @@ export async function updateSystemRolePermissionsAction(
       }
     );
     revalidateSystemPaths();
+
+    if (isFineractCommandPendingApproval(response)) {
+      return pendingApproval();
+    }
+
     return ok();
   } catch (error) {
     return fail(error, "Failed to update role permissions");
@@ -439,10 +534,15 @@ export async function deleteSystemRoleAction(
   }
 
   try {
-    await fetchFineractAPIAsCurrentUser(`/roles/${parsed.data.id}`, {
+    const response = await fetchFineractAPIAsCurrentUser(`/roles/${parsed.data.id}`, {
       method: "DELETE",
     });
     revalidateSystemPaths();
+
+    if (isFineractCommandPendingApproval(response)) {
+      return pendingApproval();
+    }
+
     return ok();
   } catch (error) {
     return fail(error, "Failed to delete role");
@@ -459,7 +559,7 @@ export async function setSystemRoleEnabledAction(
   }
 
   try {
-    await fetchFineractAPIAsCurrentUser(
+    const response = await fetchFineractAPIAsCurrentUser(
       `/roles/${parsed.data.id}?command=${enabled ? "enable" : "disable"}`,
       {
         method: "POST",
@@ -467,6 +567,11 @@ export async function setSystemRoleEnabledAction(
       }
     );
     revalidateSystemPaths();
+
+    if (isFineractCommandPendingApproval(response)) {
+      return pendingApproval();
+    }
+
     return ok();
   } catch (error) {
     return fail(error, `Failed to ${enabled ? "enable" : "disable"} role`);
@@ -478,7 +583,9 @@ export async function listMakerCheckerPermissionsAction(): Promise<SystemPermiss
     "/permissions?makerCheckerable=true",
     { cache: "no-store" }
   );
-  return asArray(permissions).map(mapPermission);
+  return asArray(permissions)
+    .map(mapPermission)
+    .filter((permission) => !isBlockedMakerCheckerTask(permission));
 }
 
 export async function updateMakerCheckerPermissionsAction(
@@ -490,14 +597,125 @@ export async function updateMakerCheckerPermissionsAction(
   }
 
   try {
+    // Defense in depth: strip any blocked code from the payload server-side too, in
+    // case a stale client or a direct call tries to enable one.
+    const allPermissions = asArray(
+      await fetchFineractAPIAsCurrentUser("/permissions?makerCheckerable=true", {
+        cache: "no-store",
+      })
+    ).map(mapPermission);
+    const blockedCodes = new Set(
+      allPermissions
+        .filter(isBlockedMakerCheckerTask)
+        .map((permission) => permission.code)
+    );
+    const sanitizedPermissions = Object.fromEntries(
+      Object.entries(parsed.data.permissions).filter(
+        ([code]) => !blockedCodes.has(code)
+      )
+    );
+
     await fetchFineractAPIAsCurrentUser("/permissions?makerCheckerable=true", {
       method: "PUT",
-      body: JSON.stringify(parsed.data),
+      body: JSON.stringify({ permissions: sanitizedPermissions }),
     });
     revalidateSystemPaths();
     return ok();
   } catch (error) {
     return fail(error, "Failed to update maker checker tasks");
+  }
+}
+
+export async function getMakerCheckerSearchTemplateAction(): Promise<AuditTrailSearchTemplate> {
+  const template = await fetchFineractAPIAsCurrentUser(
+    "/makercheckers/searchtemplate",
+    { cache: "no-store" }
+  );
+  return mapAuditTemplate(template);
+}
+
+export async function listMakerCheckerEntriesAction(
+  input: MakerCheckerSearchInput = {}
+): Promise<AuditTrail[]> {
+  const params = new URLSearchParams();
+  if (input.actionName) params.set("actionName", input.actionName);
+  if (input.entityName) params.set("entityName", input.entityName);
+  if (input.resourceId) params.set("resourceId", input.resourceId);
+  if (input.makerDateTimeFrom) {
+    params.set("makerDateTimeFrom", input.makerDateTimeFrom);
+    params.set("dateFormat", "dd MMMM yyyy");
+    params.set("locale", "en");
+  }
+  if (input.makerDateTimeTo) {
+    params.set("makerDateTimeTo", input.makerDateTimeTo);
+    params.set("dateFormat", "dd MMMM yyyy");
+    params.set("locale", "en");
+  }
+
+  const query = params.toString();
+  const entries = await fetchFineractAPIAsCurrentUser(
+    `/makercheckers${query ? `?${query}` : ""}`,
+    { cache: "no-store" }
+  );
+  return asArray(entries).map(mapAuditTrail);
+}
+
+export async function approveMakerCheckerEntryAction(
+  id: number | string
+): Promise<SystemActionResult> {
+  const parsed = makerCheckerIdSchema.safeParse({ id });
+  if (!parsed.success) {
+    return toFieldErrorResult(parsed.error);
+  }
+
+  try {
+    await fetchFineractAPIAsCurrentUser(
+      `/makercheckers/${parsed.data.id}?command=approve`,
+      { method: "POST", body: JSON.stringify({}) }
+    );
+    revalidateSystemPaths();
+    return ok();
+  } catch (error) {
+    return fail(error, "Failed to approve entry");
+  }
+}
+
+export async function rejectMakerCheckerEntryAction(
+  id: number | string
+): Promise<SystemActionResult> {
+  const parsed = makerCheckerIdSchema.safeParse({ id });
+  if (!parsed.success) {
+    return toFieldErrorResult(parsed.error);
+  }
+
+  try {
+    await fetchFineractAPIAsCurrentUser(
+      `/makercheckers/${parsed.data.id}?command=reject`,
+      { method: "POST", body: JSON.stringify({}) }
+    );
+    revalidateSystemPaths();
+    return ok();
+  } catch (error) {
+    return fail(error, "Failed to reject entry");
+  }
+}
+
+export async function deleteMakerCheckerEntryAction(
+  id: number | string
+): Promise<SystemActionResult> {
+  const parsed = makerCheckerIdSchema.safeParse({ id });
+  if (!parsed.success) {
+    return toFieldErrorResult(parsed.error);
+  }
+
+  try {
+    await fetchFineractAPIAsCurrentUser(`/makercheckers/${parsed.data.id}`, {
+      method: "DELETE",
+    });
+    revalidateSystemPaths();
+    return ok();
+  } catch (error) {
+    return fail(error, "Failed to delete entry");
   }
 }
 
@@ -812,5 +1030,73 @@ export async function getLoanClientNavigationAction(
     return ok({ loanId: parsed.data, clientId });
   } catch (error) {
     return fail(error, "Failed to resolve loan client");
+  }
+}
+
+export async function listPendingRescheduleLoansAction(): Promise<
+  RescheduleLoanRequest[]
+> {
+  const requests = await fetchFineractAPIAsCurrentUser(
+    "/rescheduleloans?command=pending",
+    { cache: "no-store" }
+  );
+  return asArray(requests).map(mapRescheduleLoanRequest);
+}
+
+function todayForFineract() {
+  return format(new Date(), "dd MMMM yyyy");
+}
+
+export async function approveRescheduleLoanAction(
+  id: number | string
+): Promise<SystemActionResult> {
+  const parsed = rescheduleLoanIdSchema.safeParse({ id });
+  if (!parsed.success) {
+    return toFieldErrorResult(parsed.error);
+  }
+
+  try {
+    await fetchFineractAPIAsCurrentUser(
+      `/rescheduleloans/${parsed.data.id}?command=approve`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          dateFormat: "dd MMMM yyyy",
+          locale: "en",
+          approvedOnDate: todayForFineract(),
+        }),
+      }
+    );
+    revalidateSystemPaths();
+    return ok();
+  } catch (error) {
+    return fail(error, "Failed to approve reschedule request");
+  }
+}
+
+export async function rejectRescheduleLoanAction(
+  id: number | string
+): Promise<SystemActionResult> {
+  const parsed = rescheduleLoanIdSchema.safeParse({ id });
+  if (!parsed.success) {
+    return toFieldErrorResult(parsed.error);
+  }
+
+  try {
+    await fetchFineractAPIAsCurrentUser(
+      `/rescheduleloans/${parsed.data.id}?command=reject`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          dateFormat: "dd MMMM yyyy",
+          locale: "en",
+          rejectedOnDate: todayForFineract(),
+        }),
+      }
+    );
+    revalidateSystemPaths();
+    return ok();
+  } catch (error) {
+    return fail(error, "Failed to reject reschedule request");
   }
 }

--- a/app/actions/user-management-actions.ts
+++ b/app/actions/user-management-actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { fetchFineractAPI } from "@/lib/api";
+import { fetchFineractAPI, isFineractCommandPendingApproval } from "@/lib/api";
 import { getSession } from "@/lib/auth";
 import { hasPermissionServer } from "@/lib/authorization";
 import {
@@ -874,6 +874,16 @@ export async function createUserAction(
       body: JSON.stringify(payload),
     });
 
+    if (isFineractCommandPendingApproval(response)) {
+      // Nothing was actually created yet - skip the local bookkeeping below, it
+      // would otherwise be keyed to a Fineract user that doesn't exist yet.
+      return {
+        success: true,
+        pending: true,
+        message: "User creation submitted - awaiting checker approval",
+      };
+    }
+
     const userId = Number(
       response?.resourceId ?? response?.subResourceId ?? response?.id
     );
@@ -951,10 +961,18 @@ export async function updateUserAction(
       roles: parsed.data.roles,
     };
 
-    await fetchFineractAPI(`/users/${parsed.data.userId}`, {
+    const response = await fetchFineractAPI(`/users/${parsed.data.userId}`, {
       method: "PUT",
       body: JSON.stringify(payload),
     });
+
+    if (isFineractCommandPendingApproval(response)) {
+      return {
+        success: true,
+        pending: true,
+        message: "User update submitted - awaiting checker approval",
+      };
+    }
 
     const userLogin = await upsertUserLogin({
       tenantId: tenant.id,
@@ -1015,9 +1033,17 @@ export async function deleteUserAction(input: {
     }
 
     const tenant = await requireCurrentTenant();
-    await fetchFineractAPI(`/users/${parsed.data.userId}`, {
+    const response = await fetchFineractAPI(`/users/${parsed.data.userId}`, {
       method: "DELETE",
     });
+
+    if (isFineractCommandPendingApproval(response)) {
+      return {
+        success: true,
+        pending: true,
+        message: "User deletion submitted - awaiting checker approval",
+      };
+    }
 
     await deleteUserLogin(tenant.id, parsed.data.userId);
     await prisma.mfaChallenge.deleteMany({

--- a/components/access-restricted.tsx
+++ b/components/access-restricted.tsx
@@ -1,0 +1,37 @@
+import { ShieldAlert } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+type AccessRestrictedProps = {
+  title?: string;
+  description?: string;
+  className?: string;
+};
+
+/**
+ * Friendly empty-state for "your account can't see this section" (typically a 403
+ * from Fineract) - use instead of a raw destructive error alert wherever a missing
+ * permission is an expected, unsurprising outcome rather than a bug.
+ */
+export function AccessRestricted({
+  title = "You don't have access to this",
+  description = "Your account doesn't have permission to view this section. Ask an administrator to grant the relevant permission if you believe this is a mistake.",
+  className,
+}: AccessRestrictedProps) {
+  return (
+    <Card
+      className={`rounded-lg border-dashed border-destructive/40 ${className ?? ""}`}
+    >
+      <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+          <ShieldAlert className="h-6 w-6 text-destructive" />
+        </div>
+        <div className="space-y-1">
+          <p className="font-medium text-destructive">{title}</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -244,6 +244,30 @@ export async function fetchFineractAPI(
   }
 }
 
+/**
+ * Fineract returns HTTP 200 with a normal-looking CommandProcessingResult even when a
+ * maker-checker-enabled command was intercepted and rolled back rather than applied -
+ * the only signal is `rollbackTransaction: true`. Callers of actions that touch
+ * maker-checker-eligible tasks must check this before treating the call as a success.
+ */
+export function isFineractCommandPendingApproval(result: unknown): boolean {
+  const record = result as { rollbackTransaction?: unknown } | null | undefined;
+  return Boolean(record && record.rollbackTransaction === true);
+}
+
+/**
+ * Extracts the HTTP status Fineract responded with, if the given error came from
+ * readFineractResponse. Lets callers distinguish "you don't have permission" (403)
+ * from other failures (network errors, validation errors, 500s, ...).
+ */
+export function getFineractErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as FineractError).status;
+    return typeof status === "number" ? status : undefined;
+  }
+  return undefined;
+}
+
 export async function fetchFineractAPIAsCurrentUser(
   endpoint: string,
   options: RequestInit = {},

--- a/shared/types/system.ts
+++ b/shared/types/system.ts
@@ -3,6 +3,8 @@ export type SystemActionResult<T = undefined> = {
   data?: T;
   error?: string;
   fieldErrors?: Record<string, string[] | undefined>;
+  /** True when a maker-checker-enabled task queued the request instead of applying it. */
+  pending?: boolean;
 };
 
 export type SystemPermission = {
@@ -152,4 +154,29 @@ export type LockedLoan = {
 
 export type LockedLoansPage = {
   content: LockedLoan[];
+};
+
+export type LoadFailure = {
+  status?: number;
+  message: string;
+};
+
+export type MakerCheckerSearchInput = {
+  actionName?: string;
+  entityName?: string;
+  resourceId?: string;
+  makerDateTimeFrom?: string;
+  makerDateTimeTo?: string;
+};
+
+export type RescheduleLoanRequest = {
+  id: number;
+  loanId?: number;
+  clientId?: number;
+  clientName?: string;
+  loanAccountNumber?: string;
+  rescheduleReasonComment?: string;
+  rescheduleReasonName?: string;
+  submittedOnDate?: string | number | number[] | null;
+  submittedByUsername?: string;
 };

--- a/shared/types/user-management.ts
+++ b/shared/types/user-management.ts
@@ -120,4 +120,6 @@ export interface UserActionResult<T = undefined> {
   fieldErrors?: Partial<Record<string, string[]>>;
   message?: string;
   data?: T;
+  /** True when a maker-checker-enabled task queued the request instead of applying it. */
+  pending?: boolean;
 }


### PR DESCRIPTION
## Summary
- Blocks maker-checker from being enabled on client create/update/reject and loan approve/disburse (+ undo / "in past" variants) on the Configure Maker Checker Tasks page, since those already have bespoke Loan Matrix workflows (auto-disbursement trail, teller/cashier cash linking, `LoanPayout` bookkeeping) that maker-checker would silently desync. Enforced in both the list shown and server-side on save.
- New top-level **Checker Inbox & Tasks** page (`/checker-inbox`) with two tabs:
  - **Checker Inbox**: search/filter pending maker-checker entries, bulk approve/reject/delete, and a per-entry detail view.
  - **Reschedule Loan**: review and bulk approve/reject pending loan reschedule requests.
- Role and user create/update/delete actions now detect Fineract's `rollbackTransaction: true` response (returned when a command is queued for approval instead of applied) and surface "awaiting checker approval" rather than a false success.
- New reusable `AccessRestricted` component shown when a section 403s, so a permission gap reads as an expected access boundary rather than a raw API error.

## Test plan
- [ ] Configure Maker Checker Tasks: confirm client create/update/reject and loan approve/disburse (+ undo/in-past variants) are absent from the list and cannot be enabled via a direct action call.
- [ ] Enable maker-checker for a safe task (e.g. `REPAYMENT_LOAN`); submit as a non-super-user maker; confirm it's held instead of applied.
- [ ] `/checker-inbox` Checker Inbox tab: search filters, bulk select, bulk approve/reject/delete, and detail view all work; approving/rejecting actually resolves the entry.
- [ ] `/checker-inbox` Reschedule Loan tab: pending requests list, bulk approve/reject.
- [ ] Confirm a user without `READ_RESCHEDULELOAN` sees the friendly `AccessRestricted` state on that tab instead of a raw error, while the Checker Inbox tab still loads.
- [ ] Create/update a role or user while maker-checker is enabled for that task; confirm the UI shows "awaiting checker approval" instead of a false success toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)