### PR TITLE
Fix cashier refund loan context

### DIFF
--- a/lib/__tests__/cashier-transaction-enrichment.test.ts
+++ b/lib/__tests__/cashier-transaction-enrichment.test.ts
@@ -44,6 +44,13 @@ test("keeps legacy repayment note loan id parsing", () => {
   );
 });
 
+test("parses credit balance refund loan ids from cashier notes", () => {
+  assert.equal(
+    extractLoanIdFromCashierTransactionNotes("Credit balance refund - Loan #164469"),
+    164469
+  );
+});
+
 test("matches loan payout by explicit Fineract loan note before loose amount matching", () => {
   const payout = matchLoanPayoutForCashierTransaction(
     {

--- a/lib/cashier-transaction-enrichment.ts
+++ b/lib/cashier-transaction-enrichment.ts
@@ -45,6 +45,7 @@ export type CashierTransactionLoanContext = {
 
 const LOAN_REPAYMENT_NOTE_REGEX = /loan repayment\s*#\s*(\d+)/i;
 const FINERACT_LOAN_NOTE_REGEX = /\bloan\s*:\s*(\d+)(?:\s*[-,]|\b)/i;
+const HASHED_LOAN_NOTE_REGEX = /\bloan\s*#\s*(\d+)(?:\s*[-,]|\b)/i;
 
 export function extractLoanIdFromCashierTransactionNotes(
   notes: string | null | undefined
@@ -53,7 +54,8 @@ export function extractLoanIdFromCashierTransactionNotes(
 
   const match =
     notes.match(LOAN_REPAYMENT_NOTE_REGEX) ??
-    notes.match(FINERACT_LOAN_NOTE_REGEX);
+    notes.match(FINERACT_LOAN_NOTE_REGEX) ??
+    notes.match(HASHED_LOAN_NOTE_REGEX);
   if (!match) return null;
 
   const loanId = Number(match[1]);


### PR DESCRIPTION
## What changed

- Teach cashier transaction enrichment to parse loan references written as `Loan #123`.
- Add a regression test for credit balance refund notes like `Credit balance refund - Loan #164469`.

## Why

Credit balance refund cashier rows were shown without Fullname, NRC, and Loan ID because their Fineract cashier note used `Loan #...`, while Loan Matrix only parsed `Loan:...` and `Loan repayment #...`.

## Impact

Cashier transaction history can now enrich credit balance refund rows with the linked loan/client context when the loan id is present in the note.

## Validation

- `npx tsx --test lib/__tests__/cashier-transaction-enrichment.test.ts`
- `npx eslint lib/cashier-transaction-enrichment.ts lib/__tests__/cashier-transaction-enrichment.test.ts`
