### PR TITLE
Standardize accounting module UI to match app design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 .env
 .env.*
 env.local
+
+# git worktrees
+.worktrees

--- a/app/(application)/accounting/accounting-rules/[id]/edit/page.tsx
+++ b/app/(application)/accounting/accounting-rules/[id]/edit/page.tsx
@@ -233,38 +233,37 @@ export default function EditAccountingRulePage() {
 
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Basic Information */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <Settings className="h-5 w-5" />
               Basic Information
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Define the rule name, description, and office
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="name" className="text-slate-900 dark:text-slate-100">Rule Name *</Label>
+                <Label htmlFor="name">Rule Name *</Label>
                 <Input
                   id="name"
                   value={formData.name}
                   onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
                   placeholder="Enter rule name"
-                  className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
                   required
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="office" className="text-slate-900 dark:text-slate-100">Office *</Label>
+                <Label htmlFor="office">Office *</Label>
                 <Select value={formData.officeId} onValueChange={(value) => setFormData(prev => ({ ...prev, officeId: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select office" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedOffices.map((office) => (
-                      <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={office.id} value={office.id.toString()}>
                         {office.name}
                       </SelectItem>
                     ))}
@@ -273,13 +272,12 @@ export default function EditAccountingRulePage() {
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="description" className="text-slate-900 dark:text-slate-100">Description</Label>
+              <Label htmlFor="description">Description</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                 placeholder="Enter rule description"
-                className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
                 rows={3}
               />
             </div>
@@ -287,42 +285,42 @@ export default function EditAccountingRulePage() {
         </Card>
 
         {/* Debit Rule Configuration */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <Minus className="h-5 w-5 text-red-500" />
               Affected GL Entry (Debit) Rule Type *
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Configure the debit side of the accounting rule
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <RadioGroup 
-              value={formData.debitRuleType} 
+            <RadioGroup
+              value={formData.debitRuleType}
               onValueChange={(value) => setFormData(prev => ({ ...prev, debitRuleType: value }))}
               className="space-y-3"
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="fixed" id="debit-fixed" />
-                <Label htmlFor="debit-fixed" className="text-slate-900 dark:text-slate-100">Fixed Account</Label>
+                <Label htmlFor="debit-fixed">Fixed Account</Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="list" id="debit-list" />
-                <Label htmlFor="debit-list" className="text-slate-900 dark:text-slate-100">List of Accounts</Label>
+                <Label htmlFor="debit-list">List of Accounts</Label>
               </div>
             </RadioGroup>
 
             {formData.debitRuleType === 'fixed' ? (
               <div className="space-y-2">
-                <Label htmlFor="debitAccount" className="text-slate-900 dark:text-slate-100">Debit Account *</Label>
+                <Label htmlFor="debitAccount">Debit Account *</Label>
                 <Select value={formData.accountToDebit} onValueChange={(value) => setFormData(prev => ({ ...prev, accountToDebit: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select debit account" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedAccounts.map((account) => (
-                      <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={account.id} value={account.id.toString()}>
                         {account.name} ({account.glCode})
                       </SelectItem>
                     ))}
@@ -332,7 +330,7 @@ export default function EditAccountingRulePage() {
             ) : (
               <div className="space-y-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-900 dark:text-slate-100">Debit Tags</Label>
+                  <Label>Debit Tags</Label>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                     {template.allowedDebitTagOptions.map((tag) => (
                       <div key={tag.id} className="flex items-center space-x-2">
@@ -341,7 +339,7 @@ export default function EditAccountingRulePage() {
                           checked={formData.debitTags.includes(tag.id)}
                           onCheckedChange={(checked) => handleTagChange(tag.id, 'debit', checked as boolean)}
                         />
-                        <Label htmlFor={`debit-tag-${tag.id}`} className="text-sm text-slate-900 dark:text-slate-100">
+                        <Label htmlFor={`debit-tag-${tag.id}`} className="text-sm">
                           {tag.name}
                         </Label>
                       </div>
@@ -354,7 +352,7 @@ export default function EditAccountingRulePage() {
                     checked={formData.allowMultipleDebitEntries}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, allowMultipleDebitEntries: checked as boolean }))}
                   />
-                  <Label htmlFor="multipleDebit" className="text-slate-900 dark:text-slate-100">
+                  <Label htmlFor="multipleDebit">
                     Multiple Debit Entries Allowed
                   </Label>
                 </div>
@@ -364,42 +362,42 @@ export default function EditAccountingRulePage() {
         </Card>
 
         {/* Credit Rule Configuration */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <CreditCard className="h-5 w-5 text-green-500" />
               Affected GL Entry (Credit) Rule Type *
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Configure the credit side of the accounting rule
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <RadioGroup 
-              value={formData.creditRuleType} 
+            <RadioGroup
+              value={formData.creditRuleType}
               onValueChange={(value) => setFormData(prev => ({ ...prev, creditRuleType: value }))}
               className="space-y-3"
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="fixed" id="credit-fixed" />
-                <Label htmlFor="credit-fixed" className="text-slate-900 dark:text-slate-100">Fixed Account</Label>
+                <Label htmlFor="credit-fixed">Fixed Account</Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="list" id="credit-list" />
-                <Label htmlFor="credit-list" className="text-slate-900 dark:text-slate-100">List of Accounts</Label>
+                <Label htmlFor="credit-list">List of Accounts</Label>
               </div>
             </RadioGroup>
 
             {formData.creditRuleType === 'fixed' ? (
               <div className="space-y-2">
-                <Label htmlFor="creditAccount" className="text-slate-900 dark:text-slate-100">Credit Account *</Label>
+                <Label htmlFor="creditAccount">Credit Account *</Label>
                 <Select value={formData.accountToCredit} onValueChange={(value) => setFormData(prev => ({ ...prev, accountToCredit: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select credit account" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedAccounts.map((account) => (
-                      <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={account.id} value={account.id.toString()}>
                         {account.name} ({account.glCode})
                       </SelectItem>
                     ))}
@@ -409,7 +407,7 @@ export default function EditAccountingRulePage() {
             ) : (
               <div className="space-y-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-900 dark:text-slate-100">Credit Tags</Label>
+                  <Label>Credit Tags</Label>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                     {template.allowedCreditTagOptions.map((tag) => (
                       <div key={tag.id} className="flex items-center space-x-2">
@@ -418,7 +416,7 @@ export default function EditAccountingRulePage() {
                           checked={formData.creditTags.includes(tag.id)}
                           onCheckedChange={(checked) => handleTagChange(tag.id, 'credit', checked as boolean)}
                         />
-                        <Label htmlFor={`credit-tag-${tag.id}`} className="text-sm text-slate-900 dark:text-slate-100">
+                        <Label htmlFor={`credit-tag-${tag.id}`} className="text-sm">
                           {tag.name}
                         </Label>
                       </div>
@@ -431,7 +429,7 @@ export default function EditAccountingRulePage() {
                     checked={formData.allowMultipleCreditEntries}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, allowMultipleCreditEntries: checked as boolean }))}
                   />
-                  <Label htmlFor="multipleCredit" className="text-slate-900 dark:text-slate-100">
+                  <Label htmlFor="multipleCredit">
                     Multiple Credit Entries Allowed
                   </Label>
                 </div>
@@ -447,10 +445,9 @@ export default function EditAccountingRulePage() {
               Cancel
             </Button>
           </Link>
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={isLoading}
-            className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white"
           >
             {isLoading ? (
               <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>

--- a/app/(application)/accounting/accounting-rules/[id]/page.tsx
+++ b/app/(application)/accounting/accounting-rules/[id]/page.tsx
@@ -65,11 +65,11 @@ export default function AccountingRuleViewPage() {
   if (!accountingRule) {
     return (
       <div className="text-center py-12">
-        <Settings className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2">
+        <Settings className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+        <h3 className="text-lg font-medium text-foreground mb-2">
           Accounting rule not found
         </h3>
-        <p className="text-slate-600 dark:text-slate-400 mb-6">
+        <p className="text-muted-foreground mb-6">
           The accounting rule you're looking for doesn't exist or has been deleted.
         </p>
         <Link href="/accounting/accounting-rules">
@@ -102,7 +102,7 @@ export default function AccountingRuleViewPage() {
         </div>
         <div className="flex items-center gap-2">
           <Link href={`/accounting/accounting-rules/${accountingRule.id}/edit`}>
-            <Button className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white">
+            <Button>
               <Edit className="h-4 w-4 mr-2" />
               Edit Rule
             </Button>
@@ -111,9 +111,9 @@ export default function AccountingRuleViewPage() {
       </div>
 
       {/* Basic Information */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+          <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
             <Settings className="h-5 w-5" />
             Basic Information
           </CardTitle>
@@ -121,17 +121,17 @@ export default function AccountingRuleViewPage() {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Rule Name</Label>
-              <p className="text-slate-900 dark:text-slate-100 font-medium">{accountingRule.name}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Rule Name</Label>
+              <p className="text-foreground font-medium">{accountingRule.name}</p>
             </div>
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Office</Label>
-              <p className="text-slate-900 dark:text-slate-100">{accountingRule.officeName}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Office</Label>
+              <p className="text-foreground">{accountingRule.officeName}</p>
             </div>
           </div>
           <div>
-            <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Description</Label>
-            <p className="text-slate-900 dark:text-slate-100">{accountingRule.description || '—'}</p>
+            <Label className="text-sm font-medium text-muted-foreground">Description</Label>
+            <p className="text-foreground">{accountingRule.description || '—'}</p>
           </div>
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
@@ -144,9 +144,9 @@ export default function AccountingRuleViewPage() {
       </Card>
 
       {/* Debit Configuration */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+          <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
             <Minus className="h-5 w-5 text-red-500" />
             Debit Configuration
           </CardTitle>
@@ -154,12 +154,12 @@ export default function AccountingRuleViewPage() {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Debit Accounts</Label>
-              <p className="text-slate-900 dark:text-slate-100">{getAccountNames(accountingRule.debitAccounts)}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Debit Accounts</Label>
+              <p className="text-foreground">{getAccountNames(accountingRule.debitAccounts)}</p>
             </div>
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Debit Tags</Label>
-              <p className="text-slate-900 dark:text-slate-100">{getTagNames(accountingRule.debitTags)}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Debit Tags</Label>
+              <p className="text-foreground">{getTagNames(accountingRule.debitTags)}</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -168,7 +168,7 @@ export default function AccountingRuleViewPage() {
             ) : (
               <XCircle className="h-4 w-4 text-red-500" />
             )}
-            <span className="text-sm text-slate-600 dark:text-slate-400">
+            <span className="text-sm text-muted-foreground">
               Multiple Debit Entries Allowed: {accountingRule.allowMultipleDebitEntries ? 'Yes' : 'No'}
             </span>
           </div>
@@ -176,9 +176,9 @@ export default function AccountingRuleViewPage() {
       </Card>
 
       {/* Credit Configuration */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+          <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
             <CreditCard className="h-5 w-5 text-green-500" />
             Credit Configuration
           </CardTitle>
@@ -186,12 +186,12 @@ export default function AccountingRuleViewPage() {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Credit Accounts</Label>
-              <p className="text-slate-900 dark:text-slate-100">{getAccountNames(accountingRule.creditAccounts)}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Credit Accounts</Label>
+              <p className="text-foreground">{getAccountNames(accountingRule.creditAccounts)}</p>
             </div>
             <div>
-              <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Credit Tags</Label>
-              <p className="text-slate-900 dark:text-slate-100">{getTagNames(accountingRule.creditTags)}</p>
+              <Label className="text-sm font-medium text-muted-foreground">Credit Tags</Label>
+              <p className="text-foreground">{getTagNames(accountingRule.creditTags)}</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -200,7 +200,7 @@ export default function AccountingRuleViewPage() {
             ) : (
               <XCircle className="h-4 w-4 text-red-500" />
             )}
-            <span className="text-sm text-slate-600 dark:text-slate-400">
+            <span className="text-sm text-muted-foreground">
               Multiple Credit Entries Allowed: {accountingRule.allowMultipleCreditEntries ? 'Yes' : 'No'}
             </span>
           </div>
@@ -208,27 +208,27 @@ export default function AccountingRuleViewPage() {
       </Card>
 
       {/* Allowed Offices and Accounts */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+          <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
             <Building className="h-5 w-5" />
             Permissions & Access
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div>
-            <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Allowed Offices</Label>
-            <p className="text-slate-900 dark:text-slate-100">
-              {accountingRule.allowedOffices.length > 0 
+            <Label className="text-sm font-medium text-muted-foreground">Allowed Offices</Label>
+            <p className="text-foreground">
+              {accountingRule.allowedOffices.length > 0
                 ? accountingRule.allowedOffices.map((office: any) => office.name).join(', ')
                 : 'All offices'
               }
             </p>
           </div>
           <div>
-            <Label className="text-sm font-medium text-slate-600 dark:text-slate-400">Allowed Accounts</Label>
-            <p className="text-slate-900 dark:text-slate-100">
-              {accountingRule.allowedAccounts.length > 0 
+            <Label className="text-sm font-medium text-muted-foreground">Allowed Accounts</Label>
+            <p className="text-foreground">
+              {accountingRule.allowedAccounts.length > 0
                 ? accountingRule.allowedAccounts.map((account: any) => `${account.name} (${account.glCode})`).join(', ')
                 : 'All accounts'
               }

--- a/app/(application)/accounting/accounting-rules/new/page.tsx
+++ b/app/(application)/accounting/accounting-rules/new/page.tsx
@@ -197,38 +197,37 @@ export default function NewAccountingRulePage() {
 
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Basic Information */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <Settings className="h-5 w-5" />
               Basic Information
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Define the rule name, description, and office
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="name" className="text-slate-900 dark:text-slate-100">Rule Name *</Label>
+                <Label htmlFor="name">Rule Name *</Label>
                 <Input
                   id="name"
                   value={formData.name}
                   onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
                   placeholder="Enter rule name"
-                  className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
                   required
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="office" className="text-slate-900 dark:text-slate-100">Office *</Label>
+                <Label htmlFor="office">Office *</Label>
                 <Select value={formData.officeId} onValueChange={(value) => setFormData(prev => ({ ...prev, officeId: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select office" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedOffices.map((office) => (
-                      <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={office.id} value={office.id.toString()}>
                         {office.name}
                       </SelectItem>
                     ))}
@@ -237,13 +236,12 @@ export default function NewAccountingRulePage() {
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="description" className="text-slate-900 dark:text-slate-100">Description</Label>
+              <Label htmlFor="description">Description</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                 placeholder="Enter rule description"
-                className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
                 rows={3}
               />
             </div>
@@ -251,42 +249,42 @@ export default function NewAccountingRulePage() {
         </Card>
 
         {/* Debit Rule Configuration */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <Minus className="h-5 w-5 text-red-500" />
               Affected GL Entry (Debit) Rule Type *
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Configure the debit side of the accounting rule
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <RadioGroup 
-              value={formData.debitRuleType} 
+            <RadioGroup
+              value={formData.debitRuleType}
               onValueChange={(value) => setFormData(prev => ({ ...prev, debitRuleType: value }))}
               className="space-y-3"
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="fixed" id="debit-fixed" />
-                <Label htmlFor="debit-fixed" className="text-slate-900 dark:text-slate-100">Fixed Account</Label>
+                <Label htmlFor="debit-fixed">Fixed Account</Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="list" id="debit-list" />
-                <Label htmlFor="debit-list" className="text-slate-900 dark:text-slate-100">List of Accounts</Label>
+                <Label htmlFor="debit-list">List of Accounts</Label>
               </div>
             </RadioGroup>
 
             {formData.debitRuleType === 'fixed' ? (
               <div className="space-y-2">
-                <Label htmlFor="debitAccount" className="text-slate-900 dark:text-slate-100">Debit Account *</Label>
+                <Label htmlFor="debitAccount">Debit Account *</Label>
                 <Select value={formData.accountToDebit} onValueChange={(value) => setFormData(prev => ({ ...prev, accountToDebit: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select debit account" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedAccounts.map((account) => (
-                      <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={account.id} value={account.id.toString()}>
                         {account.name} ({account.glCode})
                       </SelectItem>
                     ))}
@@ -296,7 +294,7 @@ export default function NewAccountingRulePage() {
             ) : (
               <div className="space-y-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-900 dark:text-slate-100">Debit Tags</Label>
+                  <Label>Debit Tags</Label>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                     {template.allowedDebitTagOptions.map((tag) => (
                       <div key={tag.id} className="flex items-center space-x-2">
@@ -305,7 +303,7 @@ export default function NewAccountingRulePage() {
                           checked={formData.debitTags.includes(tag.id)}
                           onCheckedChange={(checked) => handleTagChange(tag.id, 'debit', checked as boolean)}
                         />
-                        <Label htmlFor={`debit-tag-${tag.id}`} className="text-sm text-slate-900 dark:text-slate-100">
+                        <Label htmlFor={`debit-tag-${tag.id}`} className="text-sm">
                           {tag.name}
                         </Label>
                       </div>
@@ -318,7 +316,7 @@ export default function NewAccountingRulePage() {
                     checked={formData.allowMultipleDebitEntries}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, allowMultipleDebitEntries: checked as boolean }))}
                   />
-                  <Label htmlFor="multipleDebit" className="text-slate-900 dark:text-slate-100">
+                  <Label htmlFor="multipleDebit">
                     Multiple Debit Entries Allowed
                   </Label>
                 </div>
@@ -328,42 +326,42 @@ export default function NewAccountingRulePage() {
         </Card>
 
         {/* Credit Rule Configuration */}
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
               <CreditCard className="h-5 w-5 text-green-500" />
               Affected GL Entry (Credit) Rule Type *
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription className="text-muted-foreground">
               Configure the credit side of the accounting rule
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <RadioGroup 
-              value={formData.creditRuleType} 
+            <RadioGroup
+              value={formData.creditRuleType}
               onValueChange={(value) => setFormData(prev => ({ ...prev, creditRuleType: value }))}
               className="space-y-3"
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="fixed" id="credit-fixed" />
-                <Label htmlFor="credit-fixed" className="text-slate-900 dark:text-slate-100">Fixed Account</Label>
+                <Label htmlFor="credit-fixed">Fixed Account</Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="list" id="credit-list" />
-                <Label htmlFor="credit-list" className="text-slate-900 dark:text-slate-100">List of Accounts</Label>
+                <Label htmlFor="credit-list">List of Accounts</Label>
               </div>
             </RadioGroup>
 
             {formData.creditRuleType === 'fixed' ? (
               <div className="space-y-2">
-                <Label htmlFor="creditAccount" className="text-slate-900 dark:text-slate-100">Credit Account *</Label>
+                <Label htmlFor="creditAccount">Credit Account *</Label>
                 <Select value={formData.accountToCredit} onValueChange={(value) => setFormData(prev => ({ ...prev, accountToCredit: value }))}>
-                  <SelectTrigger className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger>
                     <SelectValue placeholder="Select credit account" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {template.allowedAccounts.map((account) => (
-                      <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={account.id} value={account.id.toString()}>
                         {account.name} ({account.glCode})
                       </SelectItem>
                     ))}
@@ -373,7 +371,7 @@ export default function NewAccountingRulePage() {
             ) : (
               <div className="space-y-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-900 dark:text-slate-100">Credit Tags</Label>
+                  <Label>Credit Tags</Label>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                     {template.allowedCreditTagOptions.map((tag) => (
                       <div key={tag.id} className="flex items-center space-x-2">
@@ -382,7 +380,7 @@ export default function NewAccountingRulePage() {
                           checked={formData.creditTags.includes(tag.id)}
                           onCheckedChange={(checked) => handleTagChange(tag.id, 'credit', checked as boolean)}
                         />
-                        <Label htmlFor={`credit-tag-${tag.id}`} className="text-sm text-slate-900 dark:text-slate-100">
+                        <Label htmlFor={`credit-tag-${tag.id}`} className="text-sm">
                           {tag.name}
                         </Label>
                       </div>
@@ -395,7 +393,7 @@ export default function NewAccountingRulePage() {
                     checked={formData.allowMultipleCreditEntries}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, allowMultipleCreditEntries: checked as boolean }))}
                   />
-                  <Label htmlFor="multipleCredit" className="text-slate-900 dark:text-slate-100">
+                  <Label htmlFor="multipleCredit">
                     Multiple Credit Entries Allowed
                   </Label>
                 </div>
@@ -411,10 +409,9 @@ export default function NewAccountingRulePage() {
               Cancel
             </Button>
           </Link>
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={isLoading}
-            className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white"
           >
             {isLoading ? (
               <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>

--- a/app/(application)/accounting/accounting-rules/page.tsx
+++ b/app/(application)/accounting/accounting-rules/page.tsx
@@ -139,7 +139,7 @@ export default function AccountingRulesPage() {
           </p>
         </div>
         <Link href="/accounting/accounting-rules/new">
-          <Button className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white">
+          <Button>
             <Plus className="h-4 w-4 mr-2" />
             Add Rule
           </Button>
@@ -147,9 +147,9 @@ export default function AccountingRulesPage() {
       </div>
 
       {/* Filters */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <CardTitle className="text-lg font-semibold text-foreground">
             Filters & Search
           </CardTitle>
         </CardHeader>
@@ -157,12 +157,12 @@ export default function AccountingRulesPage() {
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="flex-1">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-slate-400" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="Search rules by name, description, or office..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                  className="pl-10"
                 />
               </div>
             </div>
@@ -171,16 +171,16 @@ export default function AccountingRulesPage() {
                 value={selectedOffice}
                 onValueChange={setSelectedOffice}
               >
-                <SelectTrigger className="w-full bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
-                  <Filter className="h-4 w-4 mr-2 text-slate-400 dark:text-slate-500" />
+                <SelectTrigger className="w-full">
+                  <Filter className="h-4 w-4 mr-2 text-muted-foreground" />
                   <SelectValue placeholder="Filter by office" />
                 </SelectTrigger>
-                <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
-                  <SelectItem value="all" className="text-slate-900 dark:text-slate-100">
+                <SelectContent>
+                  <SelectItem value="all">
                     All Offices
                   </SelectItem>
                   {offices.map((office) => (
-                    <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                    <SelectItem key={office.id} value={office.id.toString()}>
                       {office.name}
                     </SelectItem>
                   ))}
@@ -193,12 +193,12 @@ export default function AccountingRulesPage() {
 
 
       {/* Rules Table */}
-      <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <CardTitle className="text-lg font-semibold text-foreground">
             Accounting Rules
           </CardTitle>
-          <CardDescription className="text-slate-600 dark:text-slate-400">
+          <CardDescription className="text-muted-foreground">
             {filteredRules.length} rule{filteredRules.length !== 1 ? 's' : ''} found
           </CardDescription>
         </CardHeader>
@@ -209,11 +209,11 @@ export default function AccountingRulesPage() {
             </div>
           ) : filteredRules.length === 0 ? (
             <div className="text-center py-12">
-              <Settings className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2">
+              <Settings className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-foreground mb-2">
                 No accounting rules found
               </h3>
-              <p className="text-slate-600 dark:text-slate-400 mb-6">
+              <p className="text-muted-foreground mb-6">
                 {searchTerm || (selectedOffice && selectedOffice !== 'all')
                   ? 'Try adjusting your search or filter criteria.'
                   : 'Get started by creating your first accounting rule.'
@@ -221,7 +221,7 @@ export default function AccountingRulesPage() {
               </p>
               {!searchTerm && (selectedOffice === 'all' || !selectedOffice) && (
                 <Link href="/accounting/accounting-rules/new">
-                  <Button className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white">
+                  <Button>
                     <Plus className="h-4 w-4 mr-2" />
                     Create First Rule
                   </Button>
@@ -232,38 +232,38 @@ export default function AccountingRulesPage() {
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
-                  <TableRow className="border-slate-200 dark:border-slate-700">
-                    <TableHead className="text-slate-900 dark:text-slate-100">Name</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Office</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Debit Tags</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Debit Account</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Credit Tags</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Credit Account</TableHead>
-                    <TableHead className="text-slate-900 dark:text-slate-100">Actions</TableHead>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Office</TableHead>
+                    <TableHead>Debit Tags</TableHead>
+                    <TableHead>Debit Account</TableHead>
+                    <TableHead>Credit Tags</TableHead>
+                    <TableHead>Credit Account</TableHead>
+                    <TableHead>Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {filteredRules.map((rule) => (
-                    <TableRow key={rule.id} className="border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50">
-                      <TableCell className="font-medium text-slate-900 dark:text-slate-100">
+                    <TableRow key={rule.id}>
+                      <TableCell className="font-medium">
                         <div>
                           <div className="font-semibold">{rule.name}</div>
-                          <div className="text-sm text-slate-600 dark:text-slate-400">{rule.description}</div>
+                          <div className="text-sm text-muted-foreground">{rule.description}</div>
                         </div>
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         {rule.officeName}
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         {getTagNames(rule.debitTags)}
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         {getAccountNames(rule.debitAccounts)}
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         {getTagNames(rule.creditTags)}
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         {getAccountNames(rule.creditAccounts)}
                       </TableCell>
                       <TableCell>
@@ -278,10 +278,10 @@ export default function AccountingRulesPage() {
                               <Edit className="h-4 w-4" />
                             </Button>
                           </Link>
-                          <Button 
-                            variant="ghost" 
-                            size="sm" 
-                            className="h-8 w-8 p-0 text-red-600 hover:text-red-700"
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 text-red-500 hover:text-red-600"
                             onClick={() => handleDelete(rule.id)}
                           >
                             <Trash2 className="h-4 w-4" />

--- a/app/(application)/accounting/accruals/page.tsx
+++ b/app/(application)/accounting/accruals/page.tsx
@@ -95,19 +95,19 @@ export default function AccrualsPage() {
 
       {/* Main Content */}
       <div className="max-w-2xl">
-        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 shadow-lg">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            <CardTitle>
               Accrual Configuration
             </CardTitle>
-            <CardDescription className="text-slate-600 dark:text-slate-400">
+            <CardDescription>
               Select the date until which you want to run periodic accruals
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
             {/* Date Input */}
             <div className="space-y-2">
-              <Label htmlFor="tillDate" className="text-sm font-medium text-slate-900 dark:text-slate-100">
+              <Label htmlFor="tillDate">
                 Accrue Till Date *
               </Label>
               <div className="relative">
@@ -116,19 +116,18 @@ export default function AccrualsPage() {
                   type="date"
                   value={tillDate}
                   onChange={(e) => setTillDate(e.target.value)}
-                  className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  className="pl-10"
                   placeholder="Select date"
                 />
-                <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-slate-400" />
+                <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               </div>
             </div>
 
             {/* Action Buttons */}
             <div className="flex items-center justify-end gap-3 pt-4">
               <Link href="/accounting">
-                <Button 
-                  variant="outline" 
-                  className="bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-600"
+                <Button
+                  variant="outline"
                 >
                   Cancel
                 </Button>
@@ -136,7 +135,7 @@ export default function AccrualsPage() {
               <Button
                 onClick={handleRunAccruals}
                 disabled={!tillDate || isLoading}
-                className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                className="disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isLoading ? (
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>

--- a/app/(application)/accounting/chart-of-accounts/[id]/edit/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/[id]/edit/page.tsx
@@ -172,7 +172,7 @@ export default function EditAccountPage() {
       <div className="container mx-auto p-6">
         <Card className="max-w-2xl mx-auto">
           <CardHeader>
-            <CardTitle className="text-red-600">Error Loading Account</CardTitle>
+            <CardTitle className="text-destructive">Error Loading Account</CardTitle>
             <CardDescription>Failed to load the GL account data. Please try again.</CardDescription>
           </CardHeader>
           <CardContent>

--- a/app/(application)/accounting/chart-of-accounts/[id]/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/[id]/page.tsx
@@ -53,7 +53,7 @@ export default function ViewAccountPage() {
       <div className="container mx-auto p-6">
         <Card className="max-w-2xl mx-auto">
           <CardHeader>
-            <CardTitle className="text-red-600 flex items-center gap-2">
+            <CardTitle className="text-destructive flex items-center gap-2">
               <XCircle className="h-5 w-5" />
               Failed to Load Account
             </CardTitle>
@@ -177,9 +177,9 @@ export default function ViewAccountPage() {
   // Get status badge
   const getStatusBadge = () => {
     if (acc.disabled) {
-      return <Badge variant="secondary" className="bg-orange-100 text-orange-800 hover:bg-orange-100">Inactive</Badge>;
+      return <Badge variant="secondary" className="bg-orange-500/20 text-orange-500 hover:bg-orange-500/20">Inactive</Badge>;
     }
-    return <Badge variant="default" className="bg-green-100 text-green-800 hover:bg-green-100">Active</Badge>;
+    return <Badge variant="default" className="bg-green-500/20 text-green-500 hover:bg-green-500/20">Active</Badge>;
   };
 
   // Get type badge color
@@ -238,7 +238,7 @@ export default function ViewAccountPage() {
                     size="sm"
                     variant={acc.disabled ? "default" : "outline"}
                     onClick={handleDisableToggle}
-                    className={acc.disabled ? "bg-green-600 hover:bg-green-700" : ""}
+                    className={acc.disabled ? "bg-green-500 hover:bg-green-600" : ""}
                   >
                     {acc.disabled ? (
                       <>

--- a/app/(application)/accounting/chart-of-accounts/new/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/new/page.tsx
@@ -68,12 +68,12 @@ export default function NewAccountPage() {
 
   if (error) {
     return (
-      <Card className="border-red-200 bg-red-50">
+      <Card>
         <CardContent className="pt-6">
           <div className="text-center">
-            <AlertCircle className="h-8 w-8 text-red-500 mx-auto mb-2" />
-            <div className="text-red-600 font-medium">Error loading template</div>
-            <div className="text-sm text-red-500 mt-1">{error.message}</div>
+            <AlertCircle className="h-8 w-8 text-destructive mx-auto mb-2" />
+            <div className="text-destructive font-medium">Error loading template</div>
+            <div className="text-sm text-destructive mt-1">{error.message}</div>
           </div>
         </CardContent>
       </Card>
@@ -85,15 +85,15 @@ export default function NewAccountPage() {
       <div className="space-y-4">
         <Card className="animate-pulse">
           <CardHeader>
-            <div className="h-6 bg-gray-200 rounded w-1/3 mb-2"></div>
-            <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+            <div className="h-6 bg-muted rounded w-1/3 mb-2"></div>
+            <div className="h-4 bg-muted rounded w-1/2"></div>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {[...Array(6)].map((_, i) => (
                 <div key={i}>
-                  <div className="h-4 bg-gray-200 rounded w-1/3 mb-2"></div>
-                  <div className="h-10 bg-gray-200 rounded"></div>
+                  <div className="h-4 bg-muted rounded w-1/3 mb-2"></div>
+                  <div className="h-10 bg-muted rounded"></div>
                 </div>
               ))}
             </div>
@@ -116,12 +116,12 @@ export default function NewAccountPage() {
 
   // Type configuration for visual enhancement
   const typeConfig: Record<string, { color: string; bgColor: string; icon: any }> = {
-    ASSET: { color: 'text-emerald-600', bgColor: 'bg-emerald-50', icon: TrendingUp },
-    LIABILITY: { color: 'text-amber-600', bgColor: 'bg-amber-50', icon: TrendingDown },
-    INCOME: { color: 'text-blue-600', bgColor: 'bg-blue-50', icon: TrendingUp },
-    REVENUE: { color: 'text-blue-600', bgColor: 'bg-blue-50', icon: TrendingUp },
-    EQUITY: { color: 'text-purple-600', bgColor: 'bg-purple-50', icon: Circle },
-    EXPENSE: { color: 'text-red-600', bgColor: 'bg-red-50', icon: TrendingDown },
+    ASSET: { color: 'text-emerald-500', bgColor: 'bg-emerald-500/20', icon: TrendingUp },
+    LIABILITY: { color: 'text-amber-500', bgColor: 'bg-amber-500/20', icon: TrendingDown },
+    INCOME: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    REVENUE: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    EQUITY: { color: 'text-purple-500', bgColor: 'bg-purple-500/20', icon: Circle },
+    EXPENSE: { color: 'text-red-500', bgColor: 'bg-red-500/20', icon: TrendingDown },
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -235,7 +235,7 @@ export default function NewAccountPage() {
                   </SelectTrigger>
                   <SelectContent>
                     {accountTypeOptions.map((opt: any) => {
-                      const config = typeConfig[opt.value?.toUpperCase()] || { color: 'text-gray-600', bgColor: 'bg-gray-50', icon: FileText };
+                      const config = typeConfig[opt.value?.toUpperCase()] || { color: 'text-muted-foreground', bgColor: 'bg-muted', icon: FileText };
                       const IconComponent = config.icon;
                       return (
                         <SelectItem key={opt.id} value={opt.id.toString()}>
@@ -290,7 +290,7 @@ export default function NewAccountPage() {
                   GL Code <span className="text-red-500">*</span>
                 </Label>
                 <div className="relative">
-                  <Hash className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                  <Hash className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                   <Input
                     id="glCode"
                     required
@@ -418,12 +418,12 @@ export default function NewAccountPage() {
         </Card>
 
         {/* Actions */}
-        <Card className="border-0 shadow-sm bg-gradient-to-r from-blue-50 to-indigo-50">
+        <Card className="border-0 shadow-sm">
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <CheckCircle className="h-5 w-5 text-blue-600" />
-                <span className="text-sm text-blue-700 font-medium">
+                <CheckCircle className="h-5 w-5 text-primary" />
+                <span className="text-sm text-primary font-medium">
                   Ready to create your new GL account
                 </span>
               </div>
@@ -439,7 +439,7 @@ export default function NewAccountPage() {
                 <Button
                   type="submit"
                   disabled={submitting}
-                  className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg flex items-center gap-2"
+                  className="flex items-center gap-2"
                 >
                   {submitting ? (
                     <>

--- a/app/(application)/accounting/chart-of-accounts/new/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/new/page.tsx
@@ -211,8 +211,8 @@ export default function NewAccountPage() {
         <Card className="border-0 shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-blue-100 flex items-center justify-center">
-                <FileText className="h-5 w-5 text-blue-600" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <FileText className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Basic Information</CardTitle>
@@ -309,8 +309,8 @@ export default function NewAccountPage() {
         <Card className="border-0 shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-purple-100 flex items-center justify-center">
-                <Settings className="h-5 w-5 text-purple-600" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <Settings className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Advanced Settings</CardTitle>
@@ -389,8 +389,8 @@ export default function NewAccountPage() {
         <Card className="border-0 shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-green-100 flex items-center justify-center">
-                <FileText className="h-5 w-5 text-green-600" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <FileText className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Description</CardTitle>

--- a/app/(application)/accounting/chart-of-accounts/new/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/new/page.tsx
@@ -208,7 +208,7 @@ export default function NewAccountPage() {
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Basic Information Card */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
@@ -306,7 +306,7 @@ export default function NewAccountPage() {
         </Card>
 
         {/* Advanced Settings Card */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
@@ -336,7 +336,7 @@ export default function NewAccountPage() {
                     {chartAccounts.map((p: any) => (
                       <SelectItem key={p.id} value={p.id.toString()}>
                         <div className="flex items-center gap-2">
-                          <Building2 className="h-4 w-4 text-gray-400" />
+                          <Building2 className="h-4 w-4 text-muted-foreground" />
                           <span>{p.name}</span>
                         </div>
                       </SelectItem>
@@ -359,7 +359,7 @@ export default function NewAccountPage() {
                     {tagOptions.map((t: any) => (
                       <SelectItem key={t.id} value={t.id.toString()}>
                         <div className="flex items-center gap-2">
-                          <Tag className="h-4 w-4 text-gray-400" />
+                          <Tag className="h-4 w-4 text-muted-foreground" />
                           <span>{t.name}</span>
                         </div>
                       </SelectItem>
@@ -370,7 +370,7 @@ export default function NewAccountPage() {
             </div>
 
             {/* Manual Entries Allowed */}
-            <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+            <div className="flex items-center justify-between p-4 bg-muted/50 rounded-lg">
               <div className="space-y-1">
                 <Label className="text-sm font-medium">Manual Entries Allowed</Label>
                 <p className="text-xs text-muted-foreground">
@@ -386,7 +386,7 @@ export default function NewAccountPage() {
         </Card>
 
         {/* Description Card */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
@@ -418,7 +418,7 @@ export default function NewAccountPage() {
         </Card>
 
         {/* Actions */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/app/(application)/accounting/chart-of-accounts/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/page.tsx
@@ -256,7 +256,6 @@ export default function ChartOfAccountsPage() {
             <Card key={acc.id} className="group hover:shadow-lg hover:scale-[1.02] transition-all duration-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-4">
-                  {/* Icon with gradient background */}
                   <div className={`h-10 w-10 rounded-xl ${config.bgColor} flex items-center justify-center flex-shrink-0 shadow-sm group-hover:shadow-md transition-shadow duration-300`}>
                     <IconComponent className={`h-5 w-5 ${config.color}`} />
                   </div>
@@ -286,7 +285,6 @@ export default function ChartOfAccountsPage() {
                       
                       {/* Right side info with enhanced badges */}
                       <div className="flex items-center gap-2 flex-shrink-0">
-                        {/* Type Badge with gradient */}
                         <Badge
                           variant="outline"
                           className={`text-xs h-6 px-3 ${config.color} border-current ${config.bgColor} hover:shadow-sm transition-all duration-200`}

--- a/app/(application)/accounting/chart-of-accounts/page.tsx
+++ b/app/(application)/accounting/chart-of-accounts/page.tsx
@@ -81,11 +81,11 @@ export default function ChartOfAccountsPage() {
 
   if (error) {
     return (
-      <Card className="border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950">
+      <Card>
         <CardContent className="pt-6">
           <div className="text-center">
-            <div className="text-red-600 dark:text-red-400 font-medium">Error loading accounts</div>
-            <div className="text-sm text-red-500 dark:text-red-300 mt-1">{error.message}</div>
+            <div className="text-destructive font-medium">Error loading accounts</div>
+            <div className="text-sm text-destructive mt-1">{error.message}</div>
           </div>
         </CardContent>
       </Card>
@@ -97,21 +97,21 @@ export default function ChartOfAccountsPage() {
       <div className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {[...Array(4)].map((_, i) => (
-            <Card key={i} className="animate-pulse border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+            <Card key={i} className="animate-pulse">
               <CardContent className="pt-6">
-                <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-3/4 mb-2"></div>
-                <div className="h-8 bg-slate-200 dark:bg-slate-700 rounded w-1/2"></div>
+                <div className="h-4 bg-muted rounded w-3/4 mb-2"></div>
+                <div className="h-8 bg-muted rounded w-1/2"></div>
               </CardContent>
             </Card>
           ))}
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[...Array(6)].map((_, i) => (
-            <Card key={i} className="animate-pulse border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+            <Card key={i} className="animate-pulse">
               <CardContent className="pt-6">
-                <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/2 mb-2"></div>
-                <div className="h-6 bg-slate-200 dark:bg-slate-700 rounded w-3/4 mb-2"></div>
-                <div className="h-3 bg-slate-200 dark:bg-slate-700 rounded w-full"></div>
+                <div className="h-4 bg-muted rounded w-1/2 mb-2"></div>
+                <div className="h-6 bg-muted rounded w-3/4 mb-2"></div>
+                <div className="h-3 bg-muted rounded w-full"></div>
               </CardContent>
             </Card>
           ))}
@@ -120,38 +120,14 @@ export default function ChartOfAccountsPage() {
     );
   }
 
-  // Type configuration with dark mode support
+  // Type configuration
   const typeConfig: Record<string, { color: string; bgColor: string; icon: any }> = {
-    ASSET: { 
-      color: 'text-emerald-600 dark:text-emerald-400', 
-      bgColor: 'bg-emerald-50 dark:bg-emerald-950', 
-      icon: TrendingUp 
-    },
-    LIABILITY: { 
-      color: 'text-amber-600 dark:text-amber-400', 
-      bgColor: 'bg-amber-50 dark:bg-amber-950', 
-      icon: TrendingDown 
-    },
-    INCOME: { 
-      color: 'text-blue-600 dark:text-blue-400', 
-      bgColor: 'bg-blue-50 dark:bg-blue-950', 
-      icon: TrendingUp 
-    },
-    REVENUE: { 
-      color: 'text-blue-600 dark:text-blue-400', 
-      bgColor: 'bg-blue-50 dark:bg-blue-950', 
-      icon: TrendingUp 
-    },
-    EQUITY: { 
-      color: 'text-purple-600 dark:text-purple-400', 
-      bgColor: 'bg-purple-50 dark:bg-purple-950', 
-      icon: Circle 
-    },
-    EXPENSE: { 
-      color: 'text-red-600 dark:text-red-400', 
-      bgColor: 'bg-red-50 dark:bg-red-950', 
-      icon: TrendingDown 
-    },
+    ASSET: { color: 'text-emerald-500', bgColor: 'bg-emerald-500/20', icon: TrendingUp },
+    LIABILITY: { color: 'text-amber-500', bgColor: 'bg-amber-500/20', icon: TrendingDown },
+    INCOME: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    REVENUE: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    EQUITY: { color: 'text-purple-500', bgColor: 'bg-purple-500/20', icon: Circle },
+    EXPENSE: { color: 'text-red-500', bgColor: 'bg-red-500/20', icon: TrendingDown },
   };
 
   return (
@@ -159,14 +135,14 @@ export default function ChartOfAccountsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Chart of Accounts</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-bold text-foreground">Chart of Accounts</h1>
+          <p className="text-muted-foreground mt-1">
             Manage your general ledger accounts and financial structure
           </p>
         </div>
         <Link href="/accounting/chart-of-accounts/new">
-          <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg">
-            <Plus className="w-4 h-4 mr-2" /> 
+          <Button>
+            <Plus className="w-4 h-4 mr-2" />
             New Account
           </Button>
         </Link>
@@ -174,57 +150,57 @@ export default function ChartOfAccountsPage() {
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950 dark:to-indigo-950">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-blue-600 dark:text-blue-400">Total Accounts</p>
-                <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">{stats.total}</p>
+                <p className="text-sm font-medium text-blue-500">Total Accounts</p>
+                <p className="text-2xl font-bold text-foreground">{stats.total}</p>
               </div>
-              <div className="h-12 w-12 rounded-lg bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-                <BookOpen className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+              <div className="h-12 w-12 rounded-lg bg-blue-500/20 flex items-center justify-center">
+                <BookOpen className="h-6 w-6 text-blue-500" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-gradient-to-br from-emerald-50 to-green-50 dark:from-emerald-950 dark:to-green-950">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">Active</p>
-                <p className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">{stats.active}</p>
+                <p className="text-sm font-medium text-emerald-500">Active</p>
+                <p className="text-2xl font-bold text-foreground">{stats.active}</p>
               </div>
-              <div className="h-12 w-12 rounded-lg bg-emerald-100 dark:bg-emerald-900 flex items-center justify-center">
-                <Circle className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              <div className="h-12 w-12 rounded-lg bg-emerald-500/20 flex items-center justify-center">
+                <Circle className="h-6 w-6 text-emerald-500" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-gradient-to-br from-red-50 to-pink-50 dark:from-red-950 dark:to-pink-950">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-red-600 dark:text-red-400">Disabled</p>
-                <p className="text-2xl font-bold text-red-900 dark:text-red-100">{stats.disabled}</p>
+                <p className="text-sm font-medium text-red-500">Disabled</p>
+                <p className="text-2xl font-bold text-foreground">{stats.disabled}</p>
               </div>
-              <div className="h-12 w-12 rounded-lg bg-red-100 dark:bg-red-900 flex items-center justify-center">
-                <Circle className="h-6 w-6 text-red-600 dark:text-red-400" />
+              <div className="h-12 w-12 rounded-lg bg-red-500/20 flex items-center justify-center">
+                <Circle className="h-6 w-6 text-red-500" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-gradient-to-br from-purple-50 to-violet-50 dark:from-purple-950 dark:to-violet-950">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-purple-600 dark:text-purple-400">Types</p>
-                <p className="text-2xl font-bold text-purple-900 dark:text-purple-100">{Object.keys(stats.types).length}</p>
+                <p className="text-sm font-medium text-purple-500">Types</p>
+                <p className="text-2xl font-bold text-foreground">{Object.keys(stats.types).length}</p>
               </div>
-              <div className="h-12 w-12 rounded-lg bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
-                <Tag className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+              <div className="h-12 w-12 rounded-lg bg-purple-500/20 flex items-center justify-center">
+                <Tag className="h-6 w-6 text-purple-500" />
               </div>
             </div>
           </CardContent>
@@ -232,33 +208,33 @@ export default function ChartOfAccountsPage() {
       </div>
 
       {/* Filters */}
-      <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-white dark:bg-slate-800">
+      <Card>
         <CardContent className="pt-6">
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-4 w-4" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
               <Input
                 placeholder="Search accounts by name or code..."
                 value={search}
                 onChange={e => { setSearch(e.target.value); setPage(1); }}
-                className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                className="pl-10"
               />
             </div>
             <Select
               value={filterType}
               onValueChange={v => { setFilterType(v); setPage(1); }}
             >
-              <SelectTrigger className="w-48 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
-                <Filter className="h-4 w-4 mr-2 text-slate-400 dark:text-slate-500" />
+              <SelectTrigger className="w-48">
+                <Filter className="h-4 w-4 mr-2 text-muted-foreground" />
                 <SelectValue placeholder="Filter by type" />
               </SelectTrigger>
-              <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
-                <SelectItem value="all" className="text-slate-900 dark:text-slate-100">All Types</SelectItem>
-                <SelectItem value="asset" className="text-slate-900 dark:text-slate-100">Assets</SelectItem>
-                <SelectItem value="liability" className="text-slate-900 dark:text-slate-100">Liabilities</SelectItem>
-                <SelectItem value="equity" className="text-slate-900 dark:text-slate-100">Equity</SelectItem>
-                <SelectItem value="income" className="text-slate-900 dark:text-slate-100">Income</SelectItem>
-                <SelectItem value="expense" className="text-slate-900 dark:text-slate-100">Expenses</SelectItem>
+              <SelectContent>
+                <SelectItem value="all">All Types</SelectItem>
+                <SelectItem value="asset">Assets</SelectItem>
+                <SelectItem value="liability">Liabilities</SelectItem>
+                <SelectItem value="equity">Equity</SelectItem>
+                <SelectItem value="income">Income</SelectItem>
+                <SelectItem value="expense">Expenses</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -269,15 +245,15 @@ export default function ChartOfAccountsPage() {
       <div className="space-y-2">
         {paginated.map((acc: any) => {
           const typeKey = (acc.type?.value || '').toUpperCase();
-          const config = typeConfig[typeKey] || { 
-            color: 'text-slate-600 dark:text-slate-400', 
-            bgColor: 'bg-slate-50 dark:bg-slate-800', 
-            icon: FileText 
+          const config = typeConfig[typeKey] || {
+            color: 'text-muted-foreground',
+            bgColor: 'bg-muted',
+            icon: FileText
           };
           const IconComponent = config.icon;
           
           return (
-            <Card key={acc.id} className="group hover:shadow-lg hover:scale-[1.02] transition-all duration-300 border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700">
+            <Card key={acc.id} className="group hover:shadow-lg hover:scale-[1.02] transition-all duration-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-4">
                   {/* Icon with gradient background */}
@@ -291,18 +267,18 @@ export default function ChartOfAccountsPage() {
                       <div className="flex items-center gap-4">
                         {/* Title and Description */}
                         <div className="min-w-0">
-                          <h3 className="font-semibold text-slate-900 dark:text-slate-100 text-sm truncate group-hover:text-primary transition-colors duration-300">
+                          <h3 className="font-semibold text-foreground text-sm truncate group-hover:text-primary transition-colors duration-300">
                             {acc.name}
                           </h3>
-                          <p className="text-xs text-slate-500 dark:text-slate-400 truncate mt-0.5">
+                          <p className="text-xs text-muted-foreground truncate mt-0.5">
                             {acc.description || 'General ledger account'}
                           </p>
                         </div>
-                        
+
                         {/* GL Code with modern styling */}
                         <div className="flex items-center gap-1.5">
-                          <Hash className="h-3 w-3 text-slate-400 dark:text-slate-500" />
-                          <span className="text-xs font-mono text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 px-2.5 py-1 rounded-md border border-slate-200 dark:border-slate-600 flex-shrink-0">
+                          <Hash className="h-3 w-3 text-muted-foreground" />
+                          <span className="text-xs font-mono text-muted-foreground bg-muted px-2.5 py-1 rounded-md flex-shrink-0">
                             {acc.glCode || acc.glcode}
                           </span>
                         </div>
@@ -311,42 +287,42 @@ export default function ChartOfAccountsPage() {
                       {/* Right side info with enhanced badges */}
                       <div className="flex items-center gap-2 flex-shrink-0">
                         {/* Type Badge with gradient */}
-                        <Badge 
-                          variant="outline" 
-                          className={`text-xs h-6 px-3 ${config.color} border-current bg-gradient-to-r ${config.bgColor} hover:shadow-sm transition-all duration-200`}
+                        <Badge
+                          variant="outline"
+                          className={`text-xs h-6 px-3 ${config.color} border-current ${config.bgColor} hover:shadow-sm transition-all duration-200`}
                         >
                           {typeKey}
                         </Badge>
-                        
+
                         {/* Usage Badge */}
                         {acc.usage?.value && (
-                          <Badge 
-                            variant="secondary" 
-                            className="text-xs h-6 px-3 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors duration-200"
+                          <Badge
+                            variant="secondary"
+                            className="text-xs h-6 px-3 transition-colors duration-200"
                           >
                             {acc.usage.value.toUpperCase()}
                           </Badge>
                         )}
-                        
+
                         {/* Status Badge with animation */}
                         <div className="relative">
                           {!acc.disabled && (
                             <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-green-500 animate-pulse" />
                           )}
-                          <Badge 
+                          <Badge
                             variant={acc.disabled ? "destructive" : "default"}
-                            className={`text-xs h-6 px-3 ${acc.disabled ? 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800' : 'bg-green-100 dark:bg-green-950 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800'} border transition-all duration-200`}
+                            className={`text-xs h-6 px-3 border ${acc.disabled ? 'text-red-500 bg-red-500/20 border-red-500/30' : 'text-green-500 bg-green-500/20 border-green-500/30'} transition-all duration-200`}
                           >
                             {acc.disabled ? 'Disabled' : 'Active'}
                           </Badge>
                         </div>
-                        
+
                         {/* Action button with enhanced styling */}
                         <Link href={`/accounting/chart-of-accounts/${acc.id}`}>
-                          <Button 
-                            variant="ghost" 
-                            size="sm" 
-                            className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-all duration-300 hover:bg-primary/10 hover:text-primary rounded-lg text-slate-600 dark:text-slate-400"
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-all duration-300 hover:bg-primary/10 hover:text-primary rounded-lg text-muted-foreground"
                           >
                             <Eye className="w-4 h-4" />
                           </Button>
@@ -363,19 +339,18 @@ export default function ChartOfAccountsPage() {
 
       {/* Pagination */}
       {pageCount > 1 && (
-        <Card className="border border-slate-200 dark:border-slate-700 shadow-sm bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-600 dark:text-slate-400">
+              <div className="text-sm text-muted-foreground">
                 Showing {((page - 1) * pageSize) + 1} to {Math.min(page * pageSize, filtered.length)} of {filtered.length} accounts
               </div>
               <div className="flex items-center gap-2">
-                <Button 
-                  size="sm" 
+                <Button
+                  size="sm"
                   variant="outline"
-                  disabled={page <= 1} 
+                  disabled={page <= 1}
                   onClick={() => setPage(p => p - 1)}
-                  className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
                 >
                   Previous
                 </Button>
@@ -388,19 +363,18 @@ export default function ChartOfAccountsPage() {
                         size="sm"
                         variant={page === pageNum ? "default" : "outline"}
                         onClick={() => setPage(pageNum)}
-                        className={`w-8 h-8 p-0 ${page === pageNum ? '' : 'border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'}`}
+                        className="w-8 h-8 p-0"
                       >
                         {pageNum}
                       </Button>
                     );
                   })}
                 </div>
-                <Button 
-                  size="sm" 
+                <Button
+                  size="sm"
                   variant="outline"
-                  disabled={page >= pageCount} 
+                  disabled={page >= pageCount}
                   onClick={() => setPage(p => p + 1)}
-                  className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
                 >
                   Next
                 </Button>
@@ -408,12 +382,12 @@ export default function ChartOfAccountsPage() {
                   value={String(pageSize)}
                   onValueChange={v => { setPageSize(Number(v)); setPage(1); }}
                 >
-                  <SelectTrigger className="w-24 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
+                  <SelectTrigger className="w-24">
                     <SelectValue placeholder="Items" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                  <SelectContent>
                     {[6, 12, 24, 48].map(n => (
-                      <SelectItem key={n} value={String(n)} className="text-slate-900 dark:text-slate-100">
+                      <SelectItem key={n} value={String(n)}>
                         {n} / page
                       </SelectItem>
                     ))}

--- a/app/(application)/accounting/closing-entries/[id]/edit/page.tsx
+++ b/app/(application)/accounting/closing-entries/[id]/edit/page.tsx
@@ -16,7 +16,7 @@ export default function EditClosurePage({ params }: { params: { id: string } }) 
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-        <p className="text-slate-600 dark:text-slate-400">Redirecting to edit mode...</p>
+        <p className="text-muted-foreground">Redirecting to edit mode...</p>
       </div>
     </div>
   );

--- a/app/(application)/accounting/closing-entries/[id]/page.tsx
+++ b/app/(application)/accounting/closing-entries/[id]/page.tsx
@@ -185,16 +185,16 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
     return (
       <div className="space-y-6">
         <div className="flex items-center gap-4">
-          <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-20 animate-pulse"></div>
-          <div className="h-8 bg-slate-200 dark:bg-slate-700 rounded w-48 animate-pulse"></div>
+          <div className="h-10 bg-muted rounded w-20 animate-pulse"></div>
+          <div className="h-8 bg-muted rounded w-48 animate-pulse"></div>
         </div>
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="space-y-4">
               {[...Array(6)].map((_, i) => (
                 <div key={i} className="flex items-center gap-4">
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-24 animate-pulse"></div>
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-48 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-24 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-48 animate-pulse"></div>
                 </div>
               ))}
             </div>
@@ -213,13 +213,13 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
             Back
           </Button>
         </div>
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="text-center py-12">
-              <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2">
+              <h3 className="text-lg font-medium text-foreground mb-2">
                 Closing entry not found
               </h3>
-              <p className="text-slate-600 dark:text-slate-400">
+              <p className="text-muted-foreground">
                 The closing entry you're looking for doesn't exist or has been deleted.
               </p>
             </div>
@@ -239,8 +239,8 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
             Back
           </Button>
           <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Closing Entry Details</h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
+            <h1 className="text-2xl font-bold text-foreground">Closing Entry Details</h1>
+            <p className="text-muted-foreground mt-1">
               View and manage closing entry information
             </p>
           </div>
@@ -249,7 +249,6 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
           <Button
             variant="outline"
             onClick={() => setIsEditing(!isEditing)}
-            className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
           >
             <Edit className="w-4 h-4 mr-2" />
             {isEditing ? 'Cancel Edit' : 'Edit'}
@@ -257,7 +256,7 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
           <Button
             variant="outline"
             onClick={() => setShowDeleteDialog(true)}
-            className="border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950"
+            className="border-red-500/20 text-red-500 hover:bg-red-500/10 hover:text-red-600"
           >
             <Trash2 className="w-4 h-4 mr-2" />
             Delete
@@ -266,9 +265,9 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
       </div>
 
       {/* Main Content */}
-      <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <CardTitle className="text-lg">
             Closure Information
           </CardTitle>
         </CardHeader>
@@ -277,16 +276,16 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
             // Edit Form
             <form onSubmit={handleEditSubmit} className="space-y-6">
               <div>
-                <Label htmlFor="comments" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                <Label htmlFor="comments">
                   Comments
                 </Label>
                 <div className="relative mt-1">
-                  <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-slate-400" />
+                  <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-muted-foreground" />
                   <textarea
                     id="comments"
                     value={editComments}
                     onChange={(e) => setEditComments(e.target.value)}
-                    className="w-full pl-10 pr-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-md text-slate-900 dark:text-slate-100 resize-none"
+                    className="w-full pl-10 pr-3 py-2 border rounded-md bg-transparent resize-none"
                     rows={3}
                     placeholder="Enter comments about this closure"
                   />
@@ -300,7 +299,6 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
                     setIsEditing(false);
                     setEditComments(closure.comments || '');
                   }}
-                  className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
                 >
                   <X className="w-4 h-4 mr-2" />
                   Cancel
@@ -308,7 +306,6 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
                 <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <Save className="w-4 h-4 mr-2" />
                   {isSubmitting ? 'Saving...' : 'Save Changes'}
@@ -321,62 +318,62 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-4">
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Office</Label>
+                    <Label>Office</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <Building2 className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100 font-medium">{closure.officeName}</span>
+                      <Building2 className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground font-medium">{closure.officeName}</span>
                     </div>
                   </div>
-                  
+
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Closing Date</Label>
+                    <Label>Closing Date</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <Calendar className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100">{formatDateArray(closure.closingDate)}</span>
+                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{formatDateArray(closure.closingDate)}</span>
                     </div>
                   </div>
-                  
+
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Comments</Label>
+                    <Label>Comments</Label>
                     <div className="flex items-start gap-2 mt-1">
-                      <MessageSquare className="h-4 w-4 text-slate-400 mt-0.5" />
-                      <span className="text-slate-600 dark:text-slate-400">
+                      <MessageSquare className="h-4 w-4 text-muted-foreground mt-0.5" />
+                      <span className="text-muted-foreground">
                         {closure.comments || 'No comments provided'}
                       </span>
                     </div>
                   </div>
                 </div>
-                
+
                 <div className="space-y-4">
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Created By</Label>
+                    <Label>Created By</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <User className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100">{closure.createdByUsername}</span>
+                      <User className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{closure.createdByUsername}</span>
                     </div>
                   </div>
-                  
+
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Created Date</Label>
+                    <Label>Created Date</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <Clock className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100">{formatDateArray(closure.createdDate)}</span>
+                      <Clock className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{formatDateArray(closure.createdDate)}</span>
                     </div>
                   </div>
-                  
+
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Last Updated</Label>
+                    <Label>Last Updated</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <Clock className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100">{formatDateArray(closure.lastUpdatedDate)}</span>
+                      <Clock className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{formatDateArray(closure.lastUpdatedDate)}</span>
                     </div>
                   </div>
-                  
+
                   <div>
-                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">Updated By</Label>
+                    <Label>Updated By</Label>
                     <div className="flex items-center gap-2 mt-1">
-                      <User className="h-4 w-4 text-slate-400" />
-                      <span className="text-slate-900 dark:text-slate-100">{closure.lastUpdatedByUsername}</span>
+                      <User className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{closure.lastUpdatedByUsername}</span>
                     </div>
                   </div>
                 </div>
@@ -404,10 +401,10 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <DialogContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+        <DialogContent>
           <DialogHeader>
-            <DialogTitle className="text-slate-900 dark:text-slate-100">Delete Closing Entry</DialogTitle>
-            <DialogDescription className="text-slate-600 dark:text-slate-400">
+            <DialogTitle>Delete Closing Entry</DialogTitle>
+            <DialogDescription>
               Are you sure you want to delete this closing entry? This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
@@ -415,7 +412,6 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
             <Button
               variant="outline"
               onClick={() => setShowDeleteDialog(false)}
-              className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
             >
               Cancel
             </Button>
@@ -423,7 +419,6 @@ export default function ViewClosurePage({ params, searchParams }: { params: { id
               variant="destructive"
               onClick={handleDelete}
               disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700 text-white"
             >
               <Trash2 className="w-4 h-4 mr-2" />
               {isDeleting ? 'Deleting...' : 'Delete'}

--- a/app/(application)/accounting/closing-entries/new/page.tsx
+++ b/app/(application)/accounting/closing-entries/new/page.tsx
@@ -147,16 +147,16 @@ export default function CreateClosurePage() {
     return (
       <div className="space-y-6">
         <div className="flex items-center gap-4">
-          <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-20 animate-pulse"></div>
-          <div className="h-8 bg-slate-200 dark:bg-slate-700 rounded w-48 animate-pulse"></div>
+          <div className="h-10 bg-muted rounded w-20 animate-pulse"></div>
+          <div className="h-8 bg-muted rounded w-48 animate-pulse"></div>
         </div>
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="space-y-4">
               {[...Array(3)].map((_, i) => (
                 <div key={i}>
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-24 mb-2 animate-pulse"></div>
-                  <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-full animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-24 mb-2 animate-pulse"></div>
+                  <div className="h-10 bg-muted rounded w-full animate-pulse"></div>
                 </div>
               ))}
             </div>
@@ -175,8 +175,8 @@ export default function CreateClosurePage() {
           Back
         </Button>
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Closing Entry</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-bold text-foreground">Create Closing Entry</h1>
+          <p className="text-muted-foreground mt-1">
             Create a new GL closure for period-end procedures
           </p>
         </div>
@@ -184,26 +184,26 @@ export default function CreateClosurePage() {
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Form Card */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 max-w-2xl">
+        <Card className="max-w-2xl">
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            <CardTitle className="text-lg">
               Closure Information
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
             {/* Office Selection */}
             <div>
-              <Label htmlFor="office" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              <Label htmlFor="office">
                 Office *
               </Label>
               <Select value={officeId} onValueChange={setOfficeId} required>
-                <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
-                  <Building2 className="w-4 h-4 mr-2 text-slate-400" />
+                <SelectTrigger className="mt-1">
+                  <Building2 className="w-4 h-4 mr-2 text-muted-foreground" />
                   <SelectValue placeholder="Select office" />
                 </SelectTrigger>
-                <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                <SelectContent>
                   {offices.map((office) => (
-                    <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                    <SelectItem key={office.id} value={office.id.toString()}>
                       {office.name}
                     </SelectItem>
                   ))}
@@ -213,7 +213,7 @@ export default function CreateClosurePage() {
 
             {/* Closing Date */}
             <div>
-              <Label htmlFor="closingDate" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              <Label htmlFor="closingDate">
                 Closing Date *
               </Label>
               <Popover>
@@ -221,15 +221,15 @@ export default function CreateClosurePage() {
                   <Button
                     variant="outline"
                     className={cn(
-                      "w-full justify-start text-left font-normal mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600",
-                      !closingDate && "text-slate-500 dark:text-slate-400"
+                      "w-full justify-start text-left font-normal mt-1",
+                      !closingDate && "text-muted-foreground"
                     )}
                   >
                     <CalendarIcon className="mr-2 h-4 w-4" />
                     {closingDate ? format(closingDate, "PPP") : <span>Pick a date</span>}
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="w-auto p-0 bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                <PopoverContent className="w-auto p-0">
                   <Calendar
                     mode="single"
                     selected={closingDate}
@@ -242,16 +242,16 @@ export default function CreateClosurePage() {
 
             {/* Comments */}
             <div>
-              <Label htmlFor="comments" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              <Label htmlFor="comments">
                 Comments
               </Label>
               <div className="relative mt-1">
-                <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-slate-400" />
+                <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-muted-foreground" />
                 <textarea
                   id="comments"
                   value={comments}
                   onChange={(e) => setComments(e.target.value)}
-                  className="w-full pl-10 pr-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-md text-slate-900 dark:text-slate-100 resize-none"
+                  className="w-full pl-10 pr-3 py-2 border rounded-md bg-transparent resize-none"
                   rows={3}
                   placeholder="Enter comments about this closure"
                 />
@@ -261,21 +261,19 @@ export default function CreateClosurePage() {
         </Card>
 
         {/* Action Buttons */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 max-w-2xl">
+        <Card className="max-w-2xl">
           <CardContent className="pt-6">
             <div className="flex justify-end gap-4">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => router.back()}
-                className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
               >
                 Cancel
               </Button>
               <Button
                 type="submit"
                 disabled={isSubmitting || !officeId || !closingDate}
-                className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Save className="w-4 h-4 mr-2" />
                 {isSubmitting ? 'Creating...' : 'Create Closure'}

--- a/app/(application)/accounting/closing-entries/page.tsx
+++ b/app/(application)/accounting/closing-entries/page.tsx
@@ -169,34 +169,34 @@ export default function ClosingEntriesPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Closing Entries</h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
+            <h1 className="text-2xl font-bold text-foreground">Closing Entries</h1>
+            <p className="text-muted-foreground mt-1">
               Manage GL closures and period-end procedures
             </p>
           </div>
-          <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-32 animate-pulse"></div>
+          <div className="h-10 bg-muted rounded w-32 animate-pulse"></div>
         </div>
 
         {/* Filters */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex flex-col sm:flex-row gap-4">
-              <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-full animate-pulse"></div>
-              <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-48 animate-pulse"></div>
+              <div className="h-10 bg-muted rounded w-full animate-pulse"></div>
+              <div className="h-10 bg-muted rounded w-48 animate-pulse"></div>
             </div>
           </CardContent>
         </Card>
 
         {/* Table */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="space-y-4">
               {[...Array(5)].map((_, i) => (
                 <div key={i} className="flex items-center gap-4">
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/4 animate-pulse"></div>
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/4 animate-pulse"></div>
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/3 animate-pulse"></div>
-                  <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/6 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-1/4 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-1/4 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-1/3 animate-pulse"></div>
+                  <div className="h-4 bg-muted rounded w-1/6 animate-pulse"></div>
                 </div>
               ))}
             </div>
@@ -211,13 +211,13 @@ export default function ClosingEntriesPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Closing Entries</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-bold text-foreground">Closing Entries</h1>
+          <p className="text-muted-foreground mt-1">
             Manage GL closures and period-end procedures
           </p>
         </div>
         <Link href="/accounting/closing-entries/new">
-          <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg">
+          <Button>
             <Plus className="w-4 h-4 mr-2" />
             Create Closure
           </Button>
@@ -225,32 +225,32 @@ export default function ClosingEntriesPage() {
       </div>
 
       {/* Filters */}
-      <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+      <Card>
         <CardContent className="pt-6">
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 dark:text-slate-500 h-4 w-4" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
               <Input
                 placeholder="Search by office, comments, or user..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                className="pl-10"
               />
             </div>
                           <Select
                 value={selectedOffice}
                 onValueChange={setSelectedOffice}
               >
-                <SelectTrigger className="w-48 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100">
-                  <Filter className="h-4 w-4 mr-2 text-slate-400 dark:text-slate-500" />
+                <SelectTrigger className="w-48">
+                  <Filter className="h-4 w-4 mr-2 text-muted-foreground" />
                   <SelectValue placeholder="Filter by office" />
                 </SelectTrigger>
-                <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
-                  <SelectItem value="all" className="text-slate-900 dark:text-slate-100">
+                <SelectContent>
+                  <SelectItem value="all">
                     All Offices
                   </SelectItem>
                   {offices.map((office) => (
-                    <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                    <SelectItem key={office.id} value={office.id.toString()}>
                       {office.name}
                     </SelectItem>
                   ))}
@@ -259,7 +259,6 @@ export default function ClosingEntriesPage() {
             <Button
               variant="outline"
               onClick={fetchData}
-              className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
             >
               <RefreshCw className="w-4 h-4 mr-2" />
               Refresh
@@ -269,22 +268,22 @@ export default function ClosingEntriesPage() {
       </Card>
 
       {/* Table */}
-      <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+      <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <CardTitle className="text-lg">
             Closing Entries ({filteredClosures.length})
           </CardTitle>
         </CardHeader>
         <CardContent>
           {filteredClosures.length === 0 ? (
             <div className="text-center py-12">
-              <div className="h-12 w-12 mx-auto mb-4 bg-slate-100 dark:bg-slate-700 rounded-full flex items-center justify-center">
-                <Calendar className="h-6 w-6 text-slate-400 dark:text-slate-500" />
+              <div className="h-12 w-12 mx-auto mb-4 bg-primary/10 rounded-full flex items-center justify-center">
+                <Calendar className="h-6 w-6 text-primary" />
               </div>
-              <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2">
+              <h3 className="text-lg font-medium text-foreground mb-2">
                 No closing entries found
               </h3>
-              <p className="text-slate-600 dark:text-slate-400 mb-6">
+              <p className="text-muted-foreground mb-6">
                 {searchTerm || (selectedOffice && selectedOffice !== 'all')
                   ? 'Try adjusting your search or filter criteria.'
                   : 'Get started by creating your first closing entry.'
@@ -292,7 +291,7 @@ export default function ClosingEntriesPage() {
               </p>
               {!searchTerm && (selectedOffice === 'all' || !selectedOffice) && (
                 <Link href="/accounting/closing-entries/new">
-                  <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white">
+                  <Button>
                     <Plus className="w-4 h-4 mr-2" />
                     Create First Closure
                   </Button>
@@ -303,35 +302,35 @@ export default function ClosingEntriesPage() {
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
-                  <TableRow className="border-slate-200 dark:border-slate-700">
-                    <TableHead className="text-slate-700 dark:text-slate-300 font-medium">Office</TableHead>
-                    <TableHead className="text-slate-700 dark:text-slate-300 font-medium">Closure Date</TableHead>
-                    <TableHead className="text-slate-700 dark:text-slate-300 font-medium">Comments</TableHead>
-                    <TableHead className="text-slate-700 dark:text-slate-300 font-medium">Created By</TableHead>
-                    <TableHead className="text-slate-700 dark:text-slate-300 font-medium text-right">Actions</TableHead>
+                  <TableRow>
+                    <TableHead>Office</TableHead>
+                    <TableHead>Closure Date</TableHead>
+                    <TableHead>Comments</TableHead>
+                    <TableHead>Created By</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {filteredClosures.map((closure) => (
-                    <TableRow key={closure.id} className="border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700">
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                    <TableRow key={closure.id}>
+                      <TableCell>
                         <div className="flex items-center gap-2">
-                          <Building2 className="h-4 w-4 text-slate-400 dark:text-slate-500" />
+                          <Building2 className="h-4 w-4 text-muted-foreground" />
                           <span className="font-medium">{closure.officeName}</span>
                         </div>
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         <div className="flex items-center gap-2">
-                          <Calendar className="h-4 w-4 text-slate-400 dark:text-slate-500" />
+                          <Calendar className="h-4 w-4 text-muted-foreground" />
                           <span>{formatDate(closure.closingDate)}</span>
                         </div>
                       </TableCell>
-                      <TableCell className="text-slate-600 dark:text-slate-400 max-w-xs truncate">
+                      <TableCell className="text-muted-foreground max-w-xs truncate">
                         {closure.comments || 'No comments'}
                       </TableCell>
-                      <TableCell className="text-slate-900 dark:text-slate-100">
+                      <TableCell>
                         <div className="flex items-center gap-2">
-                          <User className="h-4 w-4 text-slate-400 dark:text-slate-500" />
+                          <User className="h-4 w-4 text-muted-foreground" />
                           <span>{closure.createdByUsername}</span>
                         </div>
                       </TableCell>
@@ -341,7 +340,7 @@ export default function ClosingEntriesPage() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-8 w-8 p-0 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
+                              className="h-8 w-8 p-0"
                             >
                               <Eye className="w-4 h-4" />
                             </Button>
@@ -350,7 +349,7 @@ export default function ClosingEntriesPage() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-8 w-8 p-0 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
+                              className="h-8 w-8 p-0"
                             >
                               <Edit className="w-4 h-4" />
                             </Button>
@@ -360,7 +359,7 @@ export default function ClosingEntriesPage() {
                             size="sm"
                             onClick={() => handleDelete(closure.id)}
                             disabled={isDeleting === closure.id}
-                            className="h-8 w-8 p-0 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-950"
+                            className="h-8 w-8 p-0 text-red-500 hover:text-red-600"
                           >
                             <Trash2 className="w-4 h-4" />
                           </Button>

--- a/app/(application)/accounting/frequent-postings/page.tsx
+++ b/app/(application)/accounting/frequent-postings/page.tsx
@@ -335,14 +335,14 @@ export default function FrequentPostingsPage() {
             <ArrowLeft className="w-4 h-4 mr-2" />
             Back
           </Button>
-          <div className="h-8 bg-slate-200 dark:bg-slate-700 rounded w-48 animate-pulse"></div>
+          <div className="h-8 bg-muted rounded w-48 animate-pulse"></div>
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {[...Array(4)].map((_, i) => (
             <Card key={i} className="animate-pulse">
               <CardContent className="pt-6">
-                <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/3 mb-4"></div>
-                <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded w-full"></div>
+                <div className="h-4 bg-muted rounded w-1/3 mb-4"></div>
+                <div className="h-10 bg-muted rounded w-full"></div>
               </CardContent>
             </Card>
           ))}
@@ -360,8 +360,8 @@ export default function FrequentPostingsPage() {
           Back
         </Button>
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Frequent Postings</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-bold text-foreground">Frequent Postings</h1>
+          <p className="text-muted-foreground mt-1">
             Create journal entries using predefined accounting rules
           </p>
         </div>
@@ -369,9 +369,9 @@ export default function FrequentPostingsPage() {
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Basic Information */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            <CardTitle className="text-lg">
               Transaction Information
             </CardTitle>
           </CardHeader>
@@ -380,17 +380,17 @@ export default function FrequentPostingsPage() {
               {/* Left Column */}
               <div className="space-y-4">
                 <div>
-                  <Label htmlFor="office" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="office">
                     Office *
                   </Label>
                   <Select value={officeId} onValueChange={setOfficeId} required>
-                    <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
-                      <Building2 className="w-4 h-4 mr-2 text-slate-400" />
+                    <SelectTrigger className="mt-1">
+                      <Building2 className="w-4 h-4 mr-2 text-muted-foreground" />
                       <SelectValue placeholder="Select office" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                    <SelectContent>
                       {offices.map((office) => (
-                        <SelectItem key={office.id} value={office.id.toString()} className="text-slate-900 dark:text-slate-100">
+                        <SelectItem key={office.id} value={office.id.toString()}>
                           {office.name}
                         </SelectItem>
                       ))}
@@ -399,17 +399,17 @@ export default function FrequentPostingsPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="currency" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="currency">
                     Currency *
                   </Label>
                   <Select value={currencyCode} onValueChange={setCurrencyCode} required>
-                    <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
-                      <DollarSign className="w-4 h-4 mr-2 text-slate-400" />
+                    <SelectTrigger className="mt-1">
+                      <DollarSign className="w-4 h-4 mr-2 text-muted-foreground" />
                       <SelectValue placeholder="Select currency" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                    <SelectContent>
                       {currencies.map((currency) => (
-                        <SelectItem key={currency.code} value={currency.code} className="text-slate-900 dark:text-slate-100">
+                        <SelectItem key={currency.code} value={currency.code}>
                           {currency.displayLabel}
                         </SelectItem>
                       ))}
@@ -418,33 +418,33 @@ export default function FrequentPostingsPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="referenceNumber" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="referenceNumber">
                     Reference Number
                   </Label>
                   <div className="relative mt-1">
-                    <Hash className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <Hash className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="referenceNumber"
                       value={referenceNumber}
                       onChange={(e) => setReferenceNumber(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter reference number"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="paymentType" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="paymentType">
                     Payment Type
                   </Label>
                   <Select value={paymentTypeId} onValueChange={setPaymentTypeId}>
-                    <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
-                      <CreditCard className="w-4 h-4 mr-2 text-slate-400" />
+                    <SelectTrigger className="mt-1">
+                      <CreditCard className="w-4 h-4 mr-2 text-muted-foreground" />
                       <SelectValue placeholder="Select payment type" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                    <SelectContent>
                       {paymentTypes.map((type) => (
-                        <SelectItem key={type.id} value={type.id.toString()} className="text-slate-900 dark:text-slate-100">
+                        <SelectItem key={type.id} value={type.id.toString()}>
                           {type.name}
                         </SelectItem>
                       ))}
@@ -453,48 +453,48 @@ export default function FrequentPostingsPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="checkNumber" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="checkNumber">
                     Cheque Number
                   </Label>
                   <div className="relative mt-1">
-                    <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="checkNumber"
                       value={checkNumber}
                       onChange={(e) => setCheckNumber(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter cheque number"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="receiptNumber" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="receiptNumber">
                     Receipt Number
                   </Label>
                   <div className="relative mt-1">
-                    <Receipt className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <Receipt className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="receiptNumber"
                       value={receiptNumber}
                       onChange={(e) => setReceiptNumber(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter receipt number"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="comments" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="comments">
                     Comments
                   </Label>
                   <div className="relative mt-1">
-                    <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-slate-400" />
+                    <MessageSquare className="absolute left-3 top-3 w-4 h-4 text-muted-foreground" />
                     <textarea
                       id="comments"
                       value={comments}
                       onChange={(e) => setComments(e.target.value)}
-                      className="w-full pl-10 pr-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-md text-slate-900 dark:text-slate-100 resize-none"
+                      className="w-full pl-10 pr-3 py-2 border rounded-md resize-none"
                       rows={3}
                       placeholder="Enter comments"
                     />
@@ -505,17 +505,17 @@ export default function FrequentPostingsPage() {
               {/* Right Column */}
               <div className="space-y-4">
                 <div>
-                  <Label htmlFor="accountingRule" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="accountingRule">
                     Accounting Rule *
                   </Label>
                   <Select value={accountingRuleId} onValueChange={setAccountingRuleId} required>
-                    <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
-                      <FileText className="w-4 h-4 mr-2 text-slate-400" />
+                    <SelectTrigger className="mt-1">
+                      <FileText className="w-4 h-4 mr-2 text-muted-foreground" />
                       <SelectValue placeholder="Select accounting rule" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                    <SelectContent>
                       {accountingRules.map((rule) => (
-                        <SelectItem key={rule.id} value={rule.id.toString()} className="text-slate-900 dark:text-slate-100">
+                        <SelectItem key={rule.id} value={rule.id.toString()}>
                           {rule.name}
                         </SelectItem>
                       ))}
@@ -524,7 +524,7 @@ export default function FrequentPostingsPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="transactionDate" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="transactionDate">
                     Transaction Date *
                   </Label>
                   <Popover>
@@ -532,15 +532,15 @@ export default function FrequentPostingsPage() {
                       <Button
                         variant="outline"
                         className={cn(
-                          "w-full justify-start text-left font-normal mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600",
-                          !transactionDate && "text-slate-500 dark:text-slate-400"
+                          "w-full justify-start text-left font-normal mt-1",
+                          !transactionDate && "text-muted-foreground"
                         )}
                       >
                         <CalendarIcon className="mr-2 h-4 w-4" />
                         {transactionDate ? format(transactionDate, "PPP") : <span>Pick a date</span>}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0 bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                    <PopoverContent className="w-auto p-0">
                       <Calendar
                         mode="single"
                         selected={transactionDate}
@@ -552,48 +552,48 @@ export default function FrequentPostingsPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="accountNumber" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="accountNumber">
                     Account Number
                   </Label>
                   <div className="relative mt-1">
-                    <HashIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <HashIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="accountNumber"
                       value={accountNumber}
                       onChange={(e) => setAccountNumber(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter account number"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="routingCode" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="routingCode">
                     Routing Code
                   </Label>
                   <div className="relative mt-1">
-                    <Route className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <Route className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="routingCode"
                       value={routingCode}
                       onChange={(e) => setRoutingCode(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter routing code"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="bankNumber" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <Label htmlFor="bankNumber">
                     Bank Number
                   </Label>
                   <div className="relative mt-1">
-                    <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
                       id="bankNumber"
                       value={bankNumber}
                       onChange={(e) => setBankNumber(e.target.value)}
-                      className="pl-10 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                      className="pl-10"
                       placeholder="Enter bank number"
                     />
                   </div>
@@ -607,9 +607,9 @@ export default function FrequentPostingsPage() {
         {selectedRule && (
           <>
             {/* Debit Entries */}
-            <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+            <Card>
               <CardHeader>
-                <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <CardTitle className="text-lg">
                   Debit Entries
                 </CardTitle>
               </CardHeader>
@@ -618,7 +618,7 @@ export default function FrequentPostingsPage() {
                   {debitEntries.map((entry, index) => (
                     <div key={index} className="flex items-center gap-4">
                       <div className="flex-1">
-                        <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        <Label>
                           Affected GL Entry (Debit) *
                         </Label>
                         <Select
@@ -630,12 +630,12 @@ export default function FrequentPostingsPage() {
                           }}
                           required
                         >
-                          <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
+                          <SelectTrigger className="mt-1">
                             <SelectValue placeholder="Select GL account" />
                           </SelectTrigger>
-                          <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                          <SelectContent>
                             {glAccounts.map((account) => (
-                              <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                              <SelectItem key={account.id} value={account.id.toString()}>
                                 {account.name} ({account.glCode})
                               </SelectItem>
                             ))}
@@ -643,7 +643,7 @@ export default function FrequentPostingsPage() {
                         </Select>
                       </div>
                       <div className="flex-1">
-                        <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        <Label>
                           Debit Amount *
                         </Label>
                         <Input
@@ -656,7 +656,7 @@ export default function FrequentPostingsPage() {
                             newEntries[index].amount = parseFloat(e.target.value) || 0;
                             setDebitEntries(newEntries);
                           }}
-                          className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                          className="mt-1"
                           placeholder="0.00"
                           required
                         />
@@ -664,10 +664,10 @@ export default function FrequentPostingsPage() {
                       {debitEntries.length > 1 && (
                         <Button
                           type="button"
-                          variant="outline"
+                          variant="destructive"
                           size="sm"
                           onClick={() => removeDebitEntry(index)}
-                          className="mt-6 border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                          className="mt-6"
                         >
                           <Minus className="w-4 h-4" />
                         </Button>
@@ -679,7 +679,6 @@ export default function FrequentPostingsPage() {
                       type="button"
                       variant="outline"
                       onClick={addDebitEntry}
-                      className="border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700"
                     >
                       <Plus className="w-4 h-4 mr-2" />
                       Add Debit Entry
@@ -690,9 +689,9 @@ export default function FrequentPostingsPage() {
             </Card>
 
             {/* Credit Entries */}
-            <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+            <Card>
               <CardHeader>
-                <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <CardTitle className="text-lg">
                   Credit Entries
                 </CardTitle>
               </CardHeader>
@@ -701,7 +700,7 @@ export default function FrequentPostingsPage() {
                   {creditEntries.map((entry, index) => (
                     <div key={index} className="flex items-center gap-4">
                       <div className="flex-1">
-                        <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        <Label>
                           Affected GL Entry (Credit) *
                         </Label>
                         <Select
@@ -713,12 +712,12 @@ export default function FrequentPostingsPage() {
                           }}
                           required
                         >
-                          <SelectTrigger className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600">
+                          <SelectTrigger className="mt-1">
                             <SelectValue placeholder="Select GL account" />
                           </SelectTrigger>
-                          <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600">
+                          <SelectContent>
                             {glAccounts.map((account) => (
-                              <SelectItem key={account.id} value={account.id.toString()} className="text-slate-900 dark:text-slate-100">
+                              <SelectItem key={account.id} value={account.id.toString()}>
                                 {account.name} ({account.glCode})
                               </SelectItem>
                             ))}
@@ -726,7 +725,7 @@ export default function FrequentPostingsPage() {
                         </Select>
                       </div>
                       <div className="flex-1">
-                        <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        <Label>
                           Credit Amount *
                         </Label>
                         <Input
@@ -739,7 +738,7 @@ export default function FrequentPostingsPage() {
                             newEntries[index].amount = parseFloat(e.target.value) || 0;
                             setCreditEntries(newEntries);
                           }}
-                          className="mt-1 bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100"
+                          className="mt-1"
                           placeholder="0.00"
                           required
                         />
@@ -747,10 +746,10 @@ export default function FrequentPostingsPage() {
                       {creditEntries.length > 1 && (
                         <Button
                           type="button"
-                          variant="outline"
+                          variant="destructive"
                           size="sm"
                           onClick={() => removeCreditEntry(index)}
-                          className="mt-6 border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                          className="mt-6"
                         >
                           <Minus className="w-4 h-4" />
                         </Button>
@@ -762,7 +761,6 @@ export default function FrequentPostingsPage() {
                       type="button"
                       variant="outline"
                       onClick={addCreditEntry}
-                      className="border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700"
                     >
                       <Plus className="w-4 h-4 mr-2" />
                       Add Credit Entry
@@ -773,43 +771,43 @@ export default function FrequentPostingsPage() {
             </Card>
 
             {/* Balance Summary */}
-            <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+            <Card>
               <CardHeader>
-                <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <CardTitle className="text-lg">
                   Balance Summary
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="p-4 bg-red-50 dark:bg-red-950 rounded-lg border border-red-200 dark:border-red-800">
-                    <div className="text-sm font-medium text-red-600 dark:text-red-400">Total Debit</div>
-                    <div className="text-2xl font-bold text-red-700 dark:text-red-300">
+                  <div className="p-4 bg-red-500/20 rounded-lg">
+                    <div className="text-sm font-medium text-red-500">Total Debit</div>
+                    <div className="text-2xl font-bold text-red-500">
                       {currencyCode} {totalDebit.toFixed(2)}
                     </div>
                   </div>
-                  <div className="p-4 bg-green-50 dark:bg-green-950 rounded-lg border border-green-200 dark:border-green-800">
-                    <div className="text-sm font-medium text-green-600 dark:text-green-400">Total Credit</div>
-                    <div className="text-2xl font-bold text-green-700 dark:text-green-300">
+                  <div className="p-4 bg-green-500/20 rounded-lg">
+                    <div className="text-sm font-medium text-green-500">Total Credit</div>
+                    <div className="text-2xl font-bold text-green-500">
                       {currencyCode} {totalCredit.toFixed(2)}
                     </div>
                   </div>
                 </div>
                 <div className={`mt-4 p-3 rounded-lg ${
-                  isBalanced 
-                    ? 'bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' 
-                    : 'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800'
+                  isBalanced
+                    ? 'bg-green-500/20'
+                    : 'bg-red-500/20'
                 }`}>
                   <div className={`text-sm font-medium ${
-                    isBalanced 
-                      ? 'text-green-600 dark:text-green-400' 
-                      : 'text-red-600 dark:text-red-400'
+                    isBalanced
+                      ? 'text-green-500'
+                      : 'text-red-500'
                   }`}>
                     {isBalanced ? '✓ Balanced' : '✗ Not Balanced'}
                   </div>
                   <div className={`text-xs ${
-                    isBalanced 
-                      ? 'text-green-500 dark:text-green-300' 
-                      : 'text-red-500 dark:text-red-300'
+                    isBalanced
+                      ? 'text-green-500'
+                      : 'text-red-500'
                   }`}>
                     {isBalanced 
                       ? 'Debit and credit amounts are equal' 
@@ -823,21 +821,20 @@ export default function FrequentPostingsPage() {
         )}
 
         {/* Action Buttons */}
-        <Card className="border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex justify-end gap-4">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => router.back()}
-                className="border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
               >
                 Cancel
               </Button>
               <Button
                 type="submit"
                 disabled={isSubmitting || !isBalanced || !accountingRuleId || !transactionDate}
-                className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                className="disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Save className="w-4 h-4 mr-2" />
                 {isSubmitting ? 'Creating...' : 'Create Journal Entry'}

--- a/app/(application)/accounting/journal-entries/[transactionId]/page.tsx
+++ b/app/(application)/accounting/journal-entries/[transactionId]/page.tsx
@@ -216,22 +216,22 @@ export default function JournalEntryViewPage() {
 
   const getEntryTypeBadge = (entryType: string) => {
     if (entryType === 'DEBIT') {
-      return <Badge variant="destructive" className="bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400">DEBIT</Badge>;
+      return <Badge variant="destructive" className="bg-red-500/20 text-red-500">DEBIT</Badge>;
     }
-    return <Badge variant="default" className="bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400">CREDIT</Badge>;
+    return <Badge variant="default" className="bg-green-500/20 text-green-500">CREDIT</Badge>;
   };
 
   const getAccountTypeBadge = (accountType: string) => {
     const variants: { [key: string]: string } = {
-      'ASSET': 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400',
-      'LIABILITY': 'bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400',
-      'EQUITY': 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400',
-      'INCOME': 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400',
-      'EXPENSE': 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400'
+      'ASSET': 'bg-blue-500/20 text-blue-500',
+      'LIABILITY': 'bg-orange-500/20 text-orange-500',
+      'EQUITY': 'bg-purple-500/20 text-purple-500',
+      'INCOME': 'bg-green-500/20 text-green-500',
+      'EXPENSE': 'bg-red-500/20 text-red-500'
     };
-    
+
     return (
-      <Badge variant="outline" className={variants[accountType] || 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400'}>
+      <Badge variant="outline" className={variants[accountType] || 'bg-muted text-muted-foreground'}>
         {accountType}
       </Badge>
     );
@@ -270,11 +270,11 @@ export default function JournalEntryViewPage() {
 
       <div className="space-y-6">
         {/* Transaction Summary */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/20 flex items-center justify-center">
-                <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <FileText className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Transaction Summary</CardTitle>
@@ -290,14 +290,14 @@ export default function JournalEntryViewPage() {
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-muted-foreground">Office:</span>
                   <div className="flex items-center gap-2">
-                    <Building2 className="h-4 w-4 text-gray-400" />
+                    <Building2 className="h-4 w-4 text-muted-foreground" />
                     <span className="text-foreground">{firstEntry.officeName}</span>
                   </div>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-muted-foreground">Created By:</span>
                   <div className="flex items-center gap-2">
-                    <User className="h-4 w-4 text-gray-400" />
+                    <User className="h-4 w-4 text-muted-foreground" />
                     <span className="text-foreground">{firstEntry.createdByUserName}</span>
                   </div>
                 </div>
@@ -306,20 +306,20 @@ export default function JournalEntryViewPage() {
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-muted-foreground">Transaction Date:</span>
                   <div className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4 text-gray-400" />
+                    <Calendar className="h-4 w-4 text-muted-foreground" />
                     <span className="text-foreground">{formatDate(firstEntry.transactionDate)}</span>
                   </div>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-muted-foreground">Submitted on:</span>
                   <div className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4 text-gray-400" />
+                    <Calendar className="h-4 w-4 text-muted-foreground" />
                     <span className="text-foreground">{formatDateTime(firstEntry.submittedOnDate)}</span>
                   </div>
                 </div>
               </div>
             </div>
-            
+
             {firstEntry.comments && (
               <>
                 <Separator className="my-4" />
@@ -333,11 +333,11 @@ export default function JournalEntryViewPage() {
         </Card>
 
         {/* Entry Details */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-900/20 flex items-center justify-center">
-                <Hash className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <Hash className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Entry Details</CardTitle>
@@ -351,7 +351,7 @@ export default function JournalEntryViewPage() {
             <div className="overflow-x-auto">
               <table className="w-full">
                 <thead>
-                  <tr className="border-b border-gray-200 dark:border-gray-700">
+                  <tr className="border-b">
                     <th className="text-left py-3 px-4 font-medium text-muted-foreground">Entry ID</th>
                     <th className="text-left py-3 px-4 font-medium text-muted-foreground">Type</th>
                     <th className="text-left py-3 px-4 font-medium text-muted-foreground">Account Code</th>
@@ -362,10 +362,10 @@ export default function JournalEntryViewPage() {
                 </thead>
                 <tbody>
                   {journalEntries.map((entry, index) => (
-                    <tr 
-                      key={entry.id} 
-                      className={`border-b border-gray-100 dark:border-gray-800 ${
-                        index % 2 === 0 ? 'bg-white dark:bg-gray-900' : 'bg-gray-50 dark:bg-gray-800/50'
+                    <tr
+                      key={entry.id}
+                      className={`border-b ${
+                        index % 2 === 0 ? '' : 'bg-muted/50'
                       }`}
                     >
                       <td className="py-3 px-4 text-foreground">{entry.id}</td>
@@ -402,11 +402,11 @@ export default function JournalEntryViewPage() {
 
         {/* Payment Details */}
         {firstEntry.transactionDetails?.paymentDetails && (
-          <Card className="border-0 shadow-sm">
+          <Card>
             <CardHeader>
               <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-900/20 flex items-center justify-center">
-                  <CreditCard className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                  <CreditCard className="h-5 w-5 text-primary" />
                 </div>
                 <div>
                   <CardTitle className="text-lg">Payment Details</CardTitle>
@@ -426,14 +426,14 @@ export default function JournalEntryViewPage() {
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-muted-foreground">Account Number:</span>
                     <div className="flex items-center gap-2">
-                      <Banknote className="h-4 w-4 text-gray-400" />
+                      <Banknote className="h-4 w-4 text-muted-foreground" />
                       <span className="text-foreground">{firstEntry.transactionDetails.paymentDetails.accountNumber || 'N/A'}</span>
                     </div>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-muted-foreground">Check Number:</span>
                     <div className="flex items-center gap-2">
-                      <CheckSquare className="h-4 w-4 text-gray-400" />
+                      <CheckSquare className="h-4 w-4 text-muted-foreground" />
                       <span className="text-foreground">{firstEntry.transactionDetails.paymentDetails.checkNumber || 'N/A'}</span>
                     </div>
                   </div>
@@ -442,7 +442,7 @@ export default function JournalEntryViewPage() {
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-muted-foreground">Receipt Number:</span>
                     <div className="flex items-center gap-2">
-                      <Receipt className="h-4 w-4 text-gray-400" />
+                      <Receipt className="h-4 w-4 text-muted-foreground" />
                       <span className="text-foreground">{firstEntry.transactionDetails.paymentDetails.receiptNumber || 'N/A'}</span>
                     </div>
                   </div>
@@ -478,7 +478,7 @@ export default function JournalEntryViewPage() {
                 placeholder="Enter comments for the reversal..."
                 value={revertComments}
                 onChange={(e) => setRevertComments(e.target.value)}
-                className="resize-none bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                className="resize-none"
                 rows={3}
               />
             </div>
@@ -514,13 +514,13 @@ export default function JournalEntryViewPage() {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <CheckCircle className="h-5 w-5 text-green-600" />
+              <CheckCircle className="h-5 w-5 text-green-500" />
               Transaction Reverted
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div className="text-center">
-              <p className="font-semibold text-green-600 mb-2">Success!</p>
+              <p className="font-semibold text-green-500 mb-2">Success!</p>
               <p className="text-foreground mb-2">
                 A new journal entry has been created to reverse this transaction:
               </p>

--- a/app/(application)/accounting/journal-entries/[transactionId]/page.tsx
+++ b/app/(application)/accounting/journal-entries/[transactionId]/page.tsx
@@ -184,7 +184,7 @@ export default function JournalEntryViewPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
-          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
           <h3 className="text-lg font-semibold mb-2">Failed to load journal entry</h3>
           <p className="text-muted-foreground mb-4">
             Unable to fetch the journal entry details. Please try again.

--- a/app/(application)/accounting/journal-entries/new/page.tsx
+++ b/app/(application)/accounting/journal-entries/new/page.tsx
@@ -216,11 +216,11 @@ export default function JournalEntriesPage() {
 
       <div className="space-y-6">
         {/* Basic Information Card */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/20 flex items-center justify-center">
-                <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <FileText className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Entry Information</CardTitle>
@@ -234,18 +234,18 @@ export default function JournalEntriesPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* Office */}
               <div className="space-y-2">
-                <Label htmlFor="office" className="text-sm font-medium">
+                <Label htmlFor="office">
                   Office <span className="text-red-500">*</span>
                 </Label>
                 <Select value={officeId} onValueChange={setOfficeId}>
-                  <SelectTrigger className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectTrigger className="h-11">
                     <SelectValue placeholder="Select office" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectContent>
                     {offices.map(o => (
-                      <SelectItem key={o.id} value={String(o.id)} className="hover:bg-gray-100 dark:hover:bg-gray-800">
+                      <SelectItem key={o.id} value={String(o.id)}>
                         <div className="flex items-center gap-2">
-                          <Building2 className="h-4 w-4 text-gray-400" />
+                          <Building2 className="h-4 w-4 text-muted-foreground" />
                           <span className="text-foreground">{o.name}</span>
                         </div>
                       </SelectItem>
@@ -256,18 +256,18 @@ export default function JournalEntriesPage() {
 
               {/* Currency */}
               <div className="space-y-2">
-                <Label htmlFor="currency" className="text-sm font-medium">
+                <Label htmlFor="currency">
                   Currency <span className="text-red-500">*</span>
                 </Label>
                 <Select value={currencyCode} onValueChange={setCurrencyCode}>
-                  <SelectTrigger className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectTrigger className="h-11">
                     <SelectValue placeholder="Select currency" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectContent>
                     {currencies.selectedCurrencyOptions.map(c => (
-                      <SelectItem key={c.code} value={c.code} className="hover:bg-gray-100 dark:hover:bg-gray-800">
+                      <SelectItem key={c.code} value={c.code}>
                         <div className="flex items-center gap-2">
-                          <DollarSign className="h-4 w-4 text-gray-400" />
+                          <DollarSign className="h-4 w-4 text-muted-foreground" />
                           <span className="text-foreground">{c.displayLabel}</span>
                         </div>
                       </SelectItem>
@@ -278,35 +278,35 @@ export default function JournalEntriesPage() {
 
               {/* Transaction Date */}
               <div className="space-y-2">
-                <Label htmlFor="transactionDate" className="text-sm font-medium">
+                <Label htmlFor="transactionDate">
                   Transaction Date <span className="text-red-500">*</span>
                 </Label>
                 <div className="relative">
-                  <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                  <Input 
-                    id="transactionDate" 
-                    type="date" 
-                    value={transactionDate} 
+                  <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                  <Input
+                    id="transactionDate"
+                    type="date"
+                    value={transactionDate}
                     onChange={e => setTransactionDate(e.target.value)}
-                    className="h-11 pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                    className="h-11 pl-10"
                   />
                 </div>
               </div>
 
               {/* Payment Type */}
               <div className="space-y-2">
-                <Label htmlFor="paymentType" className="text-sm font-medium">
+                <Label htmlFor="paymentType">
                   Payment Type
                 </Label>
                 <Select value={paymentTypeId} onValueChange={setPaymentTypeId}>
-                  <SelectTrigger className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectTrigger className="h-11">
                     <SelectValue placeholder="Select payment type" />
                   </SelectTrigger>
-                  <SelectContent className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                  <SelectContent>
                     {paymentTypes.map(p => (
-                      <SelectItem key={p.id} value={String(p.id)} className="hover:bg-gray-100 dark:hover:bg-gray-800">
+                      <SelectItem key={p.id} value={String(p.id)}>
                         <div className="flex items-center gap-2">
-                          <CreditCard className="h-4 w-4 text-gray-400" />
+                          <CreditCard className="h-4 w-4 text-muted-foreground" />
                           <span className="text-foreground">{p.name}</span>
                         </div>
                       </SelectItem>
@@ -319,12 +319,12 @@ export default function JournalEntriesPage() {
         </Card>
 
         {/* Debits Section */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-                  <TrendingDown className="h-5 w-5 text-red-600 dark:text-red-400" />
+                <div className="h-10 w-10 rounded-lg bg-red-500/20 flex items-center justify-center">
+                  <TrendingDown className="h-5 w-5 text-red-500" />
                 </div>
                 <div>
                   <CardTitle className="text-lg">Debit Entries</CardTitle>
@@ -333,9 +333,9 @@ export default function JournalEntriesPage() {
                   </CardDescription>
                 </div>
               </div>
-              <Button 
-                size="sm" 
-                variant="outline" 
+              <Button
+                size="sm"
+                variant="outline"
                 onClick={addDebit}
                 className="flex items-center gap-2"
               >
@@ -346,20 +346,20 @@ export default function JournalEntriesPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             {debits.map((d, idx) => (
-              <div key={idx} className="flex items-center gap-4 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div key={idx} className="flex items-center gap-4 p-4 bg-muted/50 rounded-lg border">
                 <div className="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2">
                   <Select
                     value={d.glAccountId}
                     onValueChange={v => updateDebit(idx, 'glAccountId', v)}
                   >
-                    <SelectTrigger className="h-11 w-full bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                    <SelectTrigger className="h-11 w-full">
                       <SelectValue placeholder="Select GL account" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                    <SelectContent>
                       {glAccounts.map(a => (
-                        <SelectItem key={a.id} value={String(a.id)} className="hover:bg-gray-100 dark:hover:bg-gray-800">
+                        <SelectItem key={a.id} value={String(a.id)}>
                           <div className="flex items-center gap-2">
-                            <Hash className="h-4 w-4 text-gray-400" />
+                            <Hash className="h-4 w-4 text-muted-foreground" />
                             <span className="text-foreground">{a.nameDecorated}</span>
                           </div>
                         </SelectItem>
@@ -367,7 +367,7 @@ export default function JournalEntriesPage() {
                     </SelectContent>
                   </Select>
                   <div className="relative">
-                    <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                    <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                     <Input
                       type="number"
                       min="0"
@@ -375,13 +375,13 @@ export default function JournalEntriesPage() {
                       placeholder="Amount"
                       value={d.amount}
                       onChange={e => updateDebit(idx, 'amount', e.target.value)}
-                      className="h-11 w-full pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                      className="h-11 w-full pl-10"
                     />
                   </div>
                 </div>
-                <Button 
-                  size="sm" 
-                  variant="destructive" 
+                <Button
+                  size="sm"
+                  variant="destructive"
                   onClick={() => removeDebit(idx)}
                   className="h-11 w-11 shrink-0 p-0"
                 >
@@ -393,12 +393,12 @@ export default function JournalEntriesPage() {
         </Card>
 
         {/* Credits Section */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-900/20 flex items-center justify-center">
-                  <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+                <div className="h-10 w-10 rounded-lg bg-green-500/20 flex items-center justify-center">
+                  <TrendingUp className="h-5 w-5 text-green-500" />
                 </div>
                 <div>
                   <CardTitle className="text-lg">Credit Entries</CardTitle>
@@ -407,9 +407,9 @@ export default function JournalEntriesPage() {
                   </CardDescription>
                 </div>
               </div>
-              <Button 
-                size="sm" 
-                variant="outline" 
+              <Button
+                size="sm"
+                variant="outline"
                 onClick={addCredit}
                 className="flex items-center gap-2"
               >
@@ -420,20 +420,20 @@ export default function JournalEntriesPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             {credits.map((c, idx) => (
-              <div key={idx} className="flex items-center gap-4 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div key={idx} className="flex items-center gap-4 p-4 bg-muted/50 rounded-lg border">
                 <div className="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2">
                   <Select
                     value={c.glAccountId}
                     onValueChange={v => updateCredit(idx, 'glAccountId', v)}
                   >
-                    <SelectTrigger className="h-11 w-full bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                    <SelectTrigger className="h-11 w-full">
                       <SelectValue placeholder="Select GL account" />
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+                    <SelectContent>
                       {glAccounts.map(a => (
-                        <SelectItem key={a.id} value={String(a.id)} className="hover:bg-gray-100 dark:hover:bg-gray-800">
+                        <SelectItem key={a.id} value={String(a.id)}>
                           <div className="flex items-center gap-2">
-                            <Hash className="h-4 w-4 text-gray-400" />
+                            <Hash className="h-4 w-4 text-muted-foreground" />
                             <span className="text-foreground">{a.nameDecorated}</span>
                           </div>
                         </SelectItem>
@@ -441,7 +441,7 @@ export default function JournalEntriesPage() {
                     </SelectContent>
                   </Select>
                   <div className="relative">
-                    <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                    <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                     <Input
                       type="number"
                       min="0"
@@ -449,13 +449,13 @@ export default function JournalEntriesPage() {
                       placeholder="Amount"
                       value={c.amount}
                       onChange={e => updateCredit(idx, 'amount', e.target.value)}
-                      className="h-11 w-full pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                      className="h-11 w-full pl-10"
                     />
                   </div>
                 </div>
-                <Button 
-                  size="sm" 
-                  variant="destructive" 
+                <Button
+                  size="sm"
+                  variant="destructive"
                   onClick={() => removeCredit(idx)}
                   className="h-11 w-11 shrink-0 p-0"
                 >
@@ -467,30 +467,30 @@ export default function JournalEntriesPage() {
         </Card>
 
         {/* Balance Summary */}
-        <Card className="border-0 shadow-sm bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-                  <Calculator className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+                <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+                  <Calculator className="h-6 w-6 text-primary" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-blue-900 dark:text-blue-100">Entry Balance</h3>
-                  <p className="text-sm text-blue-700 dark:text-blue-300">Total debits vs total credits</p>
+                  <h3 className="font-semibold text-foreground">Entry Balance</h3>
+                  <p className="text-sm text-muted-foreground">Total debits vs total credits</p>
                 </div>
               </div>
               <div className="flex items-center gap-6">
                 <div className="text-center">
-                  <div className="text-sm text-blue-600 dark:text-blue-400 font-medium">Total Debits</div>
-                  <div className="text-lg font-bold text-blue-900 dark:text-blue-100">${totalDebits.toFixed(2)}</div>
+                  <div className="text-sm text-muted-foreground font-medium">Total Debits</div>
+                  <div className="text-lg font-bold text-foreground">${totalDebits.toFixed(2)}</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-sm text-blue-600 dark:text-blue-400 font-medium">Total Credits</div>
-                  <div className="text-lg font-bold text-blue-900 dark:text-blue-100">${totalCredits.toFixed(2)}</div>
+                  <div className="text-sm text-muted-foreground font-medium">Total Credits</div>
+                  <div className="text-lg font-bold text-foreground">${totalCredits.toFixed(2)}</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-sm text-blue-600 dark:text-blue-400 font-medium">Difference</div>
-                  <div className={`text-lg font-bold ${isBalanced ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                  <div className="text-sm text-muted-foreground font-medium">Difference</div>
+                  <div className={`text-lg font-bold ${isBalanced ? 'text-green-500' : 'text-red-500'}`}>
                     ${Math.abs(totalDebits - totalCredits).toFixed(2)}
                   </div>
                 </div>
@@ -503,11 +503,11 @@ export default function JournalEntriesPage() {
         </Card>
 
         {/* Reference Information */}
-        <Card className="border-0 shadow-sm">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-900/20 flex items-center justify-center">
-                <Settings className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <Settings className="h-5 w-5 text-primary" />
               </div>
               <div>
                 <CardTitle className="text-lg">Reference Information</CardTitle>
@@ -520,83 +520,83 @@ export default function JournalEntriesPage() {
           <CardContent className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="referenceNumber" className="text-sm font-medium">
+                <Label htmlFor="referenceNumber">
                   Reference Number
                 </Label>
-                <Input 
-                  id="referenceNumber" 
-                  value={referenceNumber} 
+                <Input
+                  id="referenceNumber"
+                  value={referenceNumber}
                   onChange={e => setReferenceNumber(e.target.value)}
                   placeholder="Enter reference number"
-                  className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                  className="h-11"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="receiptNumber" className="text-sm font-medium">
+                <Label htmlFor="receiptNumber">
                   Receipt Number
                 </Label>
                 <div className="relative">
-                  <Receipt className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                  <Input 
-                    id="receiptNumber" 
-                    value={receiptNumber} 
+                  <Receipt className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                  <Input
+                    id="receiptNumber"
+                    value={receiptNumber}
                     onChange={e => setReceiptNumber(e.target.value)}
                     placeholder="Enter receipt number"
-                    className="h-11 pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                    className="h-11 pl-10"
                   />
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="checkNumber" className="text-sm font-medium">
+                <Label htmlFor="checkNumber">
                   Check Number
                 </Label>
                 <div className="relative">
-                  <CheckSquare className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                  <Input 
-                    id="checkNumber" 
-                    value={checkNumber} 
+                  <CheckSquare className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                  <Input
+                    id="checkNumber"
+                    value={checkNumber}
                     onChange={e => setCheckNumber(e.target.value)}
                     placeholder="Enter check number"
-                    className="h-11 pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                    className="h-11 pl-10"
                   />
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="accountNumber" className="text-sm font-medium">
+                <Label htmlFor="accountNumber">
                   Account Number
                 </Label>
-                <Input 
-                  id="accountNumber" 
-                  value={accountNumber} 
+                <Input
+                  id="accountNumber"
+                  value={accountNumber}
                   onChange={e => setAccountNumber(e.target.value)}
                   placeholder="Enter account number"
-                  className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                  className="h-11"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="routingCode" className="text-sm font-medium">
+                <Label htmlFor="routingCode">
                   Routing Code
                 </Label>
-                <Input 
-                  id="routingCode" 
-                  value={routingCode} 
+                <Input
+                  id="routingCode"
+                  value={routingCode}
                   onChange={e => setRoutingCode(e.target.value)}
                   placeholder="Enter routing code"
-                  className="h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                  className="h-11"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="bankNumber" className="text-sm font-medium">
+                <Label htmlFor="bankNumber">
                   Bank Number
                 </Label>
                 <div className="relative">
-                  <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                  <Input 
-                    id="bankNumber" 
-                    value={bankNumber} 
+                  <Banknote className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                  <Input
+                    id="bankNumber"
+                    value={bankNumber}
                     onChange={e => setBankNumber(e.target.value)}
                     placeholder="Enter bank number"
-                    className="h-11 pl-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                    className="h-11 pl-10"
                   />
                 </div>
               </div>
@@ -604,7 +604,7 @@ export default function JournalEntriesPage() {
 
             {/* Comments */}
             <div className="space-y-2">
-              <Label htmlFor="comments" className="text-sm font-medium">
+              <Label htmlFor="comments">
                 Comments
               </Label>
               <Textarea
@@ -613,19 +613,19 @@ export default function JournalEntriesPage() {
                 onChange={e => setComments(e.target.value)}
                 placeholder="Enter any additional comments or notes..."
                 rows={3}
-                className="resize-none bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-foreground"
+                className="resize-none"
               />
             </div>
           </CardContent>
         </Card>
 
         {/* Actions */}
-        <Card className="border-0 shadow-sm bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20">
+        <Card>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <BookOpen className="h-5 w-5 text-green-600 dark:text-green-400" />
-                <span className="text-sm text-green-700 dark:text-green-300 font-medium">
+                <BookOpen className="h-5 w-5 text-primary" />
+                <span className="text-sm text-primary font-medium">
                   Ready to create your journal entry
                 </span>
               </div>
@@ -633,14 +633,14 @@ export default function JournalEntriesPage() {
                 <Button
                   variant="outline"
                   onClick={() => router.back()}
-                  className="flex items-center gap-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                  className="flex items-center gap-2"
                 >
                   Cancel
                 </Button>
                 <Button
                   onClick={handleSubmit}
                   disabled={submitting || !isBalanced || hasIncompleteDebits || hasInvalidDebitAmounts || hasIncompleteCredits || hasInvalidCreditAmounts}
-                  className="bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white shadow-lg flex items-center gap-2"
+                  className="flex items-center gap-2"
                 >
                   {submitting ? (
                     <>

--- a/app/(application)/accounting/layout.tsx
+++ b/app/(application)/accounting/layout.tsx
@@ -5,11 +5,5 @@ interface AccountingLayoutProps {
 }
 
 export default function AccountingLayout({ children }: AccountingLayoutProps) {
-  return (
-    <div className="space-y-6">
-      <section className="p-4 bg-white dark:bg-[#0d121f] rounded-lg shadow-sm">
-        {children}
-      </section>
-    </div>
-  );
+  return <div className="space-y-6">{children}</div>;
 }

--- a/app/(application)/accounting/search-journal/page.tsx
+++ b/app/(application)/accounting/search-journal/page.tsx
@@ -106,7 +106,7 @@ interface GlAccountsResponse {
 
 export default function SearchJournalPage() {
   const router = useRouter();
-  
+
   // Filter states
   const [officeName, setOfficeName] = useState('');
   const [glAccountNameOrCode, setGlAccountNameOrCode] = useState('');
@@ -116,33 +116,33 @@ export default function SearchJournalPage() {
   const [transactionId, setTransactionId] = useState('');
   const [submittedOnDateFrom, setSubmittedOnDateFrom] = useState('');
   const [submittedOnDateTo, setSubmittedOnDateTo] = useState('');
-  
+
   // Pagination states
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
-  
+
   // Fetch offices and GL accounts
   const { data: offices = [] } = useSWR<Office[]>('/api/fineract/offices?orderBy=id', fetcher);
   const { data: glAccountsResponse, error: glAccountsError } = useSWR<GlAccountsResponse>('/api/fineract/glaccounts?manualEntriesAllowed=true&usage=1&disabled=false', fetcher);
-  
+
   // Ensure glAccounts is always an array
   const glAccounts = glAccountsResponse?.chartAccounts || [];
 
   // Build query parameters
   const queryParams = useMemo(() => {
     const params = new URLSearchParams();
-    
+
     // Pagination
     const offset = (currentPage - 1) * pageSize;
     params.append('offset', offset.toString());
     params.append('limit', pageSize.toString());
     params.append('sortOrder', '');
     params.append('orderBy', '');
-    
+
     // Date format
     params.append('dateFormat', 'dd MMMM yyyy');
     params.append('locale', 'en');
-    
+
     // Filters
     if (officeName && officeName !== 'all') params.append('officeId', officeName);
     if (glAccountNameOrCode && glAccountNameOrCode !== 'all') params.append('glAccountId', glAccountNameOrCode);
@@ -151,11 +151,11 @@ export default function SearchJournalPage() {
     if (transactionId) params.append('transactionId', transactionId);
     if (submittedOnDateFrom) params.append('submittedOnDateFrom', format(new Date(submittedOnDateFrom), 'dd MMMM yyyy'));
     if (submittedOnDateTo) params.append('submittedOnDateTo', format(new Date(submittedOnDateTo), 'dd MMMM yyyy'));
-    
+
     // Filter type
     if (filterType === 'Manual Entries') params.append('manualEntriesOnly', 'true');
     if (filterType === 'System Entries') params.append('manualEntriesOnly', 'false');
-    
+
     return params.toString();
   }, [currentPage, pageSize, officeName, glAccountNameOrCode, filterType, transactionDateFrom, transactionDateTo, transactionId, submittedOnDateFrom, submittedOnDateTo]);
 
@@ -192,43 +192,37 @@ export default function SearchJournalPage() {
   };
 
   const getAccountTypeBadge = (accountType: string) => {
-    const variants: { [key: string]: { bg: string; text: string; icon: any } } = {
-      'ASSET': { 
-        bg: 'bg-gradient-to-r from-blue-500 to-blue-600', 
-        text: 'text-white',
+    const variants: { [key: string]: { className: string; icon: any } } = {
+      'ASSET': {
+        className: 'bg-blue-500/20 text-blue-500',
         icon: TrendingUp
       },
-      'LIABILITY': { 
-        bg: 'bg-gradient-to-r from-orange-500 to-orange-600', 
-        text: 'text-white',
+      'LIABILITY': {
+        className: 'bg-orange-500/20 text-orange-500',
         icon: TrendingDown
       },
-      'EQUITY': { 
-        bg: 'bg-gradient-to-r from-purple-500 to-purple-600', 
-        text: 'text-white',
+      'EQUITY': {
+        className: 'bg-purple-500/20 text-purple-500',
         icon: Database
       },
-      'INCOME': { 
-        bg: 'bg-gradient-to-r from-green-500 to-green-600', 
-        text: 'text-white',
+      'INCOME': {
+        className: 'bg-green-500/20 text-green-500',
         icon: TrendingUp
       },
-      'EXPENSE': { 
-        bg: 'bg-gradient-to-r from-red-500 to-red-600', 
-        text: 'text-white',
+      'EXPENSE': {
+        className: 'bg-red-500/20 text-red-500',
         icon: TrendingDown
       }
     };
-    
-    const variant = variants[accountType] || { 
-      bg: 'bg-gradient-to-r from-gray-500 to-gray-600', 
-      text: 'text-white',
+
+    const variant = variants[accountType] || {
+      className: 'bg-muted text-muted-foreground',
       icon: Hash
     };
     const Icon = variant.icon;
-    
+
     return (
-      <Badge className={`${variant.bg} ${variant.text} border-0 px-3 py-1 text-xs font-medium`}>
+      <Badge variant="outline" className={`${variant.className} border-0 px-3 py-1 text-xs font-medium`}>
         <Icon className="h-3 w-3 mr-1" />
         {accountType}
       </Badge>
@@ -240,420 +234,405 @@ export default function SearchJournalPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
-      <div className="space-y-8 p-6">
-        {/* Header */}
-        <div className="relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10 rounded-3xl blur-3xl"></div>
-          <div className="relative bg-white/70 dark:bg-slate-800/70 backdrop-blur-xl rounded-3xl p-8 border border-white/20 dark:border-slate-700/50 shadow-2xl">
-            <div className="flex items-center justify-between">
-              <div className="space-y-2">
-                <div className="flex items-center gap-3">
-                  <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow-lg">
-                    <Search className="h-6 w-6 text-white" />
-                  </div>
-                  <div>
-                    <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                      Search Journal Entries
-                    </h1>
-                    <p className="text-slate-600 dark:text-slate-300 mt-1">
-                      Advanced filtering and search for financial transactions
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="h-8 w-8 rounded-full bg-gradient-to-r from-green-400 to-blue-500 flex items-center justify-center">
-                  <Sparkles className="h-4 w-4 text-white" />
-                </div>
-                <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
-                  {totalRecords} entries found
-                </span>
-              </div>
-            </div>
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+            <Search className="h-6 w-6 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">
+              Search Journal Entries
+            </h1>
+            <p className="text-muted-foreground mt-1">
+              Advanced filtering and search for financial transactions
+            </p>
           </div>
         </div>
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
+            <Sparkles className="h-4 w-4 text-primary" />
+          </div>
+          <span className="text-sm font-medium text-muted-foreground">
+            {totalRecords} entries found
+          </span>
+        </div>
+      </div>
 
-        {/* Filters */}
-        <div className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-xl rounded-3xl border border-white/20 dark:border-slate-700/50 shadow-2xl overflow-hidden">
-          <div className="bg-gradient-to-r from-blue-500/10 to-purple-500/10 dark:from-blue-500/20 dark:to-purple-500/20 p-6 border-b border-white/20 dark:border-slate-700/50">
-            <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center">
-                <Filter className="h-5 w-5 text-white" />
-              </div>
-              <div>
-                <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Search Filters</h2>
-                <p className="text-slate-600 dark:text-slate-300 text-sm">
-                  Refine your search with advanced filtering options
-                </p>
-              </div>
+      {/* Filters */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+              <Filter className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <CardTitle className="text-lg">Search Filters</CardTitle>
+              <CardDescription>
+                Refine your search with advanced filtering options
+              </CardDescription>
             </div>
           </div>
-          <div className="p-6 space-y-8">
-            {/* First Row */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Building2 className="h-4 w-4" />
-                  Office Name
-                </Label>
-                <Select value={officeName} onValueChange={setOfficeName}>
-                  <SelectTrigger className="h-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm">
-                    <SelectValue placeholder="Select office" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl border-slate-200 dark:border-slate-600 rounded-xl">
-                    <SelectItem value="all" className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">
-                      All Offices
+        </CardHeader>
+        <CardContent className="space-y-8">
+          {/* First Row */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Building2 className="h-4 w-4" />
+                Office Name
+              </Label>
+              <Select value={officeName} onValueChange={setOfficeName}>
+                <SelectTrigger className="h-12">
+                  <SelectValue placeholder="Select office" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">
+                    All Offices
+                  </SelectItem>
+                  {offices.map(office => (
+                    <SelectItem key={office.id} value={office.id.toString()}>
+                      <div className="flex items-center gap-2">
+                        <Building2 className="h-4 w-4 text-muted-foreground" />
+                        <span>{office.name}</span>
+                      </div>
                     </SelectItem>
-                    {offices.map(office => (
-                      <SelectItem key={office.id} value={office.id.toString()} className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">
-                        <div className="flex items-center gap-2">
-                          <Building2 className="h-4 w-4 text-slate-400" />
-                          <span className="text-slate-700 dark:text-slate-200">{office.name}</span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Hash className="h-4 w-4" />
-                  GL Account <span className="text-red-500">*</span>
-                </Label>
-                <Select value={glAccountNameOrCode} onValueChange={setGlAccountNameOrCode}>
-                  <SelectTrigger className="h-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm">
-                    <SelectValue placeholder="Select GL account" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl border-slate-200 dark:border-slate-600 rounded-xl">
-                    <SelectItem value="all" className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">
-                      All Accounts
-                    </SelectItem>
-                    {glAccounts.map(account => (
-                      <SelectItem key={account.id} value={account.id.toString()} className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">
-                        <div className="flex items-center gap-2">
-                          <Hash className="h-4 w-4 text-slate-400" />
-                          <span className="text-slate-700 dark:text-slate-200">{account.glCode} - {account.name}</span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <FileText className="h-4 w-4" />
-                  Filter Type
-                </Label>
-                <Select value={filterType} onValueChange={setFilterType}>
-                  <SelectTrigger className="h-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent className="bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl border-slate-200 dark:border-slate-600 rounded-xl">
-                    <SelectItem value="All" className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">All</SelectItem>
-                    <SelectItem value="Manual Entries" className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">Manual Entries</SelectItem>
-                    <SelectItem value="System Entries" className="hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg">System Entries</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
-            {/* Second Row */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Calendar className="h-4 w-4" />
-                  Transaction Date From
-                </Label>
-                <div className="relative">
-                  <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                  <Input
-                    type="date"
-                    value={transactionDateFrom}
-                    onChange={e => setTransactionDateFrom(e.target.value)}
-                    className="h-12 pl-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm text-slate-700 dark:text-slate-200"
-                  />
-                </div>
-              </div>
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Hash className="h-4 w-4" />
+                GL Account <span className="text-red-500">*</span>
+              </Label>
+              <Select value={glAccountNameOrCode} onValueChange={setGlAccountNameOrCode}>
+                <SelectTrigger className="h-12">
+                  <SelectValue placeholder="Select GL account" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">
+                    All Accounts
+                  </SelectItem>
+                  {glAccounts.map(account => (
+                    <SelectItem key={account.id} value={account.id.toString()}>
+                      <div className="flex items-center gap-2">
+                        <Hash className="h-4 w-4 text-muted-foreground" />
+                        <span>{account.glCode} - {account.name}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Calendar className="h-4 w-4" />
-                  Transaction Date To
-                </Label>
-                <div className="relative">
-                  <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                  <Input
-                    type="date"
-                    value={transactionDateTo}
-                    onChange={e => setTransactionDateTo(e.target.value)}
-                    className="h-12 pl-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm text-slate-700 dark:text-slate-200"
-                  />
-                </div>
-              </div>
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <FileText className="h-4 w-4" />
+                Filter Type
+              </Label>
+              <Select value={filterType} onValueChange={setFilterType}>
+                <SelectTrigger className="h-12">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="All">All</SelectItem>
+                  <SelectItem value="Manual Entries">Manual Entries</SelectItem>
+                  <SelectItem value="System Entries">System Entries</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
 
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Hash className="h-4 w-4" />
-                  Transaction ID
-                </Label>
+          {/* Second Row */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Calendar className="h-4 w-4" />
+                Transaction Date From
+              </Label>
+              <div className="relative">
+                <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
-                  value={transactionId}
-                  onChange={e => setTransactionId(e.target.value)}
-                  placeholder="Enter transaction ID"
-                  className="h-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm text-slate-700 dark:text-slate-200"
+                  type="date"
+                  value={transactionDateFrom}
+                  onChange={e => setTransactionDateFrom(e.target.value)}
+                  className="h-12 pl-12"
                 />
               </div>
             </div>
 
-            {/* Third Row */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
-                  Submitted on Date From
-                </Label>
-                <div className="relative">
-                  <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                  <Input
-                    type="date"
-                    value={submittedOnDateFrom}
-                    onChange={e => setSubmittedOnDateFrom(e.target.value)}
-                    className="h-12 pl-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm text-slate-700 dark:text-slate-200"
-                  />
-                </div>
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Calendar className="h-4 w-4" />
+                Transaction Date To
+              </Label>
+              <div className="relative">
+                <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                <Input
+                  type="date"
+                  value={transactionDateTo}
+                  onChange={e => setTransactionDateTo(e.target.value)}
+                  className="h-12 pl-12"
+                />
               </div>
+            </div>
 
-              <div className="space-y-3">
-                <Label className="text-sm font-medium text-slate-700 dark:text-slate-200 flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
-                  Submitted on Date To
-                </Label>
-                <div className="relative">
-                  <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                  <Input
-                    type="date"
-                    value={submittedOnDateTo}
-                    onChange={e => setSubmittedOnDateTo(e.target.value)}
-                    className="h-12 pl-12 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-xl backdrop-blur-sm text-slate-700 dark:text-slate-200"
-                  />
-                </div>
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Hash className="h-4 w-4" />
+                Transaction ID
+              </Label>
+              <Input
+                value={transactionId}
+                onChange={e => setTransactionId(e.target.value)}
+                placeholder="Enter transaction ID"
+                className="h-12"
+              />
+            </div>
+          </div>
+
+          {/* Third Row */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Submitted on Date From
+              </Label>
+              <div className="relative">
+                <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                <Input
+                  type="date"
+                  value={submittedOnDateFrom}
+                  onChange={e => setSubmittedOnDateFrom(e.target.value)}
+                  className="h-12 pl-12"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <Label className="flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Submitted on Date To
+              </Label>
+              <div className="relative">
+                <Calendar className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                <Input
+                  type="date"
+                  value={submittedOnDateTo}
+                  onChange={e => setSubmittedOnDateTo(e.target.value)}
+                  className="h-12 pl-12"
+                />
               </div>
             </div>
           </div>
-        </div>
+        </CardContent>
+      </Card>
 
-        {/* Journal Entries Table */}
-        <div className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-xl rounded-3xl border border-white/20 dark:border-slate-700/50 shadow-2xl overflow-hidden">
-          <div className="bg-gradient-to-r from-green-500/10 to-emerald-500/10 dark:from-green-500/20 dark:to-emerald-500/20 p-6 border-b border-white/20 dark:border-slate-700/50">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center">
-                  <FileText className="h-5 w-5 text-white" />
-                </div>
-                <div>
-                  <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Journal Entries</h2>
-                  <p className="text-slate-600 dark:text-slate-300 text-sm">
-                    {totalRecords} entries found • Page {currentPage} of {totalPages}
-                  </p>
-                </div>
-              </div>
+      {/* Journal Entries Table */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+              <FileText className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <CardTitle className="text-lg">Journal Entries</CardTitle>
+              <CardDescription>
+                {totalRecords} entries found • Page {currentPage} of {totalPages}
+              </CardDescription>
             </div>
           </div>
-          <div className="p-6">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-16">
-                <div className="flex items-center gap-3">
-                  <div className="h-8 w-8 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-                    <Loader2 className="h-4 w-4 text-white animate-spin" />
-                  </div>
-                  <span className="text-slate-600 dark:text-slate-300 font-medium">Loading journal entries...</span>
-                </div>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <span className="text-muted-foreground font-medium">Loading journal entries...</span>
               </div>
-            ) : error ? (
-              <div className="text-center py-16">
-                <div className="h-16 w-16 rounded-full bg-gradient-to-r from-red-500 to-red-600 flex items-center justify-center mx-auto mb-4">
-                  <FileText className="h-8 w-8 text-white" />
-                </div>
-                <p className="text-slate-600 dark:text-slate-300">Failed to load journal entries</p>
-              </div>
-            ) : (
-              <>
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b border-slate-200 dark:border-slate-700">
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Entry ID</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Office</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Transaction ID</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Transaction Date</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Type</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Created By</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Submitted on date</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Account Code</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Account Name</th>
-                        <th className="text-left py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Currency</th>
-                        <th className="text-right py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Debit</th>
-                        <th className="text-right py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Credit</th>
-                        <th className="text-center py-4 px-4 font-semibold text-slate-700 dark:text-slate-200">Actions</th>
+            </div>
+          ) : error ? (
+            <div className="text-center py-16">
+              <FileText className="h-12 w-12 text-destructive mx-auto mb-4" />
+              <p className="text-muted-foreground">Failed to load journal entries</p>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Entry ID</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Office</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Transaction ID</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Transaction Date</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Type</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Created By</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Submitted on date</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Account Code</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Account Name</th>
+                      <th className="text-left py-4 px-4 font-medium text-muted-foreground">Currency</th>
+                      <th className="text-right py-4 px-4 font-medium text-muted-foreground">Debit</th>
+                      <th className="text-right py-4 px-4 font-medium text-muted-foreground">Credit</th>
+                      <th className="text-center py-4 px-4 font-medium text-muted-foreground">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {journalEntries.map((entry, index) => (
+                      <tr
+                        key={entry.id}
+                        className={`border-b transition-colors hover:bg-muted/50 ${
+                          index % 2 !== 0 ? 'bg-muted/50' : ''
+                        }`}
+                      >
+                        <td className="py-4 px-4">
+                          <span className="font-mono text-sm font-medium text-foreground">#{entry.id}</span>
+                        </td>
+                        <td className="py-4 px-4">
+                          <div className="flex items-center gap-2">
+                            <Building2 className="h-4 w-4 text-muted-foreground" />
+                            <span className="text-foreground">{entry.officeName}</span>
+                          </div>
+                        </td>
+                        <td className="py-4 px-4">
+                          <span className="font-mono text-sm text-muted-foreground">{entry.transactionId}</span>
+                        </td>
+                        <td className="py-4 px-4">
+                          <span className="text-foreground">{formatDate(entry.transactionDate)}</span>
+                        </td>
+                        <td className="py-4 px-4">
+                          {getAccountTypeBadge(entry.glAccountType.value)}
+                        </td>
+                        <td className="py-4 px-4">
+                          <div className="flex items-center gap-2">
+                            <User className="h-4 w-4 text-muted-foreground" />
+                            <span className="text-foreground">{entry.createdByUserName}</span>
+                          </div>
+                        </td>
+                        <td className="py-4 px-4">
+                          <div className="flex items-center gap-2">
+                            <Clock className="h-4 w-4 text-muted-foreground" />
+                            <span className="text-foreground">{formatDateTime(entry.submittedOnDate)}</span>
+                          </div>
+                        </td>
+                        <td className="py-4 px-4">
+                          <span className="font-mono text-sm font-medium text-foreground">{entry.glAccountCode}</span>
+                        </td>
+                        <td className="py-4 px-4">
+                          <span className="text-foreground">{entry.glAccountName}</span>
+                        </td>
+                        <td className="py-4 px-4">
+                          <span className="text-muted-foreground">{entry.currency.code}</span>
+                        </td>
+                        <td className="py-4 px-4 text-right">
+                          {entry.entryType.value === 'DEBIT' ? (
+                            <div className="flex items-center justify-end gap-2">
+                              <TrendingDown className="h-4 w-4 text-red-500" />
+                              <span className="font-mono text-sm font-medium text-red-500">
+                                {entry.currency.displaySymbol} {entry.amount.toFixed(2)}
+                              </span>
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )}
+                        </td>
+                        <td className="py-4 px-4 text-right">
+                          {entry.entryType.value === 'CREDIT' ? (
+                            <div className="flex items-center justify-end gap-2">
+                              <TrendingUp className="h-4 w-4 text-green-500" />
+                              <span className="font-mono text-sm font-medium text-green-500">
+                                {entry.currency.displaySymbol} {entry.amount.toFixed(2)}
+                              </span>
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )}
+                        </td>
+                        <td className="py-4 px-4 text-center">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleViewEntry(entry.transactionId)}
+                            className="h-9 w-9 p-0"
+                          >
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {journalEntries.map((entry, index) => (
-                        <tr 
-                          key={entry.id} 
-                          className={`border-b border-slate-100 dark:border-slate-800 transition-all duration-200 hover:bg-slate-50/50 dark:hover:bg-slate-700/30 ${
-                            index % 2 === 0 ? 'bg-white/30 dark:bg-slate-800/30' : 'bg-slate-50/30 dark:bg-slate-700/30'
-                          }`}
-                        >
-                          <td className="py-4 px-4">
-                            <span className="font-mono text-sm font-medium text-slate-700 dark:text-slate-200">#{entry.id}</span>
-                          </td>
-                          <td className="py-4 px-4">
-                            <div className="flex items-center gap-2">
-                              <Building2 className="h-4 w-4 text-slate-400" />
-                              <span className="text-slate-700 dark:text-slate-200">{entry.officeName}</span>
-                            </div>
-                          </td>
-                          <td className="py-4 px-4">
-                            <span className="font-mono text-sm text-slate-600 dark:text-slate-300">{entry.transactionId}</span>
-                          </td>
-                          <td className="py-4 px-4">
-                            <span className="text-slate-700 dark:text-slate-200">{formatDate(entry.transactionDate)}</span>
-                          </td>
-                          <td className="py-4 px-4">
-                            {getAccountTypeBadge(entry.glAccountType.value)}
-                          </td>
-                          <td className="py-4 px-4">
-                            <div className="flex items-center gap-2">
-                              <User className="h-4 w-4 text-slate-400" />
-                              <span className="text-slate-700 dark:text-slate-200">{entry.createdByUserName}</span>
-                            </div>
-                          </td>
-                          <td className="py-4 px-4">
-                            <div className="flex items-center gap-2">
-                              <Clock className="h-4 w-4 text-slate-400" />
-                              <span className="text-slate-700 dark:text-slate-200">{formatDateTime(entry.submittedOnDate)}</span>
-                            </div>
-                          </td>
-                          <td className="py-4 px-4">
-                            <span className="font-mono text-sm font-medium text-slate-700 dark:text-slate-200">{entry.glAccountCode}</span>
-                          </td>
-                          <td className="py-4 px-4">
-                            <span className="text-slate-700 dark:text-slate-200">{entry.glAccountName}</span>
-                          </td>
-                          <td className="py-4 px-4">
-                            <span className="text-slate-600 dark:text-slate-300">{entry.currency.code}</span>
-                          </td>
-                          <td className="py-4 px-4 text-right">
-                            {entry.entryType.value === 'DEBIT' ? (
-                              <div className="flex items-center justify-end gap-2">
-                                <TrendingDown className="h-4 w-4 text-red-500" />
-                                <span className="font-mono text-sm font-medium text-red-600 dark:text-red-400">
-                                  {entry.currency.displaySymbol} {entry.amount.toFixed(2)}
-                                </span>
-                              </div>
-                            ) : (
-                              <span className="text-slate-400 dark:text-slate-500">-</span>
-                            )}
-                          </td>
-                          <td className="py-4 px-4 text-right">
-                            {entry.entryType.value === 'CREDIT' ? (
-                              <div className="flex items-center justify-end gap-2">
-                                <TrendingUp className="h-4 w-4 text-green-500" />
-                                <span className="font-mono text-sm font-medium text-green-600 dark:text-green-400">
-                                  {entry.currency.displaySymbol} {entry.amount.toFixed(2)}
-                                </span>
-                              </div>
-                            ) : (
-                              <span className="text-slate-400 dark:text-slate-500">-</span>
-                            )}
-                          </td>
-                          <td className="py-4 px-4 text-center">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleViewEntry(entry.transactionId)}
-                              className="h-9 w-9 p-0 rounded-xl border-slate-200 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700"
-                            >
-                              <Eye className="h-4 w-4 text-slate-600 dark:text-slate-300" />
-                            </Button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Pagination */}
+              <div className="flex items-center justify-between mt-8 pt-6 border-t">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-muted-foreground">Items per page:</span>
+                  <Select value={pageSize.toString()} onValueChange={(value) => setPageSize(Number(value))}>
+                    <SelectTrigger className="w-20 h-9">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="10">10</SelectItem>
+                      <SelectItem value="25">25</SelectItem>
+                      <SelectItem value="50">50</SelectItem>
+                      <SelectItem value="100">100</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
 
-                {/* Pagination */}
-                <div className="flex items-center justify-between mt-8 pt-6 border-t border-slate-200 dark:border-slate-700">
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm text-slate-600 dark:text-slate-300">Items per page:</span>
-                    <Select value={pageSize.toString()} onValueChange={(value) => setPageSize(Number(value))}>
-                      <SelectTrigger className="w-20 h-9 bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 rounded-lg">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent className="bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl border-slate-200 dark:border-slate-600 rounded-lg">
-                        <SelectItem value="10">10</SelectItem>
-                        <SelectItem value="25">25</SelectItem>
-                        <SelectItem value="50">50</SelectItem>
-                        <SelectItem value="100">100</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  
-                  <div className="flex items-center gap-4">
-                    <span className="text-sm text-slate-600 dark:text-slate-300">
-                      {((currentPage - 1) * pageSize) + 1} - {Math.min(currentPage * pageSize, totalRecords)} of {totalRecords}
-                    </span>
-                    
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setCurrentPage(1)}
-                        disabled={currentPage === 1}
-                        className="h-9 w-9 p-0 rounded-lg border-slate-200 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700"
-                      >
-                        <ChevronsLeft className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setCurrentPage(currentPage - 1)}
-                        disabled={currentPage === 1}
-                        className="h-9 w-9 p-0 rounded-lg border-slate-200 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700"
-                      >
-                        <ChevronLeft className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setCurrentPage(currentPage + 1)}
-                        disabled={currentPage === totalPages}
-                        className="h-9 w-9 p-0 rounded-lg border-slate-200 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700"
-                      >
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setCurrentPage(totalPages)}
-                        disabled={currentPage === totalPages}
-                        className="h-9 w-9 p-0 rounded-lg border-slate-200 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700"
-                      >
-                        <ChevronsRight className="h-4 w-4" />
-                      </Button>
-                    </div>
+                <div className="flex items-center gap-4">
+                  <span className="text-sm text-muted-foreground">
+                    {((currentPage - 1) * pageSize) + 1} - {Math.min(currentPage * pageSize, totalRecords)} of {totalRecords}
+                  </span>
+
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(1)}
+                      disabled={currentPage === 1}
+                      className="h-9 w-9 p-0"
+                    >
+                      <ChevronsLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(currentPage - 1)}
+                      disabled={currentPage === 1}
+                      className="h-9 w-9 p-0"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(currentPage + 1)}
+                      disabled={currentPage === totalPages}
+                      className="h-9 w-9 p-0"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(totalPages)}
+                      disabled={currentPage === totalPages}
+                      className="h-9 w-9 p-0"
+                    >
+                      <ChevronsRight className="h-4 w-4" />
+                    </Button>
                   </div>
                 </div>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
-} 
+}

--- a/components/accounting/AccountingHome.tsx
+++ b/components/accounting/AccountingHome.tsx
@@ -16,61 +16,54 @@ import {
 } from 'lucide-react';
 
 const features = [
-  { 
-    title: 'Chart of Accounts', 
-    href: '/accounting/chart-of-accounts', 
+  {
+    title: 'Chart of Accounts',
+    href: '/accounting/chart-of-accounts',
     icon: BookOpen,
     description: 'Manage your general ledger accounts and account structure',
-    badge: 'Core',
-    color: 'bg-blue-500'
+    badge: 'Core'
   },
-  { 
-    title: 'Create Journal Entries', 
-    href: '/accounting/journal-entries/new', 
+  {
+    title: 'Create Journal Entries',
+    href: '/accounting/journal-entries/new',
     icon: FileText,
     description: 'Record financial transactions and post to general ledger',
-    badge: 'New',
-    color: 'bg-green-500'
+    badge: 'New'
   },
-  { 
-    title: 'Search Journal Entries', 
-    href: '/accounting/search-journal', 
+  {
+    title: 'Search Journal Entries',
+    href: '/accounting/search-journal',
     icon: Search,
     description: 'Find and review posted journal entries',
-    badge: 'Search',
-    color: 'bg-purple-500'
+    badge: 'Search'
   },
-  { 
-    title: 'Frequent Postings', 
-    href: '/accounting/frequent-postings', 
+  {
+    title: 'Frequent Postings',
+    href: '/accounting/frequent-postings',
     icon: ListChecks,
     description: 'Manage recurring and template journal entries',
-    badge: 'Templates',
-    color: 'bg-orange-500'
+    badge: 'Templates'
   },
-  { 
-    title: 'Closing Entries', 
-    href: '/accounting/closing-entries', 
+  {
+    title: 'Closing Entries',
+    href: '/accounting/closing-entries',
     icon: RefreshCcw,
     description: 'Month-end and year-end closing procedures',
-    badge: 'Period End',
-    color: 'bg-red-500'
+    badge: 'Period End'
   },
-  { 
-    title: 'Accounting Rules', 
-    href: '/accounting/accounting-rules', 
+  {
+    title: 'Accounting Rules',
+    href: '/accounting/accounting-rules',
     icon: Settings,
     description: 'Configure automatic journal entry rules and mappings',
-    badge: 'Rules',
-    color: 'bg-indigo-500'
+    badge: 'Rules'
   },
-  { 
-    title: 'Accruals', 
-    href: '/accounting/accruals', 
+  {
+    title: 'Accruals',
+    href: '/accounting/accruals',
     icon: Calculator,
     description: 'Run periodic accruals for financial calculations',
-    badge: 'Periodic',
-    color: 'bg-teal-500'
+    badge: 'Periodic'
   },
 ];
 
@@ -81,43 +74,43 @@ export default function AccountingHome() {
       <div>
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Accounting Modules</h2>
-            <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+            <h2 className="text-xl font-semibold text-foreground">Accounting Modules</h2>
+            <p className="text-sm text-muted-foreground mt-1">
               Access all your accounting tools and features
             </p>
           </div>
-          <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Shield className="h-4 w-4" />
             <span>Secure & Compliant</span>
           </div>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map(({ title, href, icon: Icon, description, badge, color }) => (
+          {features.map(({ title, href, icon: Icon, description, badge }) => (
             <Link key={title} href={href}>
-              <Card className="cursor-pointer hover:shadow-lg transition-all duration-200 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md bg-white dark:bg-slate-800 group h-full">
+              <Card className="cursor-pointer hover:shadow-lg transition-all duration-200 group h-full">
                 <CardHeader className="pb-3">
                   <div className="flex items-start justify-between">
-                    <div className={`h-10 w-10 rounded-lg ${color} flex items-center justify-center`}>
-                      <Icon className="h-5 w-5 text-white" />
+                    <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Icon className="h-5 w-5 text-primary" />
                     </div>
-                    <Badge variant="secondary" className="text-xs bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300">
+                    <Badge variant="secondary" className="text-xs">
                       {badge}
                     </Badge>
                   </div>
-                  <CardTitle className="text-lg font-semibold text-slate-900 dark:text-slate-100 group-hover:text-primary transition-colors">
+                  <CardTitle className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors">
                     {title}
                   </CardTitle>
-                  <CardDescription className="text-sm text-slate-600 dark:text-slate-400">
+                  <CardDescription className="text-sm text-muted-foreground">
                     {description}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="pt-0">
                   <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
                       <span>Access module</span>
                     </div>
-                    <ArrowRight className="h-4 w-4 text-slate-600 dark:text-slate-400 group-hover:text-primary transition-colors" />
+                    <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
                   </div>
                 </CardContent>
               </Card>

--- a/components/accounting/StatsCards.tsx
+++ b/components/accounting/StatsCards.tsx
@@ -17,31 +17,31 @@ export default function StatsCards({ stats }: { stats: Stat[] }) {
   const getTrendIcon = (trend?: "up" | "down" | "neutral") => {
     switch (trend) {
       case "up":
-        return <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />;
+        return <TrendingUp className="h-4 w-4 text-green-500" />;
       case "down":
-        return <TrendingDown className="h-4 w-4 text-red-600 dark:text-red-400" />;
+        return <TrendingDown className="h-4 w-4 text-red-500" />;
       default:
-        return <Minus className="h-4 w-4 text-gray-400 dark:text-gray-500" />;
+        return <Minus className="h-4 w-4 text-muted-foreground" />;
     }
   };
 
   const getTrendColor = (trend?: "up" | "down" | "neutral") => {
     switch (trend) {
       case "up":
-        return "text-green-600 bg-green-50 dark:bg-green-950 dark:text-green-400";
+        return "text-green-500 bg-green-500/20";
       case "down":
-        return "text-red-600 bg-red-50 dark:bg-red-950 dark:text-red-400";
+        return "text-red-500 bg-red-500/20";
       default:
-        return "text-gray-600 bg-gray-50 dark:bg-gray-950 dark:text-gray-400";
+        return "text-muted-foreground bg-muted";
     }
   };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {stats.map(({ title, value, delta, icon: Icon, description, trend }) => (
-        <Card key={title} className="hover:shadow-lg transition-all duration-200 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md bg-white dark:bg-slate-800">
+        <Card key={title} className="hover:shadow-lg transition-all duration-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
               {title}
             </CardTitle>
             <div className="h-8 w-8 rounded-lg bg-primary/10 flex items-center justify-center">
@@ -49,17 +49,17 @@ export default function StatsCards({ stats }: { stats: Stat[] }) {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900 dark:text-slate-100">{value}</div>
+            <div className="text-2xl font-bold text-foreground">{value}</div>
             {description && (
-              <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 {description}
               </p>
             )}
             {delta && delta !== "—" && (
               <div className="flex items-center gap-1 mt-2">
                 {getTrendIcon(trend)}
-                <Badge 
-                  variant="secondary" 
+                <Badge
+                  variant="secondary"
                   className={`text-xs font-medium ${getTrendColor(trend)}`}
                 >
                   {delta}

--- a/docs/superpowers/plans/2026-07-30-accounting-ui-standardize.md
+++ b/docs/superpowers/plans/2026-07-30-accounting-ui-standardize.md
@@ -1,0 +1,439 @@
+# Accounting UI Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle every accounting page/component to match the rest of the app's design system (Dashboard, Loans, Clients), with zero behavior change — pure Tailwind class edits only.
+
+**Architecture:** This is a styling-only refactor. No component is restructured, no data-fetching or route logic changes, no new dependencies. Each task edits one subsystem's files (grouped by accounting sub-feature) by applying the class-mapping rules below, then verifies with `tsc` and a diff review confirming only `className` values changed.
+
+**Tech Stack:** Next.js (App Router), Tailwind CSS, shadcn/ui (`components/ui/*`), TypeScript. No test framework is configured for this app (`package.json` has no `test` script) — verification is `npx tsc --noEmit` (type-check) plus a manual visual check.
+
+Spec: `docs/superpowers/specs/2026-07-30-accounting-ui-standardize-design.md`
+
+## Global Constraints
+
+Apply this exact class mapping everywhere it appears, across every task in this plan. This table **is** the spec — do not invent new mappings.
+
+| Find (pattern) | Replace with |
+|---|---|
+| `bg-white dark:bg-slate-800` on a `<Card>` | remove entirely (bare `<Card>` already uses `bg-card`) |
+| `border-slate-200 dark:border-slate-700` / `border-slate-600` on a `<Card>`/`Input`/`Select` | remove entirely (component default `border` already themes) |
+| `bg-gradient-to-br from-X-50 to-Y-50 dark:from-X-950 dark:to-Y-950` (card backgrounds) | remove entirely — bare `<Card>` |
+| `bg-gradient-to-r from-X-600 to-Y-600 hover:from-X-700 hover:to-Y-700 text-white shadow-lg` (buttons) | remove — use default `<Button>` (or `variant="outline"` if it was a secondary action) |
+| `text-slate-900 dark:text-slate-100` | `text-foreground` |
+| `text-slate-700 dark:text-slate-300` / `text-slate-600 dark:text-slate-400` / `text-slate-500 dark:text-slate-400` | `text-muted-foreground` |
+| `bg-white dark:bg-slate-700` / `dark:bg-slate-800` on `Input`/`Select`/`SelectContent`/`SelectTrigger`/`SelectItem` | remove entirely (component defaults) |
+| `text-slate-400 dark:text-slate-500` (icon colors inside inputs) | `text-muted-foreground` |
+| `bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300` (plain/neutral Badge) | remove custom classes — use `<Badge variant="secondary">` |
+| Per-category color pair, e.g. `text-emerald-600 dark:text-emerald-400` / `bg-emerald-50 dark:bg-emerald-950` / `bg-emerald-100 dark:bg-emerald-900` (account type, trend, status colors) | single color, no dark pair: text → `text-{color}-500`; background → `bg-{color}-500/20`. Keep the same color family (emerald/green→green, amber→amber or yellow, blue→blue, purple→purple, red→red) so the semantic meaning is unchanged — only the token pair collapses to the Dashboard idiom. |
+| `bg-slate-200 dark:bg-slate-700` (skeleton loading blocks) | `bg-muted` |
+| `border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950` (error Card) | remove — bare `<Card>`; error text → `text-destructive` |
+| Rainbow per-item icon backgrounds (`bg-blue-500`, `bg-green-500`, `bg-purple-500`, `bg-orange-500`, `bg-red-500`, `bg-indigo-500`, `bg-teal-500` used only for visual variety, not semantic status) | `bg-primary/10` container + `text-primary` icon (see `StatsCards.tsx` icon treatment) |
+| `dark:bg-[#0d121f]` (raw hex) | remove — delete the wrapping `<section>` entirely (see Task 1) |
+
+**Do not touch:** any non-styling code — data fetching (`useSWR`, `fetch`), state (`useState`, `useMemo`), form handlers, validation, routing (`Link href`), or component logic. If a line mixes a style class with logic, only the class list changes.
+
+**Verification command available in every task:** `npx tsc --noEmit` (run from `loan-matrix/`). No `test` script exists in this repo; do not invent one.
+
+---
+
+## Task 1: Shared components — AccountingHome, StatsCards, layout wrapper
+
+**Files:**
+- Modify: `components/accounting/AccountingHome.tsx`
+- Modify: `components/accounting/StatsCards.tsx`
+- Modify: `app/(application)/accounting/layout.tsx`
+
+**Interfaces:**
+- Consumes: nothing new — these are presentational components already wired into `app/(application)/accounting/page.tsx`.
+- Produces: no exported signatures change. `AccountingHome`, `StatsCards({ stats })`, `AccountingLayout({ children })` keep identical props/exports.
+
+- [ ] **Step 1: Read the three files**
+
+Read `components/accounting/AccountingHome.tsx`, `components/accounting/StatsCards.tsx`, `app/(application)/accounting/layout.tsx` in full before editing.
+
+- [ ] **Step 2: Fix `AccountingHome.tsx`**
+
+In the `features` array (lines ~18-75), delete the `color: 'bg-...-500'` property from every entry — it's no longer used.
+
+Replace the icon container (around line 101):
+```tsx
+<div className={`h-10 w-10 rounded-lg ${color} flex items-center justify-center`}>
+  <Icon className="h-5 w-5 text-white" />
+</div>
+```
+with:
+```tsx
+<div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+  <Icon className="h-5 w-5 text-primary" />
+</div>
+```
+(then remove `icon: Icon, color` destructuring's now-unused `color` from the `.map(({ title, href, icon: Icon, description, badge, color })` call — becomes `.map(({ title, href, icon: Icon, description, badge })`).
+
+Apply the Global Constraints text/border mapping to the rest of the file: `text-slate-900 dark:text-slate-100` → `text-foreground` (h2, CardTitle), `text-slate-600 dark:text-slate-400` → `text-muted-foreground` (p, CardDescription, "Access module" text, ArrowRight icon, Shield row), `border-slate-200 dark:border-slate-700` and `bg-white dark:bg-slate-800` on the `<Card>` → remove, `bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300` on the badge → remove custom classes, keep `variant="secondary"`.
+
+- [ ] **Step 3: Fix `StatsCards.tsx`**
+
+Apply Global Constraints mapping:
+- `<Card>` className: remove `border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md bg-white dark:bg-slate-800`, keep `hover:shadow-lg transition-all duration-200`.
+- `text-slate-700 dark:text-slate-200` (CardTitle) → `text-muted-foreground`.
+- `text-slate-900 dark:text-slate-100` (value) → `text-foreground`.
+- `text-slate-600 dark:text-slate-400` (description) → `text-muted-foreground`.
+
+In `getTrendColor`, collapse each branch to the Global Constraints per-category mapping:
+```tsx
+const getTrendColor = (trend?: "up" | "down" | "neutral") => {
+  switch (trend) {
+    case "up":
+      return "text-green-500 bg-green-500/20";
+    case "down":
+      return "text-red-500 bg-red-500/20";
+    default:
+      return "text-muted-foreground bg-muted";
+  }
+};
+```
+`getTrendIcon` already uses reasonable semantic colors (`text-green-600 dark:text-green-400` etc.) — simplify to match: `text-green-500`, `text-red-500`, `text-gray-400` → `text-muted-foreground`.
+
+- [ ] **Step 4: Fix `layout.tsx`**
+
+Replace the whole file body — delete the wrapping section with the raw hex background:
+```tsx
+import React from 'react';
+
+interface AccountingLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AccountingLayout({ children }: AccountingLayoutProps) {
+  return <div className="space-y-6">{children}</div>;
+}
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors introduced by these 3 files (pre-existing unrelated errors, if any, are out of scope — confirm by checking the error list doesn't mention `AccountingHome.tsx`, `StatsCards.tsx`, or `accounting/layout.tsx`).
+
+- [ ] **Step 6: Diff review**
+
+Run: `git diff components/accounting/AccountingHome.tsx components/accounting/StatsCards.tsx "app/(application)/accounting/layout.tsx"`
+Confirm every changed line is a `className` value, JSX attribute, or the one destructuring/prop removal described above — no logic, no removed functionality.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/accounting/AccountingHome.tsx components/accounting/StatsCards.tsx "app/(application)/accounting/layout.tsx"
+git commit -m "Standardize shared accounting components to app design system"
+```
+
+---
+
+## Task 2: Accounting dashboard page
+
+**Files:**
+- Modify: `app/(application)/accounting/page.tsx`
+
+**Interfaces:**
+- Consumes: `AccountingLayout`, `StatsCards`, `AccountingHome` from Task 1 (unchanged props).
+- Produces: nothing new consumed elsewhere — this is the route entry point.
+
+- [ ] **Step 1: Read the file**
+
+Read `app/(application)/accounting/page.tsx` in full. Its header (`text-3xl font-bold text-foreground` / `text-muted-foreground`) already matches the design system — leave it as-is.
+
+- [ ] **Step 2: Verify no remaining violations**
+
+Run: `grep -n "slate-\|dark:bg-\[#\|gradient" "app/(application)/accounting/page.tsx"`
+Expected: no output. If any lines match, apply the Global Constraints mapping to them.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from this file.
+
+- [ ] **Step 4: Commit** (only if Step 2 required changes; otherwise skip — nothing to commit)
+
+```bash
+git add "app/(application)/accounting/page.tsx"
+git commit -m "Standardize accounting dashboard page styling"
+```
+
+---
+
+## Task 3: Chart of Accounts (list, new, view, edit)
+
+**Files:**
+- Modify: `app/(application)/accounting/chart-of-accounts/page.tsx`
+- Modify: `app/(application)/accounting/chart-of-accounts/new/page.tsx`
+- Modify: `app/(application)/accounting/chart-of-accounts/[id]/page.tsx`
+- Modify: `app/(application)/accounting/chart-of-accounts/[id]/edit/page.tsx`
+
+**Interfaces:**
+- Consumes: `Card`, `Badge`, `Button`, `Input`, `Select*` from `@/components/ui/*` (unchanged imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Read all four files** before editing any of them, to catch shared patterns (this subsystem reuses the same account-type color scheme across list/view/edit).
+
+- [ ] **Step 2: Fix `chart-of-accounts/page.tsx`**
+
+This file has already been read in full during design. Apply exactly:
+
+- Error Card (~line 84): `border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950` → remove (bare `<Card>`); `text-red-600 dark:text-red-400` / `text-red-500 dark:text-red-300` → `text-destructive`.
+- Loading skeleton Cards (~lines 100-117): `border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800` → remove; `bg-slate-200 dark:bg-slate-700` (skeleton bars) → `bg-muted`.
+- `typeConfig` map (~lines 124-155): collapse every entry to the Global Constraints per-category mapping, e.g.:
+  ```tsx
+  const typeConfig: Record<string, { color: string; bgColor: string; icon: any }> = {
+    ASSET: { color: 'text-emerald-500', bgColor: 'bg-emerald-500/20', icon: TrendingUp },
+    LIABILITY: { color: 'text-amber-500', bgColor: 'bg-amber-500/20', icon: TrendingDown },
+    INCOME: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    REVENUE: { color: 'text-blue-500', bgColor: 'bg-blue-500/20', icon: TrendingUp },
+    EQUITY: { color: 'text-purple-500', bgColor: 'bg-purple-500/20', icon: Circle },
+    EXPENSE: { color: 'text-red-500', bgColor: 'bg-red-500/20', icon: TrendingDown },
+  };
+  ```
+- Header text (~line 162-165): `text-slate-900 dark:text-slate-100` → `text-foreground`; `text-slate-600 dark:text-slate-400` → `text-muted-foreground`.
+- "New Account" button (~line 168): `bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg` → remove, bare `<Button>`.
+- Stats Cards (~lines 177-231): each has `border border-slate-200 dark:border-slate-700 shadow-sm bg-gradient-to-br from-X-50 to-Y-50 dark:from-X-950 dark:to-Y-950` → remove entirely, bare `<Card>`. Inner text/icon colors (`text-blue-600 dark:text-blue-400`, `text-blue-900 dark:text-blue-100`, `bg-blue-100 dark:bg-blue-900`) → collapse to single-color-with-opacity per Global Constraints (e.g. `text-blue-500` for label+icon, `text-foreground` for the big number instead of `text-blue-900 dark:text-blue-100`, `bg-blue-500/20` for the icon circle).
+- Filters Card (~line 235): `border border-slate-200 dark:border-slate-700 shadow-sm bg-white dark:bg-slate-800` → remove. Search icon `text-slate-400 dark:text-slate-500` → `text-muted-foreground`. Input `bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100` → remove (keep `pl-10`). Select trigger/content/items: remove all `bg-white dark:bg-slate-700/800`, `border-slate-200 dark:border-slate-600`, `text-slate-900 dark:text-slate-100` — use bare `SelectTrigger`/`SelectContent`/`SelectItem`.
+- Account row Cards (~line 280): `border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700` → remove (keep `group hover:shadow-lg hover:scale-[1.02] transition-all duration-300`). Title `text-slate-900 dark:text-slate-100` → `text-foreground`. Description `text-slate-500 dark:text-slate-400` → `text-muted-foreground`. GL code hash icon and text `text-slate-400 dark:text-slate-500` / `text-slate-600 dark:text-slate-300` → `text-muted-foreground`; its pill background `bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600` → `bg-muted`.
+- Type badge (~line 314): keep `variant="outline"` and the per-type `config.color`, but simplify className to `` `text-xs h-6 px-3 ${config.color} border-current ${config.bgColor} hover:shadow-sm transition-all duration-200` `` (drop `bg-gradient-to-r` prefix — `config.bgColor` is now a flat class).
+- Usage badge (~line 323): `bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600` → remove custom classes, keep `variant="secondary"`.
+- Status badge (~line 336): replace the inline ternary with Global Constraints colors: disabled → `text-red-500 bg-red-500/20 border-red-500/30`, active → `text-green-500 bg-green-500/20 border-green-500/30`.
+- Action button (~line 349): `text-slate-600 dark:text-slate-400` → `text-muted-foreground`.
+- Pagination Card and its buttons (~lines 366-421): same `border border-slate-200 dark:border-slate-700 shadow-sm bg-white dark:bg-slate-800` removal; `text-slate-600 dark:text-slate-400` → `text-muted-foreground`; button `border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700` → remove (bare `variant="outline"` already handles this). Page-size Select: same Select cleanup as the filters Select above.
+
+- [ ] **Step 3: Fix `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`**
+
+Read each file. Apply the same Global Constraints mapping found in Step 2 wherever the same patterns recur (headers, Cards, Inputs, Selects, Badges, buttons). These forms will have Label/Input pairs and multi-step or single-form layouts not present in the list page — map every `slate-*`/gradient occurrence using the Global Constraints table; there is no new pattern type here (chart-of-accounts detail/edit/new pages use the same Card/Input/Select/Badge/Button primitives as the list page).
+
+- [ ] **Step 4: Confirm no violations remain**
+
+Run: `grep -rn "slate-\|gradient-to-" "app/(application)/accounting/chart-of-accounts/"`
+Expected: no output.
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from these 4 files.
+
+- [ ] **Step 6: Diff review**
+
+Run: `git diff "app/(application)/accounting/chart-of-accounts/"`
+Confirm only `className` values changed — no logic (filtering, pagination math, fetch calls, form submit handlers) touched.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "app/(application)/accounting/chart-of-accounts/"
+git commit -m "Standardize chart of accounts pages styling"
+```
+
+---
+
+## Task 4: Accounting Rules (list, new, view, edit)
+
+**Files:**
+- Modify: `app/(application)/accounting/accounting-rules/page.tsx`
+- Modify: `app/(application)/accounting/accounting-rules/new/page.tsx`
+- Modify: `app/(application)/accounting/accounting-rules/[id]/page.tsx`
+- Modify: `app/(application)/accounting/accounting-rules/[id]/edit/page.tsx`
+
+**Interfaces:**
+- Consumes: `@/components/ui/*` primitives (unchanged imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Read all four files** before editing.
+
+- [ ] **Step 2: Apply the Global Constraints mapping** to every file — headers (`text-slate-900 dark:text-slate-100` → `text-foreground`, etc.), Cards (strip `border-slate-*`/`bg-white dark:bg-slate-800`/gradients), Inputs/Selects (strip manual bg/border/text slate classes), Badges (strip custom slate classes on non-semantic badges; collapse any status/type color pairs to the single-color-with-opacity idiom), buttons (strip gradients), skeletons (`bg-slate-200 dark:bg-slate-700` → `bg-muted`), error states (`text-destructive`, bare `Card`).
+
+- [ ] **Step 3: Confirm no violations remain**
+
+Run: `grep -rn "slate-\|gradient-to-" "app/(application)/accounting/accounting-rules/"`
+Expected: no output.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from these 4 files.
+
+- [ ] **Step 5: Diff review**
+
+Run: `git diff "app/(application)/accounting/accounting-rules/"`
+Confirm only styling changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/(application)/accounting/accounting-rules/"
+git commit -m "Standardize accounting rules pages styling"
+```
+
+---
+
+## Task 5: Closing Entries (list, new, view, edit)
+
+**Files:**
+- Modify: `app/(application)/accounting/closing-entries/page.tsx`
+- Modify: `app/(application)/accounting/closing-entries/new/page.tsx`
+- Modify: `app/(application)/accounting/closing-entries/[id]/page.tsx`
+- Modify: `app/(application)/accounting/closing-entries/[id]/edit/page.tsx`
+
+**Interfaces:**
+- Consumes: `@/components/ui/*` primitives (unchanged imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Read all four files** before editing.
+
+- [ ] **Step 2: Apply the Global Constraints mapping** to every file, same categories as Task 4 (headers, Cards, Inputs/Selects, Badges, buttons, skeletons, error states). Closing entries typically show a status (e.g. pending/posted/reversed) — collapse any such status badge coloring to the single-color-with-opacity idiom, preserving which status maps to which color family.
+
+- [ ] **Step 3: Confirm no violations remain**
+
+Run: `grep -rn "slate-\|gradient-to-" "app/(application)/accounting/closing-entries/"`
+Expected: no output.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from these 4 files.
+
+- [ ] **Step 5: Diff review**
+
+Run: `git diff "app/(application)/accounting/closing-entries/"`
+Confirm only styling changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/(application)/accounting/closing-entries/"
+git commit -m "Standardize closing entries pages styling"
+```
+
+---
+
+## Task 6: Journal Entries (new, view by transaction)
+
+**Files:**
+- Modify: `app/(application)/accounting/journal-entries/new/page.tsx`
+- Modify: `app/(application)/accounting/journal-entries/[transactionId]/page.tsx`
+
+**Interfaces:**
+- Consumes: `@/components/ui/*` primitives (unchanged imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Read both files** before editing. These are the two largest accounting files (664 and 549 lines) — likely a multi-line-item journal entry form and a transaction detail view.
+
+- [ ] **Step 2: Apply the Global Constraints mapping** to both files (headers, Cards, Inputs/Selects, Badges, buttons, skeletons, error states). Pay particular attention to any debit/credit or balanced/unbalanced indicator coloring — preserve the semantic distinction (e.g. debit vs. credit, balanced vs. unbalanced) using the single-color-with-opacity idiom rather than dropping the distinction.
+
+- [ ] **Step 3: Confirm no violations remain**
+
+Run: `grep -rn "slate-\|gradient-to-" "app/(application)/accounting/journal-entries/"`
+Expected: no output.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from these 2 files.
+
+- [ ] **Step 5: Diff review**
+
+Run: `git diff "app/(application)/accounting/journal-entries/"`
+Confirm only styling changed — these forms likely have running-total/balance-validation logic; verify none of it moved or changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/(application)/accounting/journal-entries/"
+git commit -m "Standardize journal entries pages styling"
+```
+
+---
+
+## Task 7: Search Journal, Frequent Postings, Accruals
+
+**Files:**
+- Modify: `app/(application)/accounting/search-journal/page.tsx`
+- Modify: `app/(application)/accounting/frequent-postings/page.tsx`
+- Modify: `app/(application)/accounting/accruals/page.tsx`
+
+**Interfaces:**
+- Consumes: `@/components/ui/*` primitives (unchanged imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Read `search-journal/page.tsx` and `frequent-postings/page.tsx`** before editing (not yet read during design).
+
+- [ ] **Step 2: Fix `accruals/page.tsx`**
+
+This file has already been read in full during design. Apply exactly:
+
+- Card (~line 98): `bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 shadow-lg` → remove, bare `<Card>` (keep no extra classes).
+- CardTitle (~line 100): `text-slate-900 dark:text-slate-100` → remove (CardTitle already defaults to foreground text via `text-card-foreground` on the parent `Card`) — just drop the className override.
+- CardDescription (~line 103): `text-slate-600 dark:text-slate-400` → remove (CardDescription already defaults to `text-muted-foreground`).
+- Label (~line 110): `text-slate-900 dark:text-slate-100` → remove className override (Label defaults are fine).
+- Date Input (~line 119): `bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500` → keep only `pl-10` (rely on Input defaults; drop the custom indigo focus ring to match every other Input in the app).
+- Calendar icon (~line 122): `text-slate-400` → `text-muted-foreground`.
+- Cancel button (~line 131): `bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-600` → remove, bare `<Button variant="outline">`.
+- Submit button (~line 139): `bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white disabled:opacity-50 disabled:cursor-not-allowed` → `disabled:opacity-50 disabled:cursor-not-allowed` only (bare `<Button>` for primary color).
+
+- [ ] **Step 3: Apply the Global Constraints mapping to `search-journal/page.tsx` and `frequent-postings/page.tsx`** — same categories as prior tasks (headers, Cards, Inputs/Selects, Badges, buttons, skeletons, error states). Search Journal likely has a results table/list — if any row striping or status coloring uses `slate-*`, replace backgrounds/borders per the Global Constraints table; leave table structure and data logic untouched.
+
+- [ ] **Step 4: Confirm no violations remain**
+
+Run: `grep -rn "slate-\|gradient-to-" "app/(application)/accounting/search-journal/" "app/(application)/accounting/frequent-postings/" "app/(application)/accounting/accruals/"`
+Expected: no output.
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no new errors from these 3 files.
+
+- [ ] **Step 6: Diff review**
+
+Run: `git diff "app/(application)/accounting/search-journal/" "app/(application)/accounting/frequent-postings/" "app/(application)/accounting/accruals/"`
+Confirm only styling changed — accruals' `handleRunAccruals` fetch/date-formatting logic must be byte-identical.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "app/(application)/accounting/search-journal/" "app/(application)/accounting/frequent-postings/" "app/(application)/accounting/accruals/"
+git commit -m "Standardize search journal, frequent postings, and accruals pages styling"
+```
+
+---
+
+## Task 8: Full-module verification
+
+**Files:** none modified — verification only.
+
+**Interfaces:** N/A.
+
+- [ ] **Step 1: Repo-wide grep for leftover violations**
+
+Run: `grep -rn "slate-\|dark:bg-\[#\|gradient-to-" "app/(application)/accounting/" components/accounting/`
+Expected: no output. If anything remains, go back to the owning task and fix it (do not patch ad hoc here — keep the fix attributed to its subsystem's commit history by amending that task's work before moving on).
+
+- [ ] **Step 2: Full type-check**
+
+Run: `cd "loan-matrix" && npx tsc --noEmit`
+Expected: no errors in any `app/(application)/accounting/**` or `components/accounting/**` file. (Pre-existing errors elsewhere in the app, unrelated to this refactor, are out of scope.)
+
+- [ ] **Step 3: Production build**
+
+Run: `cd "loan-matrix" && npm run build`
+Expected: build succeeds (confirms no broken JSX/Tailwind syntax across all touched files, since `next build --webpack` runs the full TypeScript + bundling pipeline).
+
+- [ ] **Step 4: Manual visual pass**
+
+Run `npm run dev`, then visit each of these routes in the browser in both light and dark mode (toggle via the app's theme switcher), confirming: (a) it visually reads consistently with `/loans` and `/clients` — no stray slate panels, no gradients, no rainbow icon colors; (b) all interactive elements still work — search, filters, pagination, form submission, navigation links:
+  - `/accounting`
+  - `/accounting/chart-of-accounts`, `/accounting/chart-of-accounts/new`, and one existing account's view/edit pages
+  - `/accounting/accounting-rules`, `/accounting/accounting-rules/new`, and one existing rule's view/edit pages
+  - `/accounting/closing-entries`, `/accounting/closing-entries/new`, and one existing entry's view/edit pages
+  - `/accounting/journal-entries/new` and one existing transaction's view page
+  - `/accounting/search-journal`
+  - `/accounting/frequent-postings`
+  - `/accounting/accruals`
+
+- [ ] **Step 5: Report results**
+
+Summarize pass/fail per route. If any route regresses functionally (not just visually), stop and fix before proceeding — this plan guarantees zero behavior change.

--- a/docs/superpowers/specs/2026-07-30-accounting-ui-standardize-design.md
+++ b/docs/superpowers/specs/2026-07-30-accounting-ui-standardize-design.md
@@ -1,0 +1,54 @@
+# Accounting UI Standardization
+
+## Problem
+
+The accounting module (`components/accounting/`, `app/(application)/accounting/**`, 14 page files + 2 shared components) styles itself independently of the rest of the app. Every page hand-rolls colors instead of using the shared design system, producing:
+
+- Hardcoded `slate-*` + manual `dark:` pairs on Cards/Inputs/Selects/Badges (e.g. `bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700`) instead of the shared `Card` component's built-in `bg-card`/`text-card-foreground`/`border`, which already themes via CSS variables.
+- Gradient buttons and gradient card backgrounds (`bg-gradient-to-r from-blue-600 to-purple-600`, `from-blue-50 to-indigo-50 dark:from-blue-950...`) not used anywhere else in the app.
+- Arbitrary, non-semantic per-item colors (each `AccountingHome` tile gets a different hardcoded rainbow color with no meaning).
+- A raw hex value (`dark:bg-[#0d121f]`) in `layout.tsx` instead of a token.
+- Inconsistency even within the module — some spots (`accruals/page.tsx` header, `accounting/page.tsx` header) already correctly use `text-foreground`/`text-muted-foreground`.
+
+Other modules (Dashboard, Loans, Clients) don't do any of this — they use the shared UI primitives at their defaults and reserve color only for real semantic meaning (status, trend), expressed as a single Tailwind color at `/20` opacity for backgrounds plus `-500` text, with no manual `dark:` pairs.
+
+## Goal
+
+Restyle every page under `app/(application)/accounting/**` and `components/accounting/**` to match the rest of the app's visual language, with zero behavior change. This is a pure styling/markup refactor — no data-fetching, routing, or business logic changes.
+
+## Rules
+
+Applied uniformly across all 14 accounting page files and the 2 shared components:
+
+1. **Cards** — use bare `<Card>`/`<CardHeader>`/`<CardContent>` with no overrides. Remove `bg-white dark:bg-slate-800`, `border-slate-200 dark:border-slate-700`, and gradient backgrounds (`bg-gradient-to-br from-blue-50...`).
+2. **Text** — `text-slate-900 dark:text-slate-100` → `text-foreground`; `text-slate-600/500 dark:text-slate-400` → `text-muted-foreground`.
+3. **Inputs/Selects** — drop manual `bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 text-slate-900...`; rely on component defaults (matches the Loans search bar).
+4. **Buttons** — remove gradient buttons; use default `<Button>` (primary) or `variant="outline"`, matching Clients/Loans.
+5. **Semantic color coding** (account type badges, trend arrows, active/disabled status) — keep the meaning, re-implement using the idiom Dashboard already uses: a single Tailwind color at `/20` opacity for backgrounds + plain `-500` text, no manual `dark:` pairs.
+6. **Module tiles** (`AccountingHome.tsx`) — replace the 7 arbitrary rainbow icon colors with the treatment `StatsCards.tsx` already uses correctly: `bg-primary/10` circle + `text-primary` icon.
+7. **Loading skeletons** — `bg-slate-200 dark:bg-slate-700` → `bg-muted`, matching Loans' skeleton.
+8. **Error states** — plain `<Card>` + `text-destructive`, no custom red card styling.
+9. **`layout.tsx` wrapper** — drop the extra `bg-white dark:bg-[#0d121f] rounded-lg shadow-sm` box around all accounting pages; no other module wraps its content in an extra card-like section.
+
+## Scope
+
+Files in scope:
+
+- `components/accounting/AccountingHome.tsx`
+- `components/accounting/StatsCards.tsx`
+- `app/(application)/accounting/layout.tsx`
+- `app/(application)/accounting/page.tsx`
+- `app/(application)/accounting/accounting-rules/page.tsx`, `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`
+- `app/(application)/accounting/accruals/page.tsx`
+- `app/(application)/accounting/chart-of-accounts/page.tsx`, `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`
+- `app/(application)/accounting/closing-entries/page.tsx`, `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`
+- `app/(application)/accounting/frequent-postings/page.tsx`
+- `app/(application)/accounting/journal-entries/new/page.tsx`, `[transactionId]/page.tsx`
+- `app/(application)/accounting/search-journal/page.tsx`
+
+Out of scope: any Fineract API/data logic, routing structure, non-accounting modules.
+
+## Verification
+
+- `npm run build` / `tsc` type-check passes (styling-only edits, but Tailwind class typos can still break `cn()` usage or JSX).
+- Manual visual pass in the browser: each accounting page in both light and dark mode, confirming it reads consistently with Loans/Clients/Dashboard and nothing regresses (search, filters, pagination, forms still functional).


### PR DESCRIPTION
## Summary
- Replaces hardcoded `slate-*` colors, manual `dark:` pairs, gradients, and arbitrary per-item icon colors across the entire accounting module (2 shared components + 17 page files under `app/(application)/accounting/**`) with the design-system tokens the rest of the app already uses (Dashboard/Loans/Clients): bare `Card`/`Badge`/`Button` defaults, `text-foreground`/`text-muted-foreground`, `bg-primary`/`text-primary`, `text-destructive`, `bg-muted`, and a `text-{color}-500`/`bg-{color}-500/20` idiom for semantic status/category colors.
- Pure styling refactor — zero behavior change. Verified with `tsc --noEmit` (no new errors vs. a documented 5-error pre-existing baseline), `npm run build` (clean production build), and a token-level diff audit confirming no fetch/state/handler/balance-calculation logic changed anywhere, including the two largest files (journal entry debit/credit forms).
- Executed via an 8-task plan with a task-scoped review after each task and a final whole-branch review; see `docs/superpowers/specs/2026-07-30-accounting-ui-standardize-design.md` and `docs/superpowers/plans/2026-07-30-accounting-ui-standardize.md` for the full design and task breakdown.

## Follow-ups noted but out of scope for this PR
- 8 raw spinner elements (`border-indigo-600`/`border-blue-600`/`border-white`) not yet unified onto the `Loader2` component used elsewhere in the module.
- A few small cross-task cosmetic drifts (account-type badge border treatment, empty-state icon idiom, `CardTitle` className redundancy) noted in the final review as candidates for a follow-up normalization pass — none affect correctness.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (baseline: 5 pre-existing accounting-related errors, unchanged)
- [x] `npm run build` — production build compiles successfully
- [x] Repo-wide grep confirms zero remaining hardcoded `slate-*`/gradient/raw-hex violations in the accounting module
- [ ] Manual visual pass in light/dark mode (deferred — building the app locally requires connecting to a live Postgres instance via `.env.local`; recommend a reviewer click through `/accounting` and its subpages before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)