### PR TITLE
Restore historical client loans

### DIFF
--- a/app/(application)/clients/[id]/components/client-loans.tsx
+++ b/app/(application)/clients/[id]/components/client-loans.tsx
@@ -199,23 +199,7 @@ export function ClientLoans({ clientId, readOnly = false }: ClientLoansProps) {
       rawLoans = data.loanAccounts;
     }
     
-    const CUTOFF = new Date("2026-01-01T00:00:00Z");
-
-    const parseFineractDate = (
-      d: string | number[] | null | undefined
-    ): Date | null => {
-      if (!d) return null;
-      if (Array.isArray(d) && d.length >= 3) return new Date(d[0], d[1] - 1, d[2]);
-      if (typeof d === "string") return new Date(d);
-      return null;
-    };
-
     return rawLoans
-      .filter((loan: RawClientLoan) => {
-        const date = parseFineractDate(loan.timeline?.actualDisbursementDate)
-          ?? parseFineractDate(loan.timeline?.submittedOnDate);
-        return !date || date >= CUTOFF;
-      })
       .map((loan) => ({
       id: loan.id,
       accountNo: loan.accountNo,

--- a/lib/__tests__/client-loans-table.test.ts
+++ b/lib/__tests__/client-loans-table.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -7,6 +9,12 @@ import {
   orderClientLoansLatestFirst,
   paginateClientLoans,
 } from "../client-loans-table";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
 
 test("orders client loans newest first while preserving chronological sequence numbers", () => {
   const loans = [
@@ -76,4 +84,13 @@ test("filters client loans by account number or loan product name", () => {
     filterClientLoans(loans, "  ").map((loan) => loan.id),
     [31, 32, 33]
   );
+});
+
+test("keeps historical loans returned by Fineract in the client loan list", () => {
+  const source = readRepoFile(
+    "app/(application)/clients/[id]/components/client-loans.tsx"
+  );
+
+  assert.doesNotMatch(source, /const CUTOFF = new Date\("2026-01-01T00:00:00Z"\)/);
+  assert.doesNotMatch(source, /date >= CUTOFF/);
 });


### PR DESCRIPTION
## Summary\n- remove the client-loan history cutoff that hid Fineract loans dated before 1 January 2026\n- retain historical loans such as Nano Loan account 000079791\n- add regression coverage for the removed cutoff\n\n## Verification\n- npx tsx --test lib/__tests__/client-loans-table.test.ts