### PR TITLE
Add tenant-configured self-service password reset

### DIFF
--- a/app/api/auth/password-reset/complete/route.ts
+++ b/app/api/auth/password-reset/complete/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  completePasswordReset,
+  PasswordResetError,
+  validatePassword,
+} from "@/lib/password-reset";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+function getRequestContext(request: NextRequest) {
+  return {
+    requestIp:
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      null,
+    userAgent: request.headers.get("user-agent"),
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const challengeId =
+      typeof body.challengeId === "string" ? body.challengeId.trim() : "";
+    const verificationToken =
+      typeof body.verificationToken === "string"
+        ? body.verificationToken.trim()
+        : "";
+    const password = typeof body.password === "string" ? body.password : "";
+    const repeatPassword =
+      typeof body.repeatPassword === "string" ? body.repeatPassword : "";
+
+    if (!challengeId || !verificationToken || !password || !repeatPassword) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Verification and both password fields are required",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (password !== repeatPassword) {
+      return NextResponse.json(
+        { success: false, error: "Passwords do not match" },
+        { status: 400 }
+      );
+    }
+
+    const validation = validatePassword(password);
+    if (!validation.valid) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Password does not meet the requirements",
+          details: validation.errors,
+        },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const result = await completePasswordReset({
+      tenantId: tenant.id,
+      challengeId,
+      verificationToken,
+      password,
+      context: getRequestContext(request),
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    if (error instanceof PasswordResetError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error completing password reset:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to complete password reset" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/password-reset/request/route.ts
+++ b/app/api/auth/password-reset/request/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  PasswordResetError,
+  requestPasswordReset,
+} from "@/lib/password-reset";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+function getRequestContext(request: NextRequest) {
+  return {
+    requestIp:
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      null,
+    userAgent: request.headers.get("user-agent"),
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const username = typeof body.username === "string" ? body.username.trim() : "";
+
+    if (!username) {
+      return NextResponse.json(
+        { success: false, error: "Username is required" },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const result = await requestPasswordReset({
+      tenantId: tenant.id,
+      tenantName: tenant.name,
+      tenantSettings: tenant.settings,
+      username,
+      context: getRequestContext(request),
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    if (error instanceof PasswordResetError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error requesting password reset:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Unable to start password reset. Please try again.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/password-reset/resend/route.ts
+++ b/app/api/auth/password-reset/resend/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  PasswordResetError,
+  resendPasswordResetCode,
+} from "@/lib/password-reset";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+function getRequestContext(request: NextRequest) {
+  return {
+    requestIp:
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      null,
+    userAgent: request.headers.get("user-agent"),
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const challengeId =
+      typeof body.challengeId === "string" ? body.challengeId.trim() : "";
+
+    if (!challengeId) {
+      return NextResponse.json(
+        { success: false, error: "Challenge ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const result = await resendPasswordResetCode({
+      tenantId: tenant.id,
+      tenantName: tenant.name,
+      tenantSettings: tenant.settings,
+      challengeId,
+      context: getRequestContext(request),
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    if (error instanceof PasswordResetError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error resending password reset code:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to resend password reset code" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/password-reset/verify/route.ts
+++ b/app/api/auth/password-reset/verify/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  PasswordResetError,
+  verifyPasswordResetCode,
+} from "@/lib/password-reset";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+function getRequestContext(request: NextRequest) {
+  return {
+    requestIp:
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      null,
+    userAgent: request.headers.get("user-agent"),
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const challengeId =
+      typeof body.challengeId === "string" ? body.challengeId.trim() : "";
+    const code = typeof body.code === "string" ? body.code.trim() : "";
+
+    if (!challengeId || !code) {
+      return NextResponse.json(
+        { success: false, error: "Challenge ID and verification code are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!/^\d{6}$/.test(code)) {
+      return NextResponse.json(
+        { success: false, error: "Verification code must be exactly 6 digits" },
+        { status: 400 }
+      );
+    }
+
+    const tenant = await requireCurrentTenant();
+    const result = await verifyPasswordResetCode({
+      tenantId: tenant.id,
+      challengeId,
+      code,
+      context: getRequestContext(request),
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    if (error instanceof PasswordResetError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+
+    console.error("Error verifying password reset code:", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to verify password reset code" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/system/password-reset-logs/route.ts
+++ b/app/api/system/password-reset-logs/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SpecificPermission } from "@/shared/types/auth";
+import { hasPermissionServer } from "@/lib/authorization";
+import { prisma } from "@/lib/prisma";
+import { requireCurrentTenant } from "@/lib/user-login-service";
+
+export async function GET(request: NextRequest) {
+  try {
+    const canReadUsers = await hasPermissionServer(SpecificPermission.READ_USER);
+    const canManageSystem = await hasPermissionServer(SpecificPermission.SYSTEM_ADMIN);
+
+    if (!canReadUsers && !canManageSystem) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const tenant = await requireCurrentTenant();
+    const searchParams = request.nextUrl.searchParams;
+    const requestedLimit = Number(searchParams.get("limit") || 50);
+    const requestedOffset = Number(searchParams.get("offset") || 0);
+    const limit = Math.min(
+      Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 50, 1),
+      100
+    );
+    const offset = Math.max(
+      Number.isFinite(requestedOffset) ? requestedOffset : 0,
+      0
+    );
+    const username = searchParams.get("username")?.trim();
+    const event = searchParams.get("event")?.trim();
+
+    const where = {
+      tenantId: tenant.id,
+      ...(username ? { username: { contains: username, mode: "insensitive" as const } } : {}),
+      ...(event ? { event } : {}),
+    };
+
+    const [total, logs] = await Promise.all([
+      prisma.passwordResetLog.count({ where }),
+      prisma.passwordResetLog.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+    ]);
+
+    return NextResponse.json({
+      total,
+      offset,
+      limit,
+      logs,
+    });
+  } catch (error) {
+    console.error("Error fetching password reset logs:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch password reset logs" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -259,6 +259,7 @@ export default function LoginPage() {
                   </div>
                 </div>
 
+                {/* Remember me is temporarily disabled until session lifetime behavior is finalized.
                 <div className="flex items-center space-x-2">
                   <input
                     type="checkbox"
@@ -269,6 +270,7 @@ export default function LoginPage() {
                     Remember me for 30 days
                   </label>
                 </div>
+                */}
 
                 <Button
                   type="submit"

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, LockIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+type ResetStep = "request" | "verify" | "complete" | "done";
+
+const passwordRequirements = [
+  "At least 12 characters",
+  "One uppercase letter",
+  "One lowercase letter",
+  "One number",
+  "One special character",
+];
+
+export default function ResetPasswordPage() {
+  const [step, setStep] = useState<ResetStep>("request");
+  const [username, setUsername] = useState("");
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [repeatPassword, setRepeatPassword] = useState("");
+  const [challengeId, setChallengeId] = useState("");
+  const [verificationToken, setVerificationToken] = useState("");
+  const [deliveryDescription, setDeliveryDescription] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const callApi = async (path: string, body: Record<string, string>) => {
+    const response = await fetch(path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || "Something went wrong. Please try again.");
+    }
+    return data;
+  };
+
+  const submitRequest = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+    setIsLoading(true);
+
+    try {
+      const data = await callApi("/api/auth/password-reset/request", { username });
+      setChallengeId(data.challengeId || "");
+      setDeliveryDescription(data.deliveryDescription || "your configured contact");
+      setMessage(data.message || "A verification code has been sent.");
+      setStep("verify");
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Unable to start password reset"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const verifyCode = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+    setIsLoading(true);
+
+    try {
+      const data = await callApi("/api/auth/password-reset/verify", {
+        challengeId,
+        code,
+      });
+      setVerificationToken(data.verificationToken);
+      setStep("complete");
+    } catch (verifyError) {
+      setError(
+        verifyError instanceof Error
+          ? verifyError.message
+          : "Unable to verify the code"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resendCode = async () => {
+    setError("");
+    setMessage("");
+    setIsLoading(true);
+
+    try {
+      const data = await callApi("/api/auth/password-reset/resend", {
+        challengeId,
+      });
+      setDeliveryDescription(data.deliveryDescription || deliveryDescription);
+      setMessage("A new verification code has been sent.");
+    } catch (resendError) {
+      setError(
+        resendError instanceof Error
+          ? resendError.message
+          : "Unable to resend the code"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const completeReset = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+    setIsLoading(true);
+
+    try {
+      const data = await callApi("/api/auth/password-reset/complete", {
+        challengeId,
+        verificationToken,
+        password,
+        repeatPassword,
+      });
+      setMessage(data.message || "Password reset successfully.");
+      setStep("done");
+    } catch (completeError) {
+      setError(
+        completeError instanceof Error
+          ? completeError.message
+          : "Unable to complete password reset"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-8">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+
+      <div className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-md items-center justify-center">
+        <Card className="w-full shadow-xl">
+          <CardHeader className="space-y-4 text-center">
+            <div className="flex justify-center">
+              <ThemeAwareLogo width={150} height={50} className="h-12 w-auto" />
+            </div>
+            <div>
+              <CardTitle className="text-2xl">Reset your password</CardTitle>
+              <CardDescription className="mt-2">
+                {step === "request" && "Enter your username to receive a verification code."}
+                {step === "verify" && `Enter the code sent to ${deliveryDescription}.`}
+                {step === "complete" && "Choose a new password for your account."}
+                {step === "done" && "Your password has been changed."}
+              </CardDescription>
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-5">
+            {error && (
+              <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-600">
+                <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            {message && step !== "done" && (
+              <div className="rounded-md border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-700">
+                {message}
+              </div>
+            )}
+
+            {step === "request" && (
+              <form onSubmit={submitRequest} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="username">Username</Label>
+                  <Input
+                    id="username"
+                    value={username}
+                    onChange={(event) => setUsername(event.target.value)}
+                    placeholder="Enter your username"
+                    autoComplete="username"
+                    required
+                  />
+                </div>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Send verification code
+                </Button>
+              </form>
+            )}
+
+            {step === "verify" && (
+              <form onSubmit={verifyCode} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="code">Verification code</Label>
+                  <Input
+                    id="code"
+                    value={code}
+                    onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    placeholder="000000"
+                    className="text-center text-xl tracking-[0.35em]"
+                    required
+                  />
+                </div>
+                <Button type="submit" className="w-full" disabled={isLoading || code.length !== 6}>
+                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Verify code
+                </Button>
+                <Button type="button" variant="outline" className="w-full" onClick={resendCode} disabled={isLoading}>
+                  Resend code
+                </Button>
+              </form>
+            )}
+
+            {step === "complete" && (
+              <form onSubmit={completeReset} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="new-password">New password</Label>
+                  <div className="relative">
+                    <Input
+                      id="new-password"
+                      type="password"
+                      value={password}
+                      onChange={(event) => setPassword(event.target.value)}
+                      autoComplete="new-password"
+                      className="pl-10"
+                      required
+                    />
+                    <LockIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="repeat-password">Repeat new password</Label>
+                  <Input
+                    id="repeat-password"
+                    type="password"
+                    value={repeatPassword}
+                    onChange={(event) => setRepeatPassword(event.target.value)}
+                    autoComplete="new-password"
+                    required
+                  />
+                </div>
+                <div className="rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
+                  <p className="mb-1 font-medium text-foreground">Password requirements</p>
+                  <ul className="list-disc space-y-1 pl-4">
+                    {passwordRequirements.map((requirement) => (
+                      <li key={requirement}>{requirement}</li>
+                    ))}
+                  </ul>
+                </div>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Change password
+                </Button>
+              </form>
+            )}
+
+            {step === "done" && (
+              <div className="space-y-4 text-center">
+                <CheckCircle2 className="mx-auto h-12 w-12 text-green-600" />
+                <p className="text-sm text-muted-foreground">{message}</p>
+                <Button asChild className="w-full">
+                  <Link href="/auth/login">Return to login</Link>
+                </Button>
+              </div>
+            )}
+
+            {step !== "done" && (
+              <div className="text-center text-sm">
+                <Link href="/auth/login" className="text-blue-600 hover:underline">
+                  Back to login
+                </Link>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertCircle,
   CheckCircle2,
+  Eye,
+  EyeOff,
   Loader2,
   LockIcon,
   ServerIcon,
@@ -20,8 +22,14 @@ import { Meteors } from "@/components/magicui/meteors";
 import { Particles } from "@/components/magicui/particles";
 import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { cn } from "@/lib/utils";
 
 type ResetStep = "request" | "verify" | "complete" | "done";
+const PASSWORD_RESET_CODE_LENGTH = 6;
+
+function emptyCodeDigits() {
+  return Array.from({ length: PASSWORD_RESET_CODE_LENGTH }, () => "");
+}
 
 const passwordRequirements = [
   "At least 12 characters",
@@ -34,15 +42,19 @@ const passwordRequirements = [
 export default function ResetPasswordPage() {
   const [step, setStep] = useState<ResetStep>("request");
   const [username, setUsername] = useState("");
-  const [code, setCode] = useState("");
+  const [codeDigits, setCodeDigits] = useState<string[]>(() => emptyCodeDigits());
   const [password, setPassword] = useState("");
   const [repeatPassword, setRepeatPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showRepeatPassword, setShowRepeatPassword] = useState(false);
   const [challengeId, setChallengeId] = useState("");
   const [verificationToken, setVerificationToken] = useState("");
   const [deliveryDescription, setDeliveryDescription] = useState("");
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const digitRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const code = codeDigits.join("");
 
   const callApi = async (path: string, body: Record<string, string>) => {
     const response = await fetch(path, {
@@ -104,6 +116,113 @@ export default function ResetPasswordPage() {
     }
   };
 
+  useEffect(() => {
+    if (step === "verify") {
+      window.requestAnimationFrame(() => {
+        digitRefs.current[0]?.focus();
+      });
+    }
+  }, [step]);
+
+  const focusDigit = (index: number) => {
+    const nextIndex = Math.max(
+      0,
+      Math.min(index, PASSWORD_RESET_CODE_LENGTH - 1)
+    );
+    digitRefs.current[nextIndex]?.focus();
+    digitRefs.current[nextIndex]?.select();
+  };
+
+  const applyDigits = (startIndex: number, value: string) => {
+    const sanitized = value
+      .replace(/\D/g, "")
+      .slice(0, PASSWORD_RESET_CODE_LENGTH - startIndex);
+
+    if (!sanitized) {
+      setCodeDigits((current) => {
+        const next = [...current];
+        next[startIndex] = "";
+        return next;
+      });
+      return;
+    }
+
+    setCodeDigits((current) => {
+      const next = [...current];
+      sanitized.split("").forEach((digit, offset) => {
+        next[startIndex + offset] = digit;
+      });
+      return next;
+    });
+
+    const focusIndex = Math.min(
+      startIndex + sanitized.length,
+      PASSWORD_RESET_CODE_LENGTH - 1
+    );
+    window.requestAnimationFrame(() => {
+      focusDigit(focusIndex);
+    });
+  };
+
+  const handleDigitChange = (index: number, value: string) => {
+    setError("");
+    setMessage("");
+    applyDigits(index, value);
+  };
+
+  const handleDigitKeyDown = (
+    index: number,
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusDigit(index - 1);
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusDigit(index + 1);
+      return;
+    }
+
+    if (event.key !== "Backspace") {
+      return;
+    }
+
+    event.preventDefault();
+    setError("");
+    setMessage("");
+
+    setCodeDigits((current) => {
+      const next = [...current];
+
+      if (next[index]) {
+        next[index] = "";
+        return next;
+      }
+
+      if (index > 0) {
+        next[index - 1] = "";
+        window.requestAnimationFrame(() => {
+          focusDigit(index - 1);
+        });
+      }
+
+      return next;
+    });
+  };
+
+  const handleDigitPaste = (
+    index: number,
+    event: React.ClipboardEvent<HTMLInputElement>
+  ) => {
+    event.preventDefault();
+    setError("");
+    setMessage("");
+    applyDigits(index, event.clipboardData.getData("text"));
+  };
+
   const resendCode = async () => {
     setError("");
     setMessage("");
@@ -114,7 +233,11 @@ export default function ResetPasswordPage() {
         challengeId,
       });
       setDeliveryDescription(data.deliveryDescription || deliveryDescription);
+      setCodeDigits(emptyCodeDigits());
       setMessage("A new verification code has been sent.");
+      window.requestAnimationFrame(() => {
+        focusDigit(0);
+      });
     } catch (resendError) {
       setError(
         resendError instanceof Error
@@ -341,21 +464,43 @@ export default function ResetPasswordPage() {
                   >
                     Verification code
                   </Label>
-                  <Input
-                    id="code"
-                    value={code}
-                    onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
-                    inputMode="numeric"
-                    autoComplete="one-time-code"
-                    placeholder="000000"
-                    className="py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground text-center text-xl tracking-[0.35em]"
-                    required
-                  />
+                  <div className="grid grid-cols-6 gap-2">
+                    {codeDigits.map((digit, index) => (
+                      <input
+                        key={`password-reset-digit-${index + 1}`}
+                        id={index === 0 ? "code" : undefined}
+                        ref={(element) => {
+                          digitRefs.current[index] = element;
+                        }}
+                        type="text"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        autoComplete={index === 0 ? "one-time-code" : "off"}
+                        maxLength={1}
+                        value={digit}
+                        aria-label={`Verification code digit ${index + 1}`}
+                        onChange={(event) =>
+                          handleDigitChange(index, event.target.value)
+                        }
+                        onKeyDown={(event) => handleDigitKeyDown(index, event)}
+                        onPaste={(event) => handleDigitPaste(index, event)}
+                        onFocus={(event) => event.currentTarget.select()}
+                        className={cn(
+                          "h-14 rounded-md border bg-background text-center text-xl font-semibold text-foreground outline-none transition-all duration-200",
+                          "border-border focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20",
+                          digit && "border-blue-500"
+                        )}
+                      />
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Type or paste your {PASSWORD_RESET_CODE_LENGTH}-digit verification code.
+                  </p>
                 </div>
                 <Button
                   type="submit"
                   className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
-                  disabled={isLoading || code.length !== 6}
+                  disabled={isLoading || code.length !== PASSWORD_RESET_CODE_LENGTH}
                 >
                   {isLoading ? (
                     <>
@@ -390,14 +535,27 @@ export default function ResetPasswordPage() {
                   <div className="relative">
                     <Input
                       id="new-password"
-                      type="password"
+                      type={showPassword ? "text" : "password"}
                       value={password}
                       onChange={(event) => setPassword(event.target.value)}
                       autoComplete="new-password"
-                      className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
+                      className="pl-10 pr-12 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       required
                     />
                     <LockIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-blue-500" />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((current) => !current)}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                      aria-pressed={showPassword}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
                   </div>
                 </div>
                 <div className="space-y-2">
@@ -407,15 +565,36 @@ export default function ResetPasswordPage() {
                   >
                     Repeat new password
                   </Label>
-                  <Input
-                    id="repeat-password"
-                    type="password"
-                    value={repeatPassword}
-                    onChange={(event) => setRepeatPassword(event.target.value)}
-                    autoComplete="new-password"
-                    className="py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
-                    required
-                  />
+                  <div className="relative">
+                    <Input
+                      id="repeat-password"
+                      type={showRepeatPassword ? "text" : "password"}
+                      value={repeatPassword}
+                      onChange={(event) => setRepeatPassword(event.target.value)}
+                      autoComplete="new-password"
+                      className="pr-12 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setShowRepeatPassword((current) => !current)
+                      }
+                      aria-label={
+                        showRepeatPassword
+                          ? "Hide repeated password"
+                          : "Show repeated password"
+                      }
+                      aria-pressed={showRepeatPassword}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      {showRepeatPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
                 </div>
                 <div className="rounded-md border border-border bg-card/50 p-3 text-xs text-muted-foreground">
                   <p className="mb-1 font-medium text-foreground">Password requirements</p>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -24,6 +24,7 @@ import { Particles } from "@/components/magicui/particles";
 import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
+import { PASSWORD_REQUIREMENTS } from "@/shared/password-policy";
 
 type ResetStep = "request" | "verify" | "complete" | "done";
 const PASSWORD_RESET_CODE_LENGTH = 6;
@@ -31,33 +32,6 @@ const PASSWORD_RESET_CODE_LENGTH = 6;
 function emptyCodeDigits() {
   return Array.from({ length: PASSWORD_RESET_CODE_LENGTH }, () => "");
 }
-
-const passwordRequirements = [
-  {
-    label: "At least 12 characters",
-    test: (value: string) => value.length >= 12,
-  },
-  {
-    label: "50 characters or fewer",
-    test: (value: string) => value.length > 0 && value.length <= 50,
-  },
-  {
-    label: "One uppercase letter",
-    test: (value: string) => /[A-Z]/.test(value),
-  },
-  {
-    label: "One lowercase letter",
-    test: (value: string) => /[a-z]/.test(value),
-  },
-  {
-    label: "One number",
-    test: (value: string) => /[0-9]/.test(value),
-  },
-  {
-    label: "One special character",
-    test: (value: string) => /[^\w\s]/.test(value),
-  },
-];
 
 export default function ResetPasswordPage() {
   const [step, setStep] = useState<ResetStep>("request");
@@ -75,11 +49,11 @@ export default function ResetPasswordPage() {
   const [isLoading, setIsLoading] = useState(false);
   const digitRefs = useRef<Array<HTMLInputElement | null>>([]);
   const code = codeDigits.join("");
-  const passwordRequirementScore = passwordRequirements.filter(({ test }) =>
+  const passwordRequirementScore = PASSWORD_REQUIREMENTS.filter(({ test }) =>
     test(password)
   ).length;
   const passwordMeetsRequirements =
-    passwordRequirementScore === passwordRequirements.length;
+    passwordRequirementScore === PASSWORD_REQUIREMENTS.length;
   const passwordsMatch =
     repeatPassword.length > 0 && password === repeatPassword;
 
@@ -630,7 +604,7 @@ export default function ResetPasswordPage() {
                   <div className="mb-2 flex items-center justify-between gap-3">
                     <p className="font-medium text-foreground">Password requirements</p>
                     <span className="text-[11px] font-medium text-muted-foreground">
-                      {passwordRequirementScore}/{passwordRequirements.length} met
+                      {passwordRequirementScore}/{PASSWORD_REQUIREMENTS.length} met
                     </span>
                   </div>
                   <div
@@ -641,19 +615,19 @@ export default function ResetPasswordPage() {
                       className="h-full rounded-full bg-green-500 transition-all duration-300"
                       style={{
                         width: `${
-                          (passwordRequirementScore / passwordRequirements.length) *
+                          (passwordRequirementScore / PASSWORD_REQUIREMENTS.length) *
                           100
                         }%`,
                       }}
                     />
                   </div>
                   <ul className="space-y-1.5">
-                    {passwordRequirements.map(({ label, test }) => {
+                    {PASSWORD_REQUIREMENTS.map(({ key, label, test }) => {
                       const isMet = test(password);
 
                       return (
                         <li
-                          key={label}
+                          key={key}
                           className={cn(
                             "flex items-center gap-2 transition-colors duration-200",
                             isMet ? "text-green-500" : "text-muted-foreground"

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   AlertCircle,
   CheckCircle2,
+  Circle,
   Eye,
   EyeOff,
   Loader2,
@@ -32,11 +33,30 @@ function emptyCodeDigits() {
 }
 
 const passwordRequirements = [
-  "At least 12 characters",
-  "One uppercase letter",
-  "One lowercase letter",
-  "One number",
-  "One special character",
+  {
+    label: "At least 12 characters",
+    test: (value: string) => value.length >= 12,
+  },
+  {
+    label: "50 characters or fewer",
+    test: (value: string) => value.length > 0 && value.length <= 50,
+  },
+  {
+    label: "One uppercase letter",
+    test: (value: string) => /[A-Z]/.test(value),
+  },
+  {
+    label: "One lowercase letter",
+    test: (value: string) => /[a-z]/.test(value),
+  },
+  {
+    label: "One number",
+    test: (value: string) => /[0-9]/.test(value),
+  },
+  {
+    label: "One special character",
+    test: (value: string) => /[^\w\s]/.test(value),
+  },
 ];
 
 export default function ResetPasswordPage() {
@@ -55,6 +75,9 @@ export default function ResetPasswordPage() {
   const [isLoading, setIsLoading] = useState(false);
   const digitRefs = useRef<Array<HTMLInputElement | null>>([]);
   const code = codeDigits.join("");
+  const passwordRequirementScore = passwordRequirements.filter(({ test }) =>
+    test(password)
+  ).length;
 
   const callApi = async (path: string, body: Record<string, string>) => {
     const response = await fetch(path, {
@@ -597,11 +620,47 @@ export default function ResetPasswordPage() {
                   </div>
                 </div>
                 <div className="rounded-md border border-border bg-card/50 p-3 text-xs text-muted-foreground">
-                  <p className="mb-1 font-medium text-foreground">Password requirements</p>
-                  <ul className="list-disc space-y-1 pl-4">
-                    {passwordRequirements.map((requirement) => (
-                      <li key={requirement}>{requirement}</li>
-                    ))}
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <p className="font-medium text-foreground">Password requirements</p>
+                    <span className="text-[11px] font-medium text-muted-foreground">
+                      {passwordRequirementScore}/{passwordRequirements.length} met
+                    </span>
+                  </div>
+                  <div
+                    className="mb-3 h-1.5 overflow-hidden rounded-full bg-muted"
+                    aria-hidden="true"
+                  >
+                    <div
+                      className="h-full rounded-full bg-green-500 transition-all duration-300"
+                      style={{
+                        width: `${
+                          (passwordRequirementScore / passwordRequirements.length) *
+                          100
+                        }%`,
+                      }}
+                    />
+                  </div>
+                  <ul className="space-y-1.5">
+                    {passwordRequirements.map(({ label, test }) => {
+                      const isMet = test(password);
+
+                      return (
+                        <li
+                          key={label}
+                          className={cn(
+                            "flex items-center gap-2 transition-colors duration-200",
+                            isMet ? "text-green-500" : "text-muted-foreground"
+                          )}
+                        >
+                          {isMet ? (
+                            <CheckCircle2 className="h-4 w-4 shrink-0" />
+                          ) : (
+                            <Circle className="h-4 w-4 shrink-0" />
+                          )}
+                          <span>{label}</span>
+                        </li>
+                      );
+                    })}
                   </ul>
                 </div>
                 <Button

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -78,6 +78,10 @@ export default function ResetPasswordPage() {
   const passwordRequirementScore = passwordRequirements.filter(({ test }) =>
     test(password)
   ).length;
+  const passwordMeetsRequirements =
+    passwordRequirementScore === passwordRequirements.length;
+  const passwordsMatch =
+    repeatPassword.length > 0 && password === repeatPassword;
 
   const callApi = async (path: string, body: Record<string, string>) => {
     const response = await fetch(path, {
@@ -618,6 +622,9 @@ export default function ResetPasswordPage() {
                       )}
                     </button>
                   </div>
+                  {repeatPassword && !passwordsMatch && (
+                    <p className="text-sm text-red-500">Passwords do not match.</p>
+                  )}
                 </div>
                 <div className="rounded-md border border-border bg-card/50 p-3 text-xs text-muted-foreground">
                   <div className="mb-2 flex items-center justify-between gap-3">
@@ -666,7 +673,9 @@ export default function ResetPasswordPage() {
                 <Button
                   type="submit"
                   className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
-                  disabled={isLoading}
+                  disabled={
+                    isLoading || !passwordMeetsRequirements || !passwordsMatch
+                  }
                 >
                   {isLoading ? (
                     <>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,11 +2,22 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { AlertCircle, CheckCircle2, Loader2, LockIcon } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  LockIcon,
+  ServerIcon,
+  ShieldIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { BorderBeam } from "@/components/magicui/border-beam";
+import { Globe } from "@/components/magicui/globe";
+import { Meteors } from "@/components/magicui/meteors";
+import { Particles } from "@/components/magicui/particles";
 import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 
@@ -142,38 +153,129 @@ export default function ResetPasswordPage() {
   };
 
   return (
-    <main className="min-h-screen bg-background px-6 py-8">
-      <div className="absolute right-4 top-4">
+    <div className="min-h-screen flex flex-col md:flex-row bg-background overflow-x-hidden relative">
+      <div className="absolute top-4 right-4 z-50">
         <ThemeToggle />
       </div>
 
-      <div className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-md items-center justify-center">
-        <Card className="w-full shadow-xl">
-          <CardHeader className="space-y-4 text-center">
-            <div className="flex justify-center">
-              <ThemeAwareLogo width={150} height={50} className="h-12 w-auto" />
-            </div>
-            <div>
-              <CardTitle className="text-2xl">Reset your password</CardTitle>
-              <CardDescription className="mt-2">
-                {step === "request" && "Enter your username to receive a verification code."}
-                {step === "verify" && `Enter the code sent to ${deliveryDescription}.`}
-                {step === "complete" && "Choose a new password for your account."}
-                {step === "done" && "Your password has been changed."}
-              </CardDescription>
-            </div>
-          </CardHeader>
+      <div className="absolute inset-0 overflow-hidden pointer-events-none z-0 opacity-90">
+        <Meteors number={10} />
+        <Particles />
+        <div className="absolute inset-0 translate-x-[200px]">
+          <Globe />
+        </div>
+      </div>
 
-          <CardContent className="space-y-5">
+      <div className="hidden md:block md:w-1/2 relative z-10">
+        <div className="absolute inset-0 z-20 flex flex-col justify-between p-12 mx-auto max-w-4xl">
+          <div>
+            <ThemeAwareLogo width={150} height={150} />
+          </div>
+
+          <div className="space-y-8 max-w-md">
+            <div className="space-y-2">
+              <p className="text-blue-500 text-lg font-medium">
+                Let&apos;s put Security everywhere
+              </p>
+              <p className="text-foreground text-lg">
+                Empowering Secure Lending, Everywhere.
+              </p>
+            </div>
+
+            <h2 className="text-6xl font-bold text-foreground leading-tight">
+              LOAN
+              <br />
+              MATRIX
+            </h2>
+
+            <div className="relative translate-x-[200px]">
+              <div className="absolute -right-40 -top-20 w-80 h-80">
+                <div className="absolute inset-0 border-2 border-blue-500/30 rounded-full animate-[spin_30s_linear_infinite]"></div>
+                <div className="absolute inset-4 border border-blue-500/20 rounded-full animate-[spin_20s_linear_infinite_reverse]"></div>
+                <div className="absolute inset-10 border border-blue-500/10 rounded-full animate-[spin_25s_linear_infinite]"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="w-32 h-32 bg-card/50 backdrop-blur-sm rounded-lg flex items-center justify-center border border-border">
+                    <LockIcon className="h-16 w-16 text-blue-500" />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-6 pt-8">
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <ShieldIcon className="h-8 w-8 text-blue-500 mb-2" />
+                <span className="text-foreground text-sm font-medium text-center">
+                  Enterprise Security
+                </span>
+              </div>
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <ServerIcon className="h-8 w-8 text-blue-500 mb-2" />
+                <span className="text-foreground text-sm font-medium text-center">
+                  Advanced Analytics
+                </span>
+              </div>
+              <div className="flex flex-col items-center bg-card/50 backdrop-blur-sm rounded-lg p-4 transition-all duration-300 hover:bg-card/70 border border-border">
+                <svg
+                  className="h-8 w-8 text-blue-500 mb-2"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span className="text-foreground text-sm font-medium text-center">
+                  Compliance Ready
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-4">
+            <Button
+              variant="outline"
+              className="border-blue-500 text-foreground hover:bg-blue-500/20 transition-all duration-300"
+            >
+              LOAN MANAGEMENT
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col justify-center items-center p-6 md:p-12 lg:p-16 w-full md:w-1/2 relative z-10">
+        <div className="w-full max-w-md space-y-8 mx-auto">
+          <div className="md:hidden flex justify-center mb-8">
+            <ThemeAwareLogo width={120} height={40} className="h-12 w-auto" />
+          </div>
+
+          <Card className="w-full shadow-xl border-border overflow-hidden transition-all duration-300 hover:border-blue-500/40 bg-card/70 backdrop-blur-sm">
+            <CardContent className="p-8 space-y-6">
+              <div className="text-center space-y-2 mb-8">
+                <h1 className="text-3xl font-bold tracking-tight text-foreground">
+                  Reset your password
+                </h1>
+                <p className="text-blue-500">
+                  {step === "request" && "Enter your username to continue"}
+                  {step === "verify" && `Enter the code sent to ${deliveryDescription}.`}
+                  {step === "complete" && "Choose a new password for your account."}
+                  {step === "done" && "Your password has been changed."}
+                </p>
+              </div>
+
             {error && (
-              <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-600">
-                <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
-                <span>{error}</span>
+              <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 flex items-start gap-2">
+                <AlertCircle className="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-red-500">{error}</p>
               </div>
             )}
 
             {message && step !== "done" && (
-              <div className="rounded-md border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-700">
+              <div className="bg-blue-500/10 border border-blue-500/30 rounded-md p-3 text-sm text-blue-500">
                 {message}
               </div>
             )}
@@ -181,19 +283,51 @@ export default function ResetPasswordPage() {
             {step === "request" && (
               <form onSubmit={submitRequest} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="username">Username</Label>
-                  <Input
-                    id="username"
-                    value={username}
-                    onChange={(event) => setUsername(event.target.value)}
-                    placeholder="Enter your username"
-                    autoComplete="username"
-                    required
-                  />
+                  <Label
+                    htmlFor="username"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Username
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="username"
+                      type="text"
+                      value={username}
+                      onChange={(event) => setUsername(event.target.value)}
+                      placeholder="Enter your username"
+                      autoComplete="username"
+                      className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
+                      required
+                    />
+                    <svg
+                      className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-blue-500"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                      <circle cx="12" cy="7" r="4"></circle>
+                    </svg>
+                  </div>
                 </div>
-                <Button type="submit" className="w-full" disabled={isLoading}>
-                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                  Send verification code
+                <Button
+                  type="submit"
+                  className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
+                  disabled={isLoading}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>SENDING CODE...</span>
+                    </>
+                  ) : (
+                    <span>SEND VERIFICATION CODE</span>
+                  )}
                 </Button>
               </form>
             )}
@@ -201,7 +335,12 @@ export default function ResetPasswordPage() {
             {step === "verify" && (
               <form onSubmit={verifyCode} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="code">Verification code</Label>
+                  <Label
+                    htmlFor="code"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Verification code
+                  </Label>
                   <Input
                     id="code"
                     value={code}
@@ -209,16 +348,32 @@ export default function ResetPasswordPage() {
                     inputMode="numeric"
                     autoComplete="one-time-code"
                     placeholder="000000"
-                    className="text-center text-xl tracking-[0.35em]"
+                    className="py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground text-center text-xl tracking-[0.35em]"
                     required
                   />
                 </div>
-                <Button type="submit" className="w-full" disabled={isLoading || code.length !== 6}>
-                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                  Verify code
+                <Button
+                  type="submit"
+                  className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
+                  disabled={isLoading || code.length !== 6}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>VERIFYING CODE...</span>
+                    </>
+                  ) : (
+                    <span>VERIFY CODE</span>
+                  )}
                 </Button>
-                <Button type="button" variant="outline" className="w-full" onClick={resendCode} disabled={isLoading}>
-                  Resend code
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full py-6 border-blue-500 text-foreground hover:bg-blue-500/20 transition-all duration-300"
+                  onClick={resendCode}
+                  disabled={isLoading}
+                >
+                  RESEND CODE
                 </Button>
               </form>
             )}
@@ -226,7 +381,12 @@ export default function ResetPasswordPage() {
             {step === "complete" && (
               <form onSubmit={completeReset} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="new-password">New password</Label>
+                  <Label
+                    htmlFor="new-password"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    New password
+                  </Label>
                   <div className="relative">
                     <Input
                       id="new-password"
@@ -234,24 +394,30 @@ export default function ResetPasswordPage() {
                       value={password}
                       onChange={(event) => setPassword(event.target.value)}
                       autoComplete="new-password"
-                      className="pl-10"
+                      className="pl-10 py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                       required
                     />
-                    <LockIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <LockIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-blue-500" />
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="repeat-password">Repeat new password</Label>
+                  <Label
+                    htmlFor="repeat-password"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Repeat new password
+                  </Label>
                   <Input
                     id="repeat-password"
                     type="password"
                     value={repeatPassword}
                     onChange={(event) => setRepeatPassword(event.target.value)}
                     autoComplete="new-password"
+                    className="py-6 bg-background border-border focus:border-blue-500 focus:ring-blue-500 transition-all duration-200 text-foreground"
                     required
                   />
                 </div>
-                <div className="rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
+                <div className="rounded-md border border-border bg-card/50 p-3 text-xs text-muted-foreground">
                   <p className="mb-1 font-medium text-foreground">Password requirements</p>
                   <ul className="list-disc space-y-1 pl-4">
                     {passwordRequirements.map((requirement) => (
@@ -259,33 +425,101 @@ export default function ResetPasswordPage() {
                     ))}
                   </ul>
                 </div>
-                <Button type="submit" className="w-full" disabled={isLoading}>
-                  {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                  Change password
+                <Button
+                  type="submit"
+                  className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20 flex items-center justify-center gap-2"
+                  disabled={isLoading}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>CHANGING PASSWORD...</span>
+                    </>
+                  ) : (
+                    <span>CHANGE PASSWORD</span>
+                  )}
                 </Button>
               </form>
             )}
 
             {step === "done" && (
               <div className="space-y-4 text-center">
-                <CheckCircle2 className="mx-auto h-12 w-12 text-green-600" />
+                <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
                 <p className="text-sm text-muted-foreground">{message}</p>
-                <Button asChild className="w-full">
-                  <Link href="/auth/login">Return to login</Link>
+                <Button
+                  asChild
+                  className="w-full py-6 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-blue-500/20"
+                >
+                  <Link href="/auth/login">RETURN TO LOGIN</Link>
                 </Button>
               </div>
             )}
 
             {step !== "done" && (
-              <div className="text-center text-sm">
-                <Link href="/auth/login" className="text-blue-600 hover:underline">
+              <div className="text-center text-sm pt-2">
+                <Link
+                  href="/auth/login"
+                  className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
+                >
                   Back to login
                 </Link>
               </div>
             )}
-          </CardContent>
-        </Card>
+
+            </CardContent>
+            <BorderBeam
+              duration={8}
+              size={100}
+              className="from-transparent via-blue-500 to-transparent"
+            />
+          </Card>
+
+          <div className="flex items-center justify-center space-x-2 pt-4">
+            <div className="p-2 rounded-full bg-card border border-border">
+              <svg
+                className="h-4 w-4 text-blue-500"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+              </svg>
+            </div>
+            <span className="text-sm text-blue-500">
+              Secure, encrypted connection
+            </span>
+          </div>
+
+          <div className="text-center text-sm text-muted-foreground pt-4">
+            © 2025 Enterprise Loan Management System. All rights reserved.
+            <div className="flex justify-center space-x-4 mt-2">
+              <Link
+                href="/terms"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Terms
+              </Link>
+              <Link
+                href="/privacy"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Privacy
+              </Link>
+              <Link
+                href="/support"
+                className="text-blue-500 hover:text-blue-600 text-xs"
+              >
+                Support
+              </Link>
+            </div>
+          </div>
+        </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/lib/__tests__/password-reset-config.test.ts
+++ b/lib/__tests__/password-reset-config.test.ts
@@ -51,9 +51,11 @@ test("password reset password policy rejects weak passwords", async () => {
 
   assert.equal(validatePassword("short").valid, false);
   assert.equal(
-    validatePassword("Strong-password-123!").valid,
+    validatePassword("Very-Strong-123!").valid,
     true
   );
+  assert.equal(validatePassword("Strong password-123!").valid, false);
+  assert.equal(validatePassword("Strong-password-123!!").valid, false);
 });
 
 test("login remember-me control remains commented out", async () => {

--- a/lib/__tests__/password-reset-config.test.ts
+++ b/lib/__tests__/password-reset-config.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("password reset configuration defaults to disabled", async () => {
+  const { getTenantSelfPasswordResetConfig } = await import(
+    "../../shared/types/tenant"
+  );
+
+  assert.deepEqual(getTenantSelfPasswordResetConfig(null), {
+    enabled: false,
+    notificationChannels: [],
+  });
+  assert.deepEqual(getTenantSelfPasswordResetConfig({}), {
+    enabled: false,
+    notificationChannels: [],
+  });
+});
+
+test("password reset configuration accepts the canonical configuration keys", async () => {
+  const { getTenantSelfPasswordResetConfig } = await import(
+    "../../shared/types/tenant"
+  );
+
+  assert.deepEqual(
+    getTenantSelfPasswordResetConfig({
+      selfPasswordReset: {
+        enabled: true,
+        notificationChannels: ["sms", "email", "invalid", "sms"],
+      },
+    }),
+    {
+      enabled: true,
+      notificationChannels: ["sms", "email"],
+    }
+  );
+
+  assert.deepEqual(getTenantSelfPasswordResetConfig({
+    wrongPasswordReset: {
+      enabled: true,
+      notificationChannels: ["email"],
+    },
+  }), {
+    enabled: false,
+    notificationChannels: [],
+  });
+});
+
+test("password reset password policy rejects weak passwords", async () => {
+  process.env.DATABASE_URL ||= "postgresql://user:pass@localhost:5432/loan_matrix";
+  const { validatePassword } = await import("../password-reset");
+
+  assert.equal(validatePassword("short").valid, false);
+  assert.equal(
+    validatePassword("Strong-password-123!").valid,
+    true
+  );
+});
+
+test("login remember-me control remains commented out", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
+  const source = readFileSync(
+    resolve(process.cwd(), "app/auth/login/page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /Remember me is temporarily disabled/);
+  assert.match(source, /id="remember"/);
+});

--- a/lib/fineract-api.ts
+++ b/lib/fineract-api.ts
@@ -1437,6 +1437,26 @@ export class FineractAPIService {
     }
   }
 
+  async getUser(userId: number): Promise<any> {
+    const response: AxiosResponse<any> = await this.client.get(`/users/${userId}`);
+    return response.data;
+  }
+
+  async updateUserPassword(
+    userId: number,
+    password: string,
+    repeatPassword: string
+  ): Promise<any> {
+    const response: AxiosResponse<any> = await this.client.put(
+      `/users/${userId}`,
+      {
+        password,
+        repeatPassword,
+      }
+    );
+    return response.data;
+  }
+
   // Loan Officer Assignment
   async assignLoanOfficer(
     loanId: number,

--- a/lib/password-reset.ts
+++ b/lib/password-reset.ts
@@ -1,0 +1,851 @@
+import { createHash, randomBytes, randomInt, timingSafeEqual } from "crypto";
+import { prisma } from "@/lib/prisma";
+import {
+  getFineractServiceWithSystemAuth,
+} from "@/lib/fineract-api";
+import {
+  getTenantSelfPasswordResetConfig,
+  type SelfPasswordResetChannel,
+} from "@/shared/types/tenant";
+import {
+  normalizeSmsPhoneNumber,
+  sendEmail,
+  sendSms,
+} from "@/lib/notification-service";
+import { upsertUserLogin } from "@/lib/user-login-service";
+
+export const PASSWORD_RESET_DISABLED_MESSAGE =
+  "Self password reset is not configured. Please contact your system administrator.";
+export const PASSWORD_RESET_GENERIC_MESSAGE =
+  "If the username is registered and has a configured contact, a verification code has been sent.";
+
+const PASSWORD_RESET_EXPIRY_MINUTES = 10;
+const PASSWORD_RESET_MAX_ATTEMPTS = 5;
+const PASSWORD_RESET_MAX_RESENDS = 5;
+const PASSWORD_RESET_RESEND_COOLDOWN_SECONDS = 60;
+const PASSWORD_RESET_CODE_LENGTH = 6;
+
+type PasswordResetContext = {
+  requestIp?: string | null;
+  userAgent?: string | null;
+};
+
+type PasswordResetUser = {
+  fineractUserId: number;
+  username: string;
+  email: string | null;
+  phone: string | null;
+  countryCode: string | null;
+};
+
+type DeliveryTarget = {
+  channel: SelfPasswordResetChannel;
+  destination: string;
+};
+
+export class PasswordResetError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "PasswordResetError";
+    this.status = status;
+  }
+}
+
+function getPasswordResetSecret() {
+  return process.env.NEXTAUTH_SECRET || "loan-matrix-password-reset-secret";
+}
+
+function hashPasswordResetValue(challengeId: string, value: string) {
+  return createHash("sha256")
+    .update(`${challengeId}:${value}:${getPasswordResetSecret()}`)
+    .digest("hex");
+}
+
+function matchesHash(expected: string, actual: string) {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const actualBuffer = Buffer.from(actual, "utf8");
+
+  return (
+    expectedBuffer.length === actualBuffer.length &&
+    timingSafeEqual(expectedBuffer, actualBuffer)
+  );
+}
+
+function generatePasswordResetCode() {
+  return randomInt(0, 10 ** PASSWORD_RESET_CODE_LENGTH)
+    .toString()
+    .padStart(PASSWORD_RESET_CODE_LENGTH, "0");
+}
+
+function generateVerificationToken() {
+  return randomBytes(24).toString("hex");
+}
+
+function getExpiryDate() {
+  return new Date(
+    Date.now() + PASSWORD_RESET_EXPIRY_MINUTES * 60 * 1000
+  );
+}
+
+function getResendAvailableAt(lastSentAt: Date) {
+  return new Date(
+    lastSentAt.getTime() + PASSWORD_RESET_RESEND_COOLDOWN_SECONDS * 1000
+  );
+}
+
+function normalizeEmail(value: unknown) {
+  if (typeof value !== "string") return null;
+  const email = value.trim();
+  return email || null;
+}
+
+function normalizePhone(value: unknown) {
+  if (typeof value !== "string") return null;
+  const phone = value.trim();
+  return phone || null;
+}
+
+function maskEmail(email: string) {
+  const [localPart, domain] = email.trim().split("@");
+  if (!localPart || !domain) return "***";
+  return `${localPart.slice(0, 1)}${"*".repeat(
+    Math.max(localPart.length - 1, 2)
+  )}@${domain}`;
+}
+
+function maskPhone(phone: string) {
+  const trimmed = phone.trim();
+  if (trimmed.length <= 4) return "*".repeat(trimmed.length || 3);
+  return `${trimmed.slice(0, 3)}${"*".repeat(
+    Math.max(trimmed.length - 5, 3)
+  )}${trimmed.slice(-2)}`;
+}
+
+function maskDestination(channel: SelfPasswordResetChannel, destination: string) {
+  return channel === "email"
+    ? `Email to ${maskEmail(destination)}`
+    : `SMS to ${maskPhone(destination)}`;
+}
+
+function getRequestDescription(targets: DeliveryTarget[]) {
+  return targets
+    .map((target) => maskDestination(target.channel, target.destination))
+    .join(", ");
+}
+
+function getPasswordResetTargets(
+  config: ReturnType<typeof getTenantSelfPasswordResetConfig>,
+  user: PasswordResetUser
+) {
+  const destinations: Partial<Record<SelfPasswordResetChannel, string>> = {
+    email: normalizeEmail(user.email) ?? undefined,
+    sms: normalizeSmsPhoneNumber(user.phone ?? "", user.countryCode) ?? undefined,
+  };
+
+  return config.notificationChannels.reduce<DeliveryTarget[]>(
+    (targets, channel) => {
+      const destination = destinations[channel];
+      if (destination) {
+        targets.push({ channel, destination });
+      }
+      return targets;
+    },
+    []
+  );
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function buildPasswordResetEmail(input: {
+  tenantName?: string | null;
+  username: string;
+  code: string;
+}) {
+  const productName = input.tenantName?.trim()
+    ? `${input.tenantName.trim()} Loan Matrix`
+    : "Loan Matrix";
+  const subject = `${productName} password reset code`;
+  const safeProductName = escapeHtml(productName);
+  const safeUsername = escapeHtml(input.username);
+  const safeCode = escapeHtml(input.code);
+  const text = [
+    productName,
+    "",
+    `Hello ${input.username},`,
+    "",
+    `Your password reset verification code is ${input.code}.`,
+    `This code expires in ${PASSWORD_RESET_EXPIRY_MINUTES} minutes.`,
+    "",
+    "If you did not request this, contact your system administrator.",
+  ].join("\n");
+  const html = `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:28px 12px;background:#f3f6fb;font-family:Arial,Helvetica,sans-serif;color:#111827;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #dbeafe;border-radius:16px;overflow:hidden;">
+          <tr><td style="background:#2563eb;padding:26px 30px;color:#ffffff;">
+            <div style="font-size:13px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;color:#bfdbfe;">Password reset</div>
+            <h1 style="margin:8px 0 0;font-size:24px;line-height:31px;">${safeProductName}</h1>
+          </td></tr>
+          <tr><td style="padding:32px 30px 12px;">
+            <p style="margin:0 0 10px;font-size:16px;line-height:24px;">Hello ${safeUsername},</p>
+            <p style="margin:0;font-size:15px;line-height:23px;color:#4b5563;">Use this code to reset your Loan Matrix password.</p>
+          </td></tr>
+          <tr><td style="padding:22px 30px 8px;">
+            <div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:14px;padding:24px;text-align:center;">
+              <div style="font-size:12px;text-transform:uppercase;letter-spacing:.12em;font-weight:700;color:#2563eb;margin-bottom:10px;">Verification code</div>
+              <div style="font-size:32px;line-height:38px;letter-spacing:.28em;font-weight:800;font-family:monospace;">${safeCode}</div>
+            </div>
+          </td></tr>
+          <tr><td style="padding:16px 30px 30px;color:#475569;font-size:14px;line-height:22px;">
+            This code expires in ${PASSWORD_RESET_EXPIRY_MINUTES} minutes. Do not share it with anyone.
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, html, text };
+}
+
+async function writePasswordResetLog(input: {
+  tenantId: string;
+  challengeId?: string | null;
+  fineractUserId?: number | null;
+  username: string;
+  event: string;
+  configuredChannels?: string[];
+  deliveredChannels?: string[];
+  maskedDestinations?: string[];
+  failureReason?: string | null;
+  context?: PasswordResetContext;
+}) {
+  await prisma.passwordResetLog.create({
+    data: {
+      tenantId: input.tenantId,
+      challengeId: input.challengeId ?? null,
+      fineractUserId: input.fineractUserId ?? null,
+      username: input.username,
+      event: input.event,
+      configuredChannels: input.configuredChannels ?? [],
+      deliveredChannels: input.deliveredChannels ?? [],
+      maskedDestinations: input.maskedDestinations ?? [],
+      failureReason: input.failureReason ?? null,
+      requestIp: input.context?.requestIp ?? null,
+      userAgent: input.context?.userAgent ?? null,
+    },
+  });
+}
+
+async function findPasswordResetUser(
+  tenantId: string,
+  username: string
+): Promise<PasswordResetUser | null> {
+  const normalizedUsername = username.trim();
+  const localUser = await prisma.userLogin.findFirst({
+    where: {
+      tenantId,
+      username: {
+        equals: normalizedUsername,
+        mode: "insensitive",
+      },
+    },
+  });
+
+  let fineractUser: Record<string, unknown> | null = null;
+  const fineractService = await getFineractServiceWithSystemAuth();
+
+  if (localUser) {
+    try {
+      fineractUser = (await fineractService.getUser(
+        localUser.fineractUserId
+      )) as Record<string, unknown>;
+    } catch (error) {
+      console.warn("Unable to enrich password reset user from Fineract:", error);
+    }
+  } else {
+    const users = await fineractService.getUsers();
+    fineractUser =
+      users.find(
+        (user) =>
+          typeof user?.username === "string" &&
+          user.username.trim().toLowerCase() === normalizedUsername.toLowerCase()
+      ) ?? null;
+  }
+
+  if (!localUser && !fineractUser) {
+    return null;
+  }
+
+  const fineractUserId = localUser?.fineractUserId ?? Number(fineractUser?.id);
+  if (!Number.isInteger(fineractUserId) || fineractUserId <= 0) {
+    return null;
+  }
+
+  const resolvedUsername =
+    (typeof fineractUser?.username === "string" && fineractUser.username.trim()) ||
+    localUser?.username ||
+    normalizedUsername;
+  const email =
+    normalizeEmail(localUser?.email) ?? normalizeEmail(fineractUser?.email);
+  const phone =
+    normalizePhone(localUser?.phone) ??
+    normalizePhone(fineractUser?.phone) ??
+    normalizePhone(fineractUser?.mobileNo);
+  const countryCode = localUser?.countryCode ?? null;
+
+  await upsertUserLogin({
+    tenantId,
+    fineractUserId,
+    username: resolvedUsername,
+    email,
+    phone,
+    countryCode,
+  });
+
+  return {
+    fineractUserId,
+    username: resolvedUsername,
+    email,
+    phone,
+    countryCode,
+  };
+}
+
+async function sendPasswordResetCode(input: {
+  tenantId: string;
+  tenantName: string;
+  username: string;
+  code: string;
+  targets: DeliveryTarget[];
+}) {
+  const results = await Promise.all(
+    input.targets.map(async (target) => {
+      try {
+        const delivered =
+          target.channel === "sms"
+            ? await sendSms(
+                [target.destination],
+                `Your ${input.tenantName} Loan Matrix password reset code is ${input.code}. It expires in ${PASSWORD_RESET_EXPIRY_MINUTES} minutes.`,
+                { tenantId: input.tenantId, logLabel: "password-reset-sms" }
+              )
+            : await (async () => {
+                const email = buildPasswordResetEmail({
+                  tenantName: input.tenantName,
+                  username: input.username,
+                  code: input.code,
+                });
+                return sendEmail(
+                  [target.destination],
+                  email.subject,
+                  email.html,
+                  {
+                    tenantId: input.tenantId,
+                    text: email.text,
+                    logLabel: "password-reset-email",
+                  }
+                );
+              })();
+
+        return { ...target, delivered };
+      } catch (error) {
+        console.error(`Failed to send password reset ${target.channel}:`, error);
+        return { ...target, delivered: false };
+      }
+    })
+  );
+
+  return {
+    deliveredTargets: results.filter((result) => result.delivered),
+    deliveredChannels: results
+      .filter((result) => result.delivered)
+      .map((result) => result.channel),
+  };
+}
+
+async function getActiveChallenge(tenantId: string, challengeId: string) {
+  const challenge = await prisma.passwordResetChallenge.findFirst({
+    where: { id: challengeId, tenantId },
+  });
+
+  if (!challenge) {
+    throw new PasswordResetError("Password reset challenge not found.", 404);
+  }
+
+  if (challenge.invalidatedAt || challenge.consumedAt) {
+    throw new PasswordResetError(
+      "This password reset request is no longer active.",
+      410
+    );
+  }
+
+  if (challenge.expiresAt.getTime() <= Date.now()) {
+    throw new PasswordResetError(
+      "This password reset request has expired. Please start again.",
+      410
+    );
+  }
+
+  return challenge;
+}
+
+export function validatePassword(password: string) {
+  const errors: string[] = [];
+
+  if (password.length < 12) errors.push("Password must be at least 12 characters long");
+  if (password.length > 50) errors.push("Password must not exceed 50 characters");
+  if (!/[A-Z]/.test(password)) errors.push("Password must contain an uppercase letter");
+  if (!/[a-z]/.test(password)) errors.push("Password must contain a lowercase letter");
+  if (!/[0-9]/.test(password)) errors.push("Password must contain a number");
+  if (!/[^\w\s]/.test(password)) errors.push("Password must contain a special character");
+
+  return { valid: errors.length === 0, errors };
+}
+
+export async function requestPasswordReset(input: {
+  tenantId: string;
+  tenantName: string;
+  tenantSettings: unknown;
+  username: string;
+  context?: PasswordResetContext;
+}) {
+  const username = input.username.trim();
+  const config = getTenantSelfPasswordResetConfig(input.tenantSettings);
+
+  if (!config.enabled) {
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      username,
+      event: "DISABLED",
+      configuredChannels: config.notificationChannels,
+      context: input.context,
+    });
+    throw new PasswordResetError(PASSWORD_RESET_DISABLED_MESSAGE, 403);
+  }
+
+  const user = await findPasswordResetUser(input.tenantId, username);
+  if (!user) {
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      username,
+      event: "UNKNOWN_USER",
+      configuredChannels: config.notificationChannels,
+      context: input.context,
+    });
+    return { message: PASSWORD_RESET_GENERIC_MESSAGE };
+  }
+
+  const targets = getPasswordResetTargets(config, user);
+  const maskedDestinations = targets.map((target) =>
+    maskDestination(target.channel, target.destination)
+  );
+
+  if (targets.length === 0) {
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      fineractUserId: user.fineractUserId,
+      username: user.username,
+      event: "NO_DESTINATION",
+      configuredChannels: config.notificationChannels,
+      maskedDestinations,
+      context: input.context,
+    });
+    return { message: PASSWORD_RESET_GENERIC_MESSAGE };
+  }
+
+  await prisma.passwordResetChallenge.updateMany({
+    where: {
+      tenantId: input.tenantId,
+      fineractUserId: user.fineractUserId,
+      consumedAt: null,
+      invalidatedAt: null,
+    },
+    data: { invalidatedAt: new Date() },
+  });
+
+  const code = generatePasswordResetCode();
+  const challenge = await prisma.passwordResetChallenge.create({
+    data: {
+      tenantId: input.tenantId,
+      fineractUserId: user.fineractUserId,
+      username: user.username,
+      codeHash: "pending",
+      configuredChannels: config.notificationChannels,
+      maskedDestinations,
+      maxAttempts: PASSWORD_RESET_MAX_ATTEMPTS,
+      expiresAt: getExpiryDate(),
+    },
+  });
+
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: { codeHash: hashPasswordResetValue(challenge.id, code) },
+  });
+
+  await writePasswordResetLog({
+    tenantId: input.tenantId,
+    challengeId: challenge.id,
+    fineractUserId: user.fineractUserId,
+    username: user.username,
+    event: "REQUESTED",
+    configuredChannels: config.notificationChannels,
+    maskedDestinations,
+    context: input.context,
+  });
+
+  const delivery = await sendPasswordResetCode({
+    tenantId: input.tenantId,
+    tenantName: input.tenantName,
+    username: user.username,
+    code,
+    targets,
+  });
+
+  if (delivery.deliveredTargets.length === 0) {
+    await prisma.passwordResetChallenge.update({
+      where: { id: challenge.id },
+      data: { invalidatedAt: new Date() },
+    });
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      challengeId: challenge.id,
+      fineractUserId: user.fineractUserId,
+      username: user.username,
+      event: "DELIVERY_FAILED",
+      configuredChannels: config.notificationChannels,
+      maskedDestinations,
+      failureReason: "No configured notification channel accepted the reset code.",
+      context: input.context,
+    });
+    throw new PasswordResetError(
+      "We could not send a password reset code. Please contact your system administrator.",
+      502
+    );
+  }
+
+  const deliveredTargets = delivery.deliveredTargets;
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      deliveredChannels: delivery.deliveredChannels,
+      maskedDestinations: deliveredTargets.map((target) =>
+        maskDestination(target.channel, target.destination)
+      ),
+    },
+  });
+  await writePasswordResetLog({
+    tenantId: input.tenantId,
+    challengeId: challenge.id,
+    fineractUserId: user.fineractUserId,
+    username: user.username,
+    event: "CODE_SENT",
+    configuredChannels: config.notificationChannels,
+    deliveredChannels: delivery.deliveredChannels,
+    maskedDestinations: deliveredTargets.map((target) =>
+      maskDestination(target.channel, target.destination)
+    ),
+    context: input.context,
+  });
+
+  return {
+    challengeId: challenge.id,
+    message: PASSWORD_RESET_GENERIC_MESSAGE,
+    deliveryDescription: getRequestDescription(deliveredTargets),
+    expiresAt: challenge.expiresAt,
+  };
+}
+
+export async function resendPasswordResetCode(input: {
+  tenantId: string;
+  tenantName: string;
+  tenantSettings: unknown;
+  challengeId: string;
+  context?: PasswordResetContext;
+}) {
+  const config = getTenantSelfPasswordResetConfig(input.tenantSettings);
+  if (!config.enabled) {
+    throw new PasswordResetError(PASSWORD_RESET_DISABLED_MESSAGE, 403);
+  }
+
+  const challenge = await getActiveChallenge(input.tenantId, input.challengeId);
+  if (challenge.resendCount >= PASSWORD_RESET_MAX_RESENDS) {
+    throw new PasswordResetError(
+      "Too many resend attempts. Please start the password reset again.",
+      429
+    );
+  }
+
+  const resendAvailableAt = getResendAvailableAt(challenge.lastSentAt);
+  if (resendAvailableAt.getTime() > Date.now()) {
+    throw new PasswordResetError(
+      `Please wait ${Math.ceil(
+        (resendAvailableAt.getTime() - Date.now()) / 1000
+      )} seconds before requesting another code.`,
+      429
+    );
+  }
+
+  const user = await findPasswordResetUser(input.tenantId, challenge.username);
+  if (!user) {
+    throw new PasswordResetError("Password reset user could not be resolved.", 404);
+  }
+
+  const targets = getPasswordResetTargets(config, user);
+  if (targets.length === 0) {
+    throw new PasswordResetError(
+      "No configured contact is available for this password reset.",
+      400
+    );
+  }
+
+  const code = generatePasswordResetCode();
+  const expiresAt = getExpiryDate();
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      codeHash: hashPasswordResetValue(challenge.id, code),
+      verificationTokenHash: null,
+      verifiedAt: null,
+      attempts: 0,
+      resendCount: { increment: 1 },
+      lastSentAt: new Date(),
+      expiresAt,
+      configuredChannels: config.notificationChannels,
+      deliveredChannels: [],
+      maskedDestinations: targets.map((target) =>
+        maskDestination(target.channel, target.destination)
+      ),
+    },
+  });
+
+  const delivery = await sendPasswordResetCode({
+    tenantId: input.tenantId,
+    tenantName: input.tenantName,
+    username: challenge.username,
+    code,
+    targets,
+  });
+
+  if (delivery.deliveredTargets.length === 0) {
+    await prisma.passwordResetChallenge.update({
+      where: { id: challenge.id },
+      data: { invalidatedAt: new Date() },
+    });
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      challengeId: challenge.id,
+      fineractUserId: challenge.fineractUserId,
+      username: challenge.username,
+      event: "RESEND_FAILED",
+      configuredChannels: config.notificationChannels,
+      failureReason: "No configured notification channel accepted the reset code.",
+      context: input.context,
+    });
+    throw new PasswordResetError(
+      "We could not resend the password reset code. Please start again.",
+      502
+    );
+  }
+
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      deliveredChannels: delivery.deliveredChannels,
+      maskedDestinations: delivery.deliveredTargets.map((target) =>
+        maskDestination(target.channel, target.destination)
+      ),
+    },
+  });
+  await writePasswordResetLog({
+    tenantId: input.tenantId,
+    challengeId: challenge.id,
+    fineractUserId: challenge.fineractUserId,
+    username: challenge.username,
+    event: "CODE_RESENT",
+    configuredChannels: config.notificationChannels,
+    deliveredChannels: delivery.deliveredChannels,
+    maskedDestinations: delivery.deliveredTargets.map((target) =>
+      maskDestination(target.channel, target.destination)
+    ),
+    context: input.context,
+  });
+
+  return {
+    message: PASSWORD_RESET_GENERIC_MESSAGE,
+    deliveryDescription: getRequestDescription(delivery.deliveredTargets),
+    expiresAt,
+    resendAvailableAt: getResendAvailableAt(new Date()),
+  };
+}
+
+export async function verifyPasswordResetCode(input: {
+  tenantId: string;
+  challengeId: string;
+  code: string;
+  context?: PasswordResetContext;
+}) {
+  const challenge = await getActiveChallenge(input.tenantId, input.challengeId);
+
+  if (challenge.attempts >= challenge.maxAttempts) {
+    throw new PasswordResetError(
+      "Too many incorrect verification attempts. Please start again.",
+      429
+    );
+  }
+
+  const normalizedCode = input.code.trim();
+  const expectedHash = hashPasswordResetValue(challenge.id, normalizedCode);
+  if (!matchesHash(challenge.codeHash, expectedHash)) {
+    const attempts = challenge.attempts + 1;
+    const invalidated = attempts >= challenge.maxAttempts;
+    await prisma.passwordResetChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        attempts,
+        ...(invalidated ? { invalidatedAt: new Date() } : {}),
+      },
+    });
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      challengeId: challenge.id,
+      fineractUserId: challenge.fineractUserId,
+      username: challenge.username,
+      event: invalidated ? "MAX_ATTEMPTS" : "INVALID_CODE",
+      configuredChannels: challenge.configuredChannels,
+      deliveredChannels: challenge.deliveredChannels,
+      maskedDestinations: challenge.maskedDestinations,
+      context: input.context,
+    });
+    throw new PasswordResetError(
+      invalidated
+        ? "Too many incorrect verification attempts. Please start again."
+        : "The verification code you entered is incorrect.",
+      invalidated ? 429 : 400
+    );
+  }
+
+  const verificationToken = generateVerificationToken();
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      verificationTokenHash: hashPasswordResetValue(
+        challenge.id,
+        verificationToken
+      ),
+      verifiedAt: new Date(),
+    },
+  });
+  await writePasswordResetLog({
+    tenantId: input.tenantId,
+    challengeId: challenge.id,
+    fineractUserId: challenge.fineractUserId,
+    username: challenge.username,
+    event: "CODE_VERIFIED",
+    configuredChannels: challenge.configuredChannels,
+    deliveredChannels: challenge.deliveredChannels,
+    maskedDestinations: challenge.maskedDestinations,
+    context: input.context,
+  });
+
+  return { verificationToken };
+}
+
+export async function completePasswordReset(input: {
+  tenantId: string;
+  challengeId: string;
+  verificationToken: string;
+  password: string;
+  context?: PasswordResetContext;
+}) {
+  const challenge = await getActiveChallenge(input.tenantId, input.challengeId);
+
+  if (!challenge.verifiedAt || !challenge.verificationTokenHash) {
+    throw new PasswordResetError(
+      "Verify the password reset code before setting a new password.",
+      400
+    );
+  }
+
+  const expectedHash = hashPasswordResetValue(
+    challenge.id,
+    input.verificationToken
+  );
+  if (!matchesHash(challenge.verificationTokenHash, expectedHash)) {
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      challengeId: challenge.id,
+      fineractUserId: challenge.fineractUserId,
+      username: challenge.username,
+      event: "INVALID_VERIFICATION_TOKEN",
+      configuredChannels: challenge.configuredChannels,
+      deliveredChannels: challenge.deliveredChannels,
+      maskedDestinations: challenge.maskedDestinations,
+      context: input.context,
+    });
+    throw new PasswordResetError("This password reset verification is invalid.", 400);
+  }
+
+  const passwordValidation = validatePassword(input.password);
+  if (!passwordValidation.valid) {
+    throw new PasswordResetError(passwordValidation.errors.join(". "), 400);
+  }
+
+  try {
+    const fineractService = await getFineractServiceWithSystemAuth();
+    await fineractService.updateUserPassword(
+      challenge.fineractUserId,
+      input.password,
+      input.password
+    );
+  } catch (error) {
+    console.error("Fineract password reset failed:", error);
+    await writePasswordResetLog({
+      tenantId: input.tenantId,
+      challengeId: challenge.id,
+      fineractUserId: challenge.fineractUserId,
+      username: challenge.username,
+      event: "PASSWORD_UPDATE_FAILED",
+      configuredChannels: challenge.configuredChannels,
+      deliveredChannels: challenge.deliveredChannels,
+      maskedDestinations: challenge.maskedDestinations,
+      failureReason: "Fineract rejected or could not process the password update.",
+      context: input.context,
+    });
+    throw new PasswordResetError(
+      "We could not update your password. Please try again or contact your system administrator.",
+      502
+    );
+  }
+
+  await prisma.passwordResetChallenge.update({
+    where: { id: challenge.id },
+    data: {
+      consumedAt: new Date(),
+      verificationTokenHash: null,
+    },
+  });
+  await writePasswordResetLog({
+    tenantId: input.tenantId,
+    challengeId: challenge.id,
+    fineractUserId: challenge.fineractUserId,
+    username: challenge.username,
+    event: "PASSWORD_RESET_COMPLETED",
+    configuredChannels: challenge.configuredChannels,
+    deliveredChannels: challenge.deliveredChannels,
+    maskedDestinations: challenge.maskedDestinations,
+    context: input.context,
+  });
+
+  return { message: "Password reset successfully. Please sign in with your new password." };
+}

--- a/lib/password-reset.ts
+++ b/lib/password-reset.ts
@@ -7,6 +7,7 @@ import {
   getTenantSelfPasswordResetConfig,
   type SelfPasswordResetChannel,
 } from "@/shared/types/tenant";
+import { validatePassword as validateSharedPassword } from "@/shared/password-policy";
 import {
   normalizeSmsPhoneNumber,
   sendEmail,
@@ -401,16 +402,7 @@ async function getActiveChallenge(tenantId: string, challengeId: string) {
 }
 
 export function validatePassword(password: string) {
-  const errors: string[] = [];
-
-  if (password.length < 12) errors.push("Password must be at least 12 characters long");
-  if (password.length > 50) errors.push("Password must not exceed 50 characters");
-  if (!/[A-Z]/.test(password)) errors.push("Password must contain an uppercase letter");
-  if (!/[a-z]/.test(password)) errors.push("Password must contain a lowercase letter");
-  if (!/[0-9]/.test(password)) errors.push("Password must contain a number");
-  if (!/[^\w\s]/.test(password)) errors.push("Password must contain a special character");
-
-  return { valid: errors.length === 0, errors };
+  return validateSharedPassword(password);
 }
 
 export async function requestPasswordReset(input: {
@@ -809,7 +801,31 @@ export async function completePasswordReset(input: {
       input.password
     );
   } catch (error) {
-    console.error("Fineract password reset failed:", error);
+    const fineractError = error as {
+      message?: unknown;
+      response?: {
+        status?: unknown;
+        data?: {
+          defaultUserMessage?: unknown;
+          errors?: Array<{ defaultUserMessage?: unknown }>;
+        };
+      };
+    };
+    const fineractValidationMessage = fineractError.response?.data?.errors
+      ?.map(({ defaultUserMessage }) => defaultUserMessage)
+      .filter((message): message is string => typeof message === "string")
+      .join("; ");
+
+    console.error("Fineract password reset failed", {
+      status: fineractError.response?.status ?? null,
+      message:
+        fineractValidationMessage ||
+        (typeof fineractError.response?.data?.defaultUserMessage === "string"
+          ? fineractError.response.data.defaultUserMessage
+          : typeof fineractError.message === "string"
+            ? fineractError.message
+            : "Unknown Fineract error"),
+    });
     await writePasswordResetLog({
       tenantId: input.tenantId,
       challengeId: challenge.id,

--- a/prisma/migrations/20260801000000_add_password_reset/migration.sql
+++ b/prisma/migrations/20260801000000_add_password_reset/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "PasswordResetChallenge" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "fineractUserId" INTEGER NOT NULL,
+    "username" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "verificationTokenHash" TEXT,
+    "configuredChannels" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "deliveredChannels" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "maskedDestinations" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "resendCount" INTEGER NOT NULL DEFAULT 0,
+    "lastSentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "verifiedAt" TIMESTAMP(3),
+    "consumedAt" TIMESTAMP(3),
+    "invalidatedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PasswordResetChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PasswordResetLog" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "challengeId" TEXT,
+    "fineractUserId" INTEGER,
+    "username" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "configuredChannels" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "deliveredChannels" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "maskedDestinations" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "failureReason" TEXT,
+    "requestIp" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PasswordResetChallenge_tenantId_username_idx" ON "PasswordResetChallenge"("tenantId", "username");
+CREATE INDEX "PasswordResetChallenge_tenantId_fineractUserId_idx" ON "PasswordResetChallenge"("tenantId", "fineractUserId");
+CREATE INDEX "PasswordResetChallenge_tenantId_expiresAt_idx" ON "PasswordResetChallenge"("tenantId", "expiresAt");
+CREATE INDEX "PasswordResetChallenge_tenantId_consumedAt_idx" ON "PasswordResetChallenge"("tenantId", "consumedAt");
+CREATE INDEX "PasswordResetChallenge_tenantId_invalidatedAt_idx" ON "PasswordResetChallenge"("tenantId", "invalidatedAt");
+CREATE INDEX "PasswordResetLog_tenantId_createdAt_idx" ON "PasswordResetLog"("tenantId", "createdAt");
+CREATE INDEX "PasswordResetLog_tenantId_username_createdAt_idx" ON "PasswordResetLog"("tenantId", "username", "createdAt");
+CREATE INDEX "PasswordResetLog_tenantId_event_createdAt_idx" ON "PasswordResetLog"("tenantId", "event", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetChallenge" ADD CONSTRAINT "PasswordResetChallenge_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PasswordResetLog" ADD CONSTRAINT "PasswordResetLog_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,8 @@ model Tenant {
   userLoginBlockEvents   UserLoginBlockEvent[]
   ussdPinResetLogs       UssdPinResetLog[]
   mfaChallenges          MfaChallenge[]
+  passwordResetChallenges PasswordResetChallenge[]
+  passwordResetLogs      PasswordResetLog[]
   validationRules        ValidationRule[]
   receiptRanges          ReceiptRange[]
   repaymentCashLinks     RepaymentCashLink[]
@@ -1303,6 +1305,56 @@ model MfaChallenge {
   @@index([tenantId, expiresAt])
   @@index([tenantId, consumedAt])
   @@index([tenantId, invalidatedAt])
+}
+
+model PasswordResetChallenge {
+  id                   String   @id @default(cuid())
+  tenantId             String
+  fineractUserId       Int
+  username             String
+  codeHash             String
+  verificationTokenHash String?
+  configuredChannels   String[] @default([])
+  deliveredChannels    String[] @default([])
+  maskedDestinations   String[] @default([])
+  attempts             Int      @default(0)
+  maxAttempts          Int      @default(5)
+  resendCount          Int      @default(0)
+  lastSentAt           DateTime @default(now())
+  verifiedAt           DateTime?
+  consumedAt           DateTime?
+  invalidatedAt        DateTime?
+  expiresAt            DateTime
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+  tenant               Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, username])
+  @@index([tenantId, fineractUserId])
+  @@index([tenantId, expiresAt])
+  @@index([tenantId, consumedAt])
+  @@index([tenantId, invalidatedAt])
+}
+
+model PasswordResetLog {
+  id                 String   @id @default(cuid())
+  tenantId           String
+  challengeId        String?
+  fineractUserId     Int?
+  username           String
+  event              String
+  configuredChannels String[] @default([])
+  deliveredChannels  String[] @default([])
+  maskedDestinations String[] @default([])
+  failureReason      String?  @db.Text
+  requestIp          String?
+  userAgent          String?  @db.Text
+  createdAt          DateTime @default(now())
+  tenant             Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, createdAt])
+  @@index([tenantId, username, createdAt])
+  @@index([tenantId, event, createdAt])
 }
 
 // User Alert - system alerts shown in notifications

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,6 +5,7 @@ import { tenantMiddleware } from "./lib/tenant-middleware";
 
 const PUBLIC_PREFIXES = [
   "/auth",
+  "/reset-password",
   "/_next",
   "/static",
 ];

--- a/shared/password-policy.ts
+++ b/shared/password-policy.ts
@@ -1,0 +1,61 @@
+export const PASSWORD_MIN_LENGTH = 12;
+export const PASSWORD_MAX_LENGTH = 50;
+
+export const PASSWORD_REQUIREMENTS = [
+  {
+    key: "minLength",
+    label: "At least 12 characters",
+    error: "Password must be at least 12 characters long",
+    test: (value: string) => value.length >= PASSWORD_MIN_LENGTH,
+  },
+  {
+    key: "maxLength",
+    label: "50 characters or fewer",
+    error: "Password must not exceed 50 characters",
+    test: (value: string) => value.length > 0 && value.length <= PASSWORD_MAX_LENGTH,
+  },
+  {
+    key: "uppercase",
+    label: "One uppercase letter",
+    error: "Password must contain an uppercase letter",
+    test: (value: string) => /[A-Z]/.test(value),
+  },
+  {
+    key: "lowercase",
+    label: "One lowercase letter",
+    error: "Password must contain a lowercase letter",
+    test: (value: string) => /[a-z]/.test(value),
+  },
+  {
+    key: "number",
+    label: "One number",
+    error: "Password must contain a number",
+    test: (value: string) => /[0-9]/.test(value),
+  },
+  {
+    key: "specialCharacter",
+    label: "One special character",
+    error: "Password must contain a special character",
+    test: (value: string) => /[^\w\s]/.test(value),
+  },
+  {
+    key: "noSpaces",
+    label: "No spaces",
+    error: "Password must not contain spaces",
+    test: (value: string) => value.length > 0 && !/\s/.test(value),
+  },
+  {
+    key: "noConsecutiveRepeats",
+    label: "No consecutive repeating characters",
+    error: "Password must not contain consecutive repeating characters",
+    test: (value: string) => value.length > 0 && !/(.)\1/.test(value),
+  },
+] as const;
+
+export function validatePassword(password: string) {
+  const errors = PASSWORD_REQUIREMENTS.filter(({ test }) => !test(password)).map(
+    ({ error }) => error
+  );
+
+  return { valid: errors.length === 0, errors };
+}

--- a/shared/types/tenant.ts
+++ b/shared/types/tenant.ts
@@ -54,7 +54,13 @@ export type FirstRepaymentDateStrategy =
 
 export type InterestRateDisplayMode = "annual" | "monthly";
 export type MfaChannel = "email" | "sms";
+export type SelfPasswordResetChannel = MfaChannel;
 export type AutoDisbursementDecision = "APPROVED" | "MANUAL_REVIEW" | "DECLINED";
+
+export interface SelfPasswordResetSettings {
+  enabled?: boolean;
+  notificationChannels?: SelfPasswordResetChannel[];
+}
 
 export interface FirstRepaymentDateConfig {
   strategy: FirstRepaymentDateStrategy;
@@ -96,6 +102,8 @@ export interface TenantUssdAutoLeadRule {
 export interface TenantSettings {
   theme: string;
   features: TenantFeatures;
+  /** Self-service password reset configuration. Missing settings are disabled. */
+  selfPasswordReset?: SelfPasswordResetSettings;
   /** How loan interest rates should be displayed in the UI and documents */
   loanTermsInterestRateDisplay?: InterestRateDisplayMode;
   /** Field-level auto-population controls for lead creation */
@@ -154,6 +162,42 @@ export function getTenantFeatures(
   return {
     ...DEFAULT_FEATURES,
     ...settings?.features,
+  };
+}
+
+const SELF_PASSWORD_RESET_CHANNELS: SelfPasswordResetChannel[] = [
+  "email",
+  "sms",
+];
+
+export function getTenantSelfPasswordResetConfig(settings: unknown): {
+  enabled: boolean;
+  notificationChannels: SelfPasswordResetChannel[];
+} {
+  const config =
+    settings && typeof settings === "object"
+      ? (settings as Record<string, unknown>)
+      : {};
+  const rawConfig =
+    config.selfPasswordReset && typeof config.selfPasswordReset === "object"
+      ? (config.selfPasswordReset as Record<string, unknown>)
+      : {};
+  const rawChannels = Array.isArray(rawConfig.notificationChannels)
+    ? rawConfig.notificationChannels
+    : [];
+
+  return {
+    enabled: rawConfig.enabled === true,
+    notificationChannels: Array.from(
+      new Set(
+        rawChannels.filter(
+          (channel): channel is SelfPasswordResetChannel =>
+            SELF_PASSWORD_RESET_CHANNELS.includes(
+              channel as SelfPasswordResetChannel
+            )
+        )
+      )
+    ),
   };
 }
 


### PR DESCRIPTION
## What changed

- Add tenant-configured self-service password reset using `selfPasswordReset`.
- Support SMS and email verification-code delivery through the existing notification service.
- Add expiring, attempt-limited reset challenges and Fineract password updates.
- Add Prisma migration and tenant-scoped password-reset audit logs.
- Add the public `/reset-password` flow and protected reset-log endpoint.
- Comment out the existing Remember me checkbox for now.
- Keep tenant settings configuration JSON-only; no settings UI was added.

## Why

The login page linked to a missing reset page, and there was no self-service reset flow. The tenant setting now controls whether the flow is available; when disabled, users receive the configured administrator-contact message.

## Validation

- Focused password-reset tests passed.
- Focused ESLint passed.
- Prisma schema validation passed.
- Production build passed.
- Full repository TypeScript validation still reports unrelated pre-existing errors outside this change.