### PR TITLE
Add interest suspense accounting fields to loan product forms

### DIFF
--- a/app/(application)/products/loan-products/[id]/edit/page.tsx
+++ b/app/(application)/products/loan-products/[id]/edit/page.tsx
@@ -148,6 +148,7 @@ function mapFineractProductToForm(product: Record<string, unknown>): LoanProduct
     accountMovesOutOfNPAOnlyOnArrearsCompletion: b(
       product.accountMovesOutOfNPAOnlyOnArrearsCompletion
     ),
+    enableInterestSuspenseAccounting: b(product.enableInterestSuspenseAccounting),
     multiDisburseLoan: b(product.multiDisburseLoan),
     maxTrancheCount: n(product.maxTrancheCount),
     outstandingLoanBalance: n(product.outstandingLoanBalance),
@@ -237,6 +238,7 @@ function mapFineractProductToForm(product: Record<string, unknown>): LoanProduct
         receivableInterestAccountId:               aid("receivableInterestAccount"),
         receivableFeeAccountId:                    aid("receivableFeeAccount"),
         receivablePenaltyAccountId:                aid("receivablePenaltyAccount"),
+        interestSuspenseAccountId:                 aid("interestSuspenseAccount"),
       };
     })(),
 

--- a/app/(application)/products/loan-products/components/step-accounting.tsx
+++ b/app/(application)/products/loan-products/components/step-accounting.tsx
@@ -562,6 +562,46 @@ export function StepAccounting({ form, template, onChange }: StepAccountingProps
                     accounts={assetAccounts}
                     onChange={(v) => onChange({ receivablePenaltyAccountId: v })}
                   />
+                  <div className="sm:col-span-2 space-y-4">
+                    <div
+                      className="flex cursor-pointer select-none items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/40"
+                      onClick={() =>
+                        onChange({
+                          enableInterestSuspenseAccounting: !form.enableInterestSuspenseAccounting,
+                        })
+                      }
+                    >
+                      <div>
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                          Interest Suspense Accounting
+                        </h3>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          While a loan is non-performing, credit accrued interest to a suspense
+                          account instead of income until it is recovered or written off.
+                        </p>
+                      </div>
+                      <Switch
+                        checked={form.enableInterestSuspenseAccounting}
+                        onCheckedChange={(v) =>
+                          onChange({ enableInterestSuspenseAccounting: v })
+                        }
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </div>
+
+                    {form.enableInterestSuspenseAccounting && (
+                      <div className="rounded-lg border bg-muted/20 p-4">
+                        <GLAccountSelect
+                          id="interestSuspenseAccountId"
+                          label="Interest Suspense"
+                          required
+                          value={form.interestSuspenseAccountId}
+                          accounts={assetAccounts}
+                          onChange={(v) => onChange({ interestSuspenseAccountId: v })}
+                        />
+                      </div>
+                    )}
+                  </div>
                 </>
               )}
             </div>

--- a/shared/types/loan-product.ts
+++ b/shared/types/loan-product.ts
@@ -300,6 +300,8 @@ export interface LoanProductFormData {
   receivableInterestAccountId: number | "";
   receivableFeeAccountId: number | "";
   receivablePenaltyAccountId: number | "";
+  enableInterestSuspenseAccounting: boolean;
+  interestSuspenseAccountId: number | "";
   advancedAccountingRules: boolean;
   paymentChannelToFundSourceMappings: PaymentChannelMapping[];
   feeToIncomeAccountMappings: FeeIncomeMapping[];
@@ -418,6 +420,8 @@ export const defaultLoanProductFormData: LoanProductFormData = {
   receivableInterestAccountId: "",
   receivableFeeAccountId: "",
   receivablePenaltyAccountId: "",
+  enableInterestSuspenseAccounting: false,
+  interestSuspenseAccountId: "",
   advancedAccountingRules: false,
   paymentChannelToFundSourceMappings: [],
   feeToIncomeAccountMappings: [],
@@ -746,6 +750,8 @@ export function buildFineractPayload(form: LoanProductFormData): Record<string, 
       if (form.receivableInterestAccountId !== "") payload.receivableInterestAccountId = form.receivableInterestAccountId;
       if (form.receivableFeeAccountId !== "") payload.receivableFeeAccountId = form.receivableFeeAccountId;
       if (form.receivablePenaltyAccountId !== "") payload.receivablePenaltyAccountId = form.receivablePenaltyAccountId;
+      if (form.enableInterestSuspenseAccounting) payload.enableInterestSuspenseAccounting = true;
+      if (form.interestSuspenseAccountId !== "") payload.interestSuspenseAccountId = form.interestSuspenseAccountId;
     }
 
     if (form.advancedAccountingRules) {


### PR DESCRIPTION
## Summary
- Wires the new backend `enableInterestSuspenseAccounting` / `interestSuspenseAccountId` loan product fields (from the companion Fineract PR) into the product create/edit form.
- Follows the exact existing pattern used for `receivableInterestAccountId`: accrual-only (periodic/upfront), toggle reveals a GL account dropdown sourced from the same asset-account options list, included in the payload only when set, and reverse-mapped from Fineract's `accountingMappings.interestSuspenseAccount` on edit.
- No new API calls, no new validation — matches how sibling GL-account fields already behave in this form (backend is the source of truth for required-ness).

## Test plan
- [x] `tsc --noEmit` clean on changed files
- [x] `eslint` clean on changed files
- [x] Dev server boots without errors
- [ ] Authenticated click-through in a browser (create + edit flows, toggle behavior) — not performed; no browser-automation tooling was available in this environment and the app requires login against the shared UAT backend. Please verify visually before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)