### PR TITLE
Add recovery queue client search

### DIFF
--- a/app/(application)/loans/recoveries/recoveries-dashboard.tsx
+++ b/app/(application)/loans/recoveries/recoveries-dashboard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import {
   Bell,
   BriefcaseBusiness,
@@ -18,6 +18,7 @@ import {
   MessageSquarePlus,
   RefreshCw,
   Scale,
+  Search,
   ShieldAlert,
   StickyNote,
 } from "lucide-react";
@@ -361,7 +362,7 @@ function RecoveryStatsSkeleton() {
 
 export function RecoveriesDashboard() {
   const { currencyCode } = useCurrency();
-  const dashboardCacheRef = useRef<Partial<Record<BucketTab, Record<number, RecoveryDashboardData>>>>({});
+  const dashboardCacheRef = useRef<Record<string, RecoveryDashboardData>>({});
   const courtRowsCacheRef = useRef<CourtReportRow[] | null>(null);
   const [activeTab, setActiveTab] = useState<BucketTab>("30");
   const [dashboard, setDashboard] = useState<RecoveryDashboardData | null>(null);
@@ -372,6 +373,7 @@ export function RecoveriesDashboard() {
   const [caseProceedingsData, setCaseProceedingsData] = useState<LoanCourtData | null>(null);
   const [caseProceedingsLoading, setCaseProceedingsLoading] = useState(false);
   const [pageByTab, setPageByTab] = useState<Partial<Record<BucketTab, number>>>({});
+  const [clientNameSearch, setClientNameSearch] = useState("");
   const [actionKey, setActionKey] = useState<string | null>(null);
   const [noteTarget, setNoteTarget] = useState<RecoveryLoanRow | null>(null);
   const [noteText, setNoteText] = useState("");
@@ -384,12 +386,20 @@ export function RecoveriesDashboard() {
   const [proceedingTarget, setProceedingTarget] = useState<RecoveryLoanRow | null>(null);
   const [proceedingForm, setProceedingForm] = useState<ProceedingForm>(emptyProceedingForm);
 
+  const deferredClientNameSearch = useDeferredValue(clientNameSearch);
   const activePage = pageByTab[activeTab] ?? 1;
   const courtCaseFormValid = isCourtCaseFormValid(courtCaseForm);
   const proceedingFormValid = isProceedingFormValid(proceedingForm);
 
-  const fetchDashboard = useCallback(async (tab: BucketTab, page: number, force = false) => {
-    const cached = dashboardCacheRef.current[tab]?.[page];
+  const fetchDashboard = useCallback(async (
+    tab: BucketTab,
+    page: number,
+    clientNameSearch = "",
+    force = false
+  ) => {
+    const normalizedClientName = clientNameSearch.trim().toLocaleLowerCase();
+    const cacheKey = `${tab}:${page}:${normalizedClientName}`;
+    const cached = dashboardCacheRef.current[cacheKey];
     if (!force && cached) {
       setDashboard(cached);
       setLoading(false);
@@ -404,19 +414,16 @@ export function RecoveriesDashboard() {
         page: String(page),
         pageSize: String(PAGE_SIZE),
       });
+      if (clientNameSearch.trim()) {
+        params.set("clientName", clientNameSearch);
+      }
       const response = await fetch(`/api/recoveries/arrears?${params.toString()}`, {
         cache: "no-store",
       });
       const result = await response.json();
       if (!response.ok) throw new Error(result.error || "Failed to load recovery data");
       setDashboard(result);
-      dashboardCacheRef.current = {
-        ...dashboardCacheRef.current,
-        [tab]: {
-          ...(dashboardCacheRef.current[tab] || {}),
-          [page]: result,
-        },
-      };
+      dashboardCacheRef.current[cacheKey] = result;
     } catch (error) {
       toast({
         title: "Recoveries",
@@ -461,8 +468,8 @@ export function RecoveriesDashboard() {
       fetchCourtRows();
       return;
     }
-    fetchDashboard(activeTab, activePage);
-  }, [activePage, activeTab, fetchCourtRows, fetchDashboard]);
+    fetchDashboard(activeTab, activePage, deferredClientNameSearch);
+  }, [activePage, activeTab, deferredClientNameSearch, fetchCourtRows, fetchDashboard]);
 
   const rows = useMemo(() => dashboard?.rows || [], [dashboard]);
   const summary = dashboard?.summary;
@@ -479,8 +486,8 @@ export function RecoveriesDashboard() {
       fetchCourtRows(true);
       return;
     }
-    fetchDashboard(activeTab, activePage, true);
-  }, [activePage, activeTab, fetchCourtRows, fetchDashboard]);
+    fetchDashboard(activeTab, activePage, deferredClientNameSearch, true);
+  }, [activePage, activeTab, deferredClientNameSearch, fetchCourtRows, fetchDashboard]);
 
   const setActiveTabPage = useCallback((page: number) => {
     setPageByTab((current) => ({
@@ -488,6 +495,8 @@ export function RecoveriesDashboard() {
       [activeTab]: Math.max(1, page),
     }));
   }, [activeTab]);
+
+  const canSearchRecoveryClients = activeTab !== "court" && activeTab !== "performance";
 
   const loadCourtCaseData = useCallback(async (row: RecoveryLoanRow) => {
     setCourtCaseLoading(true);
@@ -748,6 +757,22 @@ export function RecoveriesDashboard() {
               ))}
             </TabsList>
           </Tabs>
+
+          {canSearchRecoveryClients && (
+            <div className="relative mt-4 max-w-md">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={clientNameSearch}
+                onChange={(event) => {
+                  setClientNameSearch(event.target.value);
+                  setPageByTab({});
+                }}
+                placeholder="Search by client name"
+                aria-label="Search recovery queue by client name"
+                className="pl-9"
+              />
+            </div>
+          )}
 
           <div className="mt-4">
             {activeTab === "court" ? (

--- a/app/api/recoveries/arrears/route.ts
+++ b/app/api/recoveries/arrears/route.ts
@@ -14,7 +14,12 @@ export async function GET(request: NextRequest) {
     const bucket = normalizeRecoveryBucket(searchParams.get("bucket"));
     const page = parsePositiveInt(searchParams.get("page"), 1, 100000);
     const pageSize = parsePositiveInt(searchParams.get("pageSize"), 25, 100);
-    const data = await getRecoveryDashboardData(bucket, { page, pageSize });
+    const clientName = searchParams.get("clientName")?.trim().slice(0, 100) || undefined;
+    const data = await getRecoveryDashboardData(bucket, {
+      page,
+      pageSize,
+      clientName,
+    });
 
     return NextResponse.json(data, {
       headers: { "Cache-Control": "no-store" },

--- a/lib/__tests__/recovery-client-name-search.test.ts
+++ b/lib/__tests__/recovery-client-name-search.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { filterRecoveryRowsByClientName } from "../recovery-client-name-search";
+
+const rows = [
+  { loanId: 101, clientName: "Francis Mutambo" },
+  { loanId: 102, clientName: "Jessy Thole" },
+  { loanId: 103, clientName: "Francisca Mumba" },
+];
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("filters recovery rows by a partial client name without regard to case", () => {
+  assert.deepEqual(
+    filterRecoveryRowsByClientName(rows, "FRANCIS").map((row) => row.loanId),
+    [101, 103]
+  );
+});
+
+test("keeps all recovery rows when the client-name search is blank", () => {
+  assert.deepEqual(
+    filterRecoveryRowsByClientName(rows, "  ").map((row) => row.loanId),
+    [101, 102, 103]
+  );
+});
+
+test("recovery queue sends client-name searches to the paginated arrears API", () => {
+  const dashboardSource = readRepoFile(
+    "app/(application)/loans/recoveries/recoveries-dashboard.tsx"
+  );
+  const routeSource = readRepoFile("app/api/recoveries/arrears/route.ts");
+
+  assert.match(dashboardSource, /placeholder="Search by client name"/);
+  assert.match(dashboardSource, /params\.set\("clientName", clientNameSearch\)/);
+  assert.match(routeSource, /searchParams\.get\("clientName"\)/);
+  assert.match(routeSource, /clientName/);
+});

--- a/lib/fineract-recoveries.ts
+++ b/lib/fineract-recoveries.ts
@@ -5,6 +5,10 @@ import { formatFineractDate } from "@/lib/fineract-savings-service";
 import { resolveLoanNotificationTarget } from "@/lib/loan-notification-target";
 import { sendSms } from "@/lib/notification-service";
 import { getTenantBySlug } from "@/lib/tenant-service";
+import {
+  filterRecoveryRowsByClientName,
+  normalizeRecoveryClientNameSearch,
+} from "@/lib/recovery-client-name-search";
 
 export const RECOVERY_COURT_CASE_TABLE = "lm_loan_court_case";
 export const RECOVERY_COURT_PROCEEDING_TABLE = "lm_loan_court_proceeding";
@@ -18,6 +22,8 @@ export const RECOVERY_BRANCH_REPORT = "LM_RECOVERY_BRANCH_PERFORMANCE";
 
 const DATE_FORMAT = "dd MMMM yyyy";
 const LOCALE = "en";
+const RECOVERY_SEARCH_PAGE_SIZE = 1000;
+const MAX_RECOVERY_SEARCH_ROWS = 20000;
 
 export type RecoveryBucket = "30" | "60" | "90" | "npa" | "all";
 
@@ -139,6 +145,7 @@ export type RecoveryDashboardData = {
 export type RecoveryDashboardOptions = {
   page?: number;
   pageSize?: number;
+  clientName?: string;
 };
 
 export type CourtCaseInput = {
@@ -584,11 +591,58 @@ async function runRecoverySummaryReport(): Promise<RecoveryDashboardSummary> {
   return summaryFromReport(parseReportRows(summaryData)[0], branchRows);
 }
 
+type RecoveryReportPage = {
+  rows: RecoveryLoanRow[];
+  hasNextPage: boolean;
+};
+
+async function searchRecoveryReportRows(
+  getPage: (pagination: { page: number; pageSize: number }) => Promise<RecoveryReportPage>,
+  clientName: string,
+  pagination: { page: number; pageSize: number }
+): Promise<RecoveryReportPage> {
+  const allRows: RecoveryLoanRow[] = [];
+
+  for (
+    let page = 1;
+    allRows.length < MAX_RECOVERY_SEARCH_ROWS;
+    page += 1
+  ) {
+    const pageResult = await getPage({
+      page,
+      pageSize: RECOVERY_SEARCH_PAGE_SIZE,
+    });
+    allRows.push(...pageResult.rows);
+
+    if (!pageResult.hasNextPage) {
+      break;
+    }
+  }
+
+  const matchingRows = filterRecoveryRowsByClientName(allRows, clientName);
+  const offset = (pagination.page - 1) * pagination.pageSize;
+
+  return {
+    rows: matchingRows.slice(offset, offset + pagination.pageSize),
+    hasNextPage: offset + pagination.pageSize < matchingRows.length,
+  };
+}
+
 async function runRecoveryArrearsReport(
   daysPastDue: number,
   maxDaysPastDue: number | undefined,
-  pagination: { page: number; pageSize: number }
+  pagination: { page: number; pageSize: number },
+  clientName?: string
 ): Promise<{ rows: RecoveryLoanRow[]; hasNextPage: boolean }> {
+  if (normalizeRecoveryClientNameSearch(clientName)) {
+    return searchRecoveryReportRows(
+      (searchPagination) =>
+        runRecoveryArrearsReport(daysPastDue, maxDaysPastDue, searchPagination),
+      clientName || "",
+      pagination
+    );
+  }
+
   const requestedLimit = pagination.pageSize + 1;
   const offset = (pagination.page - 1) * pagination.pageSize;
   const params = new URLSearchParams({
@@ -613,8 +667,17 @@ async function runRecoveryArrearsReport(
 }
 
 async function runRecoveryNpaReport(
-  pagination: { page: number; pageSize: number }
+  pagination: { page: number; pageSize: number },
+  clientName?: string
 ): Promise<{ rows: RecoveryLoanRow[]; hasNextPage: boolean }> {
+  if (normalizeRecoveryClientNameSearch(clientName)) {
+    return searchRecoveryReportRows(
+      (searchPagination) => runRecoveryNpaReport(searchPagination),
+      clientName || "",
+      pagination
+    );
+  }
+
   const requestedLimit = pagination.pageSize + 1;
   const offset = (pagination.page - 1) * pagination.pageSize;
   const params = new URLSearchParams({
@@ -645,7 +708,8 @@ function getBucketRange(bucket: RecoveryBucket): { min: number; max?: number } {
 
 async function getFallbackRecoveryDashboardData(
   bucket: RecoveryBucket,
-  pagination: { page: number; pageSize: number }
+  pagination: { page: number; pageSize: number },
+  clientName?: string
 ): Promise<RecoveryDashboardData> {
   const loans = await fetchAllRecoveryLoans();
   const rows = loans.map(toLoanRow).filter((row): row is RecoveryLoanRow => Boolean(row));
@@ -658,7 +722,9 @@ async function getFallbackRecoveryDashboardData(
         ? rows.filter((row) => row.isNpa)
         : rows.filter((row) => row.bucket === bucket);
 
-  const sortedRows = filteredRows.sort((a, b) => b.daysPastDue - a.daysPastDue || b.overdueAmount - a.overdueAmount);
+  const sortedRows = filterRecoveryRowsByClientName(filteredRows, clientName).sort(
+    (a, b) => b.daysPastDue - a.daysPastDue || b.overdueAmount - a.overdueAmount
+  );
   const offset = (pagination.page - 1) * pagination.pageSize;
   const pagedRows = sortedRows.slice(offset, offset + pagination.pageSize);
 
@@ -681,6 +747,7 @@ export async function getRecoveryDashboardData(
   bucket: RecoveryBucket,
   options: RecoveryDashboardOptions = {}
 ): Promise<RecoveryDashboardData> {
+  const clientName = options.clientName?.trim().slice(0, 100) || "";
   const pagination = {
     page: toPositiveInteger(options.page, 1),
     pageSize: toPositiveInteger(options.pageSize, 25, 100),
@@ -691,8 +758,13 @@ export async function getRecoveryDashboardData(
     const [summary, pageResult] = await Promise.all([
       runRecoverySummaryReport(),
       bucket === "npa"
-        ? runRecoveryNpaReport(pagination)
-        : runRecoveryArrearsReport(bucket === "all" ? 0 : min, bucket === "all" ? undefined : max, pagination),
+        ? runRecoveryNpaReport(pagination, clientName)
+        : runRecoveryArrearsReport(
+            bucket === "all" ? 0 : min,
+            bucket === "all" ? undefined : max,
+            pagination,
+            clientName
+          ),
     ]);
     const sortedRows = pageResult.rows.sort((a, b) => b.daysPastDue - a.daysPastDue || b.overdueAmount - a.overdueAmount);
 
@@ -711,7 +783,7 @@ export async function getRecoveryDashboardData(
     };
   } catch (error) {
     console.warn("Recovery reports unavailable, falling back to loan list:", error);
-    return getFallbackRecoveryDashboardData(bucket, pagination);
+    return getFallbackRecoveryDashboardData(bucket, pagination, clientName);
   }
 }
 

--- a/lib/recovery-client-name-search.ts
+++ b/lib/recovery-client-name-search.ts
@@ -1,0 +1,22 @@
+export type RecoveryClientNameRow = {
+  clientName?: string | null;
+};
+
+export function normalizeRecoveryClientNameSearch(value?: string | null): string {
+  return value?.trim().toLocaleLowerCase() || "";
+}
+
+export function filterRecoveryRowsByClientName<T extends RecoveryClientNameRow>(
+  rows: T[],
+  clientNameSearch?: string | null
+): T[] {
+  const query = normalizeRecoveryClientNameSearch(clientNameSearch);
+
+  if (!query) {
+    return rows;
+  }
+
+  return rows.filter((row) =>
+    normalizeRecoveryClientNameSearch(row.clientName).includes(query)
+  );
+}


### PR DESCRIPTION
## Summary
- add client-name search to the Recovery Queue
- search the full selected arrears/NPA bucket server-side before applying existing pagination
- retain branch scope and existing arrears calculations

## Verification
- npx tsx --test lib/__tests__/recovery-client-name-search.test.ts lib/__tests__/client-loans-table.test.ts