### PR TITLE
Fix reports date display format

### DIFF
--- a/app/(application)/reports/[reportName]/page.tsx
+++ b/app/(application)/reports/[reportName]/page.tsx
@@ -44,6 +44,7 @@ import { isOmamaTenantHostname } from "@/lib/omama-tenant";
 import { ReportDateParameterInput } from "../components/report-date-parameter-input";
 import {
   formatReportDateValue,
+  isReportDateColumn,
   isReportDateLike,
 } from "../components/report-date-utils";
 
@@ -79,6 +80,8 @@ interface ReportData {
     row: any[];
   }>;
 }
+
+type ReportColumnHeader = ReportData["columnHeaders"][number];
 
 function safeText(value: unknown, fallback = ""): string {
   if (typeof value === "string") return value;
@@ -408,9 +411,11 @@ export default function ReportDetailPage() {
     const rows = reportData.data
       .map((item) =>
         visibleIndices.map((i) => {
+            const header = reportData.columnHeaders[i];
             const cell = item.row[i];
             if (cell === null || cell === undefined) return "";
-            const str = isReportDateLike(cell)
+            const str =
+              isDateColumn(header) || isReportDateLike(cell)
               ? formatReportDateValue(cell, "")
               : String(cell);
             return str.includes(",") || str.includes('"') || str.includes("\n")
@@ -444,9 +449,10 @@ export default function ReportDetailPage() {
     const rows = reportData.data.map((item) => ({
       row_type: rowTypeIndex >= 0 ? (item.row[rowTypeIndex] as string | null) : null,
       cells: visibleIndices.map((i) => {
+        const header = reportData.columnHeaders[i];
         const cell = item.row[i];
         if (cell === null || cell === undefined) return null;
-        if (isReportDateLike(cell)) {
+        if (isDateColumn(header) || isReportDateLike(cell)) {
           return formatReportDateValue(cell, "");
         }
         return cell;
@@ -546,6 +552,9 @@ export default function ReportDetailPage() {
     setParameters(newParams);
   };
 
+  const isDateColumn = (header?: ReportColumnHeader) =>
+    isReportDateColumn(header?.columnType, header?.columnDisplayType);
+
   const renderParameterInput = (param: ReportParameter) => {
     const value = parameters[param.parameter_variable] || "";
     const options = parameterOptions[param.parameter_name] || [];
@@ -627,12 +636,12 @@ export default function ReportDetailPage() {
     }
   };
 
-  const formatCellValue = (cell: any) => {
+  const formatCellValue = (cell: any, header?: ReportColumnHeader) => {
     if (cell === null || cell === undefined) {
       return <span className="text-muted-foreground">-</span>;
     }
 
-    if (isReportDateLike(cell)) {
+    if (isDateColumn(header) || isReportDateLike(cell)) {
       return formatReportDateValue(cell, String(cell));
     }
 
@@ -849,13 +858,14 @@ export default function ReportDetailPage() {
                         return (
                           <TableRow key={rowIndex}>
                             {item.row.map((cell, cellIndex) => {
-                              if (reportData.columnHeaders[cellIndex]?.columnName === "row_type") return null;
+                              const header = reportData.columnHeaders[cellIndex];
+                              if (header?.columnName === "row_type") return null;
                               return (
                                 <TableCell
                                   key={cellIndex}
                                   className={`border-r border-border last:border-r-0${isBold ? " font-bold" : ""}`}
                                 >
-                                  {formatCellValue(cell)}
+                                  {formatCellValue(cell, header)}
                                 </TableCell>
                               );
                             })}

--- a/app/(application)/reports/[reportName]/page.tsx
+++ b/app/(application)/reports/[reportName]/page.tsx
@@ -41,6 +41,11 @@ import {
 } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
 import { isOmamaTenantHostname } from "@/lib/omama-tenant";
+import { ReportDateParameterInput } from "../components/report-date-parameter-input";
+import {
+  formatReportDateValue,
+  isReportDateLike,
+} from "../components/report-date-utils";
 
 interface ReportParameter {
   parameter_name: string;
@@ -405,17 +410,9 @@ export default function ReportDetailPage() {
         visibleIndices.map((i) => {
             const cell = item.row[i];
             if (cell === null || cell === undefined) return "";
-            if (
-              Array.isArray(cell) &&
-              cell.length === 3 &&
-              typeof cell[0] === "number"
-            ) {
-              const [year, month, day] = cell;
-              return `${year}-${month.toString().padStart(2, "0")}-${day
-                .toString()
-                .padStart(2, "0")}`;
-            }
-            const str = String(cell);
+            const str = isReportDateLike(cell)
+              ? formatReportDateValue(cell, "")
+              : String(cell);
             return str.includes(",") || str.includes('"') || str.includes("\n")
               ? `"${str.replace(/"/g, '""')}"`
               : str;
@@ -449,9 +446,8 @@ export default function ReportDetailPage() {
       cells: visibleIndices.map((i) => {
         const cell = item.row[i];
         if (cell === null || cell === undefined) return null;
-        if (Array.isArray(cell) && cell.length === 3 && typeof cell[0] === "number") {
-          const [year, month, day] = cell;
-          return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+        if (isReportDateLike(cell)) {
+          return formatReportDateValue(cell, "");
         }
         return cell;
       }),
@@ -583,12 +579,12 @@ export default function ReportDetailPage() {
 
       case "date":
         return (
-          <Input
-            type="date"
+          <ReportDateParameterInput
             value={value}
-            onChange={(e) =>
-              handleParameterChange(param.parameter_variable, e.target.value)
+            onChange={(nextValue) =>
+              handleParameterChange(param.parameter_variable, nextValue)
             }
+            placeholder={`Select ${displayLabel}`}
           />
         );
 
@@ -636,15 +632,8 @@ export default function ReportDetailPage() {
       return <span className="text-muted-foreground">-</span>;
     }
 
-    if (
-      Array.isArray(cell) &&
-      cell.length === 3 &&
-      typeof cell[0] === "number"
-    ) {
-      const [year, month, day] = cell;
-      return `${year}-${month.toString().padStart(2, "0")}-${day
-        .toString()
-        .padStart(2, "0")}`;
+    if (isReportDateLike(cell)) {
+      return formatReportDateValue(cell, String(cell));
     }
 
     return String(cell);

--- a/app/(application)/reports/components/report-date-parameter-input.tsx
+++ b/app/(application)/reports/components/report-date-parameter-input.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { format } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import { parseReportDateValue } from "./report-date-utils";
+
+interface ReportDateParameterInputProps {
+  value?: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+}
+
+export function ReportDateParameterInput({
+  value = "",
+  placeholder = "Select a date",
+  onChange,
+}: ReportDateParameterInputProps) {
+  const selectedDate = parseReportDateValue(value);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className={cn(
+            "w-full justify-start text-left font-normal",
+            !selectedDate && "text-muted-foreground"
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {selectedDate ? format(selectedDate, "dd/MM/yyyy") : placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={selectedDate ?? undefined}
+          onSelect={(date) => onChange(date ? format(date, "yyyy-MM-dd") : "")}
+          initialFocus
+        />
+        {selectedDate ? (
+          <div className="border-t p-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start"
+              onClick={() => onChange("")}
+            >
+              Clear date
+            </Button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/(application)/reports/components/report-date-utils.ts
+++ b/app/(application)/reports/components/report-date-utils.ts
@@ -1,0 +1,85 @@
+import { format } from "date-fns";
+
+export type ReportDateValue =
+  | string
+  | number
+  | Date
+  | [number, number, number]
+  | null
+  | undefined;
+
+const ISO_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DAY_FIRST_DATE_REGEX = /^(\d{2})[/-](\d{2})[/-](\d{4})$/;
+
+export function isReportDateArray(
+  value: unknown
+): value is [number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    value.every((part) => typeof part === "number")
+  );
+}
+
+export function isReportDateLike(value: unknown): boolean {
+  if (value instanceof Date) {
+    return !Number.isNaN(value.getTime());
+  }
+
+  if (isReportDateArray(value)) {
+    return true;
+  }
+
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  return (
+    ISO_DATE_ONLY_REGEX.test(trimmed) || DAY_FIRST_DATE_REGEX.test(trimmed)
+  );
+}
+
+export function parseReportDateValue(value: ReportDateValue): Date | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+  }
+
+  if (isReportDateArray(value)) {
+    const [year, month, day] = value;
+    return new Date(year, month - 1, day);
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+
+    const isoDateMatch = trimmed.match(ISO_DATE_ONLY_REGEX);
+    if (isoDateMatch) {
+      const [, year, month, day] = isoDateMatch;
+      return new Date(Number(year), Number(month) - 1, Number(day));
+    }
+
+    const dayFirstMatch = trimmed.match(DAY_FIRST_DATE_REGEX);
+    if (dayFirstMatch) {
+      const [, day, month, year] = dayFirstMatch;
+      return new Date(Number(year), Number(month) - 1, Number(day));
+    }
+
+    const parsedDate = new Date(trimmed);
+    return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+  }
+
+  return null;
+}
+
+export function formatReportDateValue(
+  value: ReportDateValue,
+  fallback = ""
+): string {
+  const parsedDate = parseReportDateValue(value);
+  return parsedDate ? format(parsedDate, "dd/MM/yyyy") : fallback;
+}

--- a/app/(application)/reports/components/report-date-utils.ts
+++ b/app/(application)/reports/components/report-date-utils.ts
@@ -4,19 +4,35 @@ export type ReportDateValue =
   | string
   | number
   | Date
-  | [number, number, number]
+  | number[]
   | null
   | undefined;
 
-const ISO_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
-const DAY_FIRST_DATE_REGEX = /^(\d{2})[/-](\d{2})[/-](\d{4})$/;
+const ISO_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})(?:[ T].*)?$/;
+const DAY_FIRST_DATE_REGEX = /^(\d{2})[/-](\d{2})[/-](\d{4})(?:[ T].*)?$/;
+
+export function isReportDateColumn(
+  columnType?: string | null,
+  columnDisplayType?: string | null
+): boolean {
+  const normalizedDisplayType = columnDisplayType?.toUpperCase();
+  const normalizedColumnType = columnType?.toUpperCase();
+
+  return (
+    normalizedDisplayType === "DATE" ||
+    normalizedDisplayType === "DATETIME" ||
+    normalizedColumnType === "DATE" ||
+    normalizedColumnType === "DATETIME" ||
+    normalizedColumnType === "TIMESTAMP"
+  );
+}
 
 export function isReportDateArray(
   value: unknown
-): value is [number, number, number] {
+): value is number[] {
   return (
     Array.isArray(value) &&
-    value.length === 3 &&
+    value.length >= 3 &&
     value.every((part) => typeof part === "number")
   );
 }
@@ -50,8 +66,8 @@ export function parseReportDateValue(value: ReportDateValue): Date | null {
   }
 
   if (isReportDateArray(value)) {
-    const [year, month, day] = value;
-    return new Date(year, month - 1, day);
+    const [year, month, day, hour = 0, minute = 0, second = 0] = value;
+    return new Date(year, month - 1, day, hour, minute, second);
   }
 
   if (typeof value === "string") {

--- a/app/(application)/reports/page.tsx
+++ b/app/(application)/reports/page.tsx
@@ -63,6 +63,7 @@ import {
 import { ReportDateParameterInput } from "./components/report-date-parameter-input";
 import {
   formatReportDateValue,
+  isReportDateColumn,
   isReportDateLike,
 } from "./components/report-date-utils";
 import { ReportsDataTable } from "./components/reports-data-table";
@@ -114,6 +115,8 @@ interface ReportData {
     row: any[];
   }>;
 }
+
+type ReportColumnHeader = ReportData["columnHeaders"][number];
 
 function safeText(value: unknown, fallback = ""): string {
   if (typeof value === "string") return value;
@@ -471,9 +474,11 @@ export default function ReportsPage() {
     const rows = reportData.data
       .map((item) =>
         item.row
-          .map((cell: any) => {
+          .map((cell: any, cellIndex: number) => {
+            const header = reportData.columnHeaders[cellIndex];
             if (cell === null || cell === undefined) return "";
-            const str = isReportDateLike(cell)
+            const str =
+              isDateColumn(header) || isReportDateLike(cell)
               ? formatReportDateValue(cell, "")
               : String(cell);
             return str.includes(",") || str.includes('"') || str.includes("\n")
@@ -495,6 +500,9 @@ export default function ReportsPage() {
     link.click();
     URL.revokeObjectURL(url);
   };
+
+  const isDateColumn = (header?: ReportColumnHeader) =>
+    isReportDateColumn(header?.columnType, header?.columnDisplayType);
 
   const handleParameterChange = async (
     paramVariable: string,
@@ -632,12 +640,12 @@ export default function ReportsPage() {
     }
   };
 
-  const formatCellValue = (cell: any) => {
+  const formatCellValue = (cell: any, header?: ReportColumnHeader) => {
     if (cell === null || cell === undefined) {
       return <span className="text-muted-foreground">-</span>;
     }
 
-    if (isReportDateLike(cell)) {
+    if (isDateColumn(header) || isReportDateLike(cell)) {
       return formatReportDateValue(cell, String(cell));
     }
 

--- a/app/(application)/reports/page.tsx
+++ b/app/(application)/reports/page.tsx
@@ -60,6 +60,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ReportDateParameterInput } from "./components/report-date-parameter-input";
+import {
+  formatReportDateValue,
+  isReportDateLike,
+} from "./components/report-date-utils";
 import { ReportsDataTable } from "./components/reports-data-table";
 
 interface FineractReport {
@@ -468,17 +473,9 @@ export default function ReportsPage() {
         item.row
           .map((cell: any) => {
             if (cell === null || cell === undefined) return "";
-            if (
-              Array.isArray(cell) &&
-              cell.length === 3 &&
-              typeof cell[0] === "number"
-            ) {
-              const [year, month, day] = cell;
-              return `${year}-${month.toString().padStart(2, "0")}-${day
-                .toString()
-                .padStart(2, "0")}`;
-            }
-            const str = String(cell);
+            const str = isReportDateLike(cell)
+              ? formatReportDateValue(cell, "")
+              : String(cell);
             return str.includes(",") || str.includes('"') || str.includes("\n")
               ? `"${str.replace(/"/g, '""')}"`
               : str;
@@ -600,12 +597,12 @@ export default function ReportsPage() {
 
       case "date":
         return (
-          <Input
-            type="date"
+          <ReportDateParameterInput
             value={value}
-            onChange={(e) =>
-              handleParameterChange(param.parameter_variable, e.target.value)
+            onChange={(nextValue) =>
+              handleParameterChange(param.parameter_variable, nextValue)
             }
+            placeholder={`Select ${displayLabel}`}
           />
         );
 
@@ -640,15 +637,8 @@ export default function ReportsPage() {
       return <span className="text-muted-foreground">-</span>;
     }
 
-    if (
-      Array.isArray(cell) &&
-      cell.length === 3 &&
-      typeof cell[0] === "number"
-    ) {
-      const [year, month, day] = cell;
-      return `${year}-${month.toString().padStart(2, "0")}-${day
-        .toString()
-        .padStart(2, "0")}`;
+    if (isReportDateLike(cell)) {
+      return formatReportDateValue(cell, String(cell));
     }
 
     return String(cell);


### PR DESCRIPTION
## What changed
- replaced the native report date parameter inputs on both reports pages with a calendar-backed control that displays dates as `dd/mm/yyyy` while still submitting `yyyy-MM-dd` to Fineract
- added shared report date utilities to normalize Fineract date arrays and ISO date strings into `dd/mm/yyyy`
- updated report result rendering plus CSV/XLSX export formatting so report dates no longer appear as `yyyy-mm-dd`

## Why
Report dates in Loan Matrix reports were being manually converted to ISO strings in the UI and exports, and the native browser date inputs also surfaced ISO-style formatting. That made the reports experience inconsistent with the required `dd/mm/yyyy` display.

## User impact
Users now see report dates in `dd/mm/yyyy` across:
- report parameter date pickers
- report result tables
- CSV exports
- Excel exports

## Root cause
The reports pages were formatting Fineract `[year, month, day]` date values directly into `yyyy-mm-dd` strings instead of using a display formatter, and report date parameters relied on native `type="date"` inputs.

## Validation
- `npx eslint app/(application)/reports/components/report-date-parameter-input.tsx app/(application)/reports/components/report-date-utils.ts`
- `git diff --check`
- `npx tsx -e "import { formatReportDateValue } from ./app/(application)/reports/components/report-date-utils.ts; console.log(formatReportDateValue([2026, 8, 4])); console.log(formatReportDateValue(2026-08-04)); console.log(formatReportDateValue(04/08/2026));"`

## Notes
- running ESLint across the existing reports pages surfaces pre-existing lint issues in those files that are outside the scope of this fix; the new shared files pass focused lint validation.