### PR TITLE
Use UPDATE_CLIENT permission for client edits

### DIFF
--- a/app/(application)/clients/[id]/edit/page.tsx
+++ b/app/(application)/clients/[id]/edit/page.tsx
@@ -2,7 +2,8 @@ import { notFound } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { hasSuperAdminServer } from "@/lib/authorization";
+import { hasPermissionServer } from "@/lib/authorization";
+import { SpecificPermission } from "@/shared/types/auth";
 import { ClientEditForm } from "./components/client-edit-form";
 
 interface PageProps {
@@ -19,7 +20,9 @@ export default async function ClientEditPage({ params }: PageProps) {
     notFound();
   }
 
-  const canEditClient = await hasSuperAdminServer();
+  const canEditClient = await hasPermissionServer(
+    SpecificPermission.UPDATE_CLIENT
+  );
 
   return (
     <div className="space-y-6">

--- a/app/(application)/clients/[id]/page.tsx
+++ b/app/(application)/clients/[id]/page.tsx
@@ -9,10 +9,11 @@ import {
   Wallet,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { hasSuperAdminServer } from "@/lib/authorization";
+import { hasPermissionServer } from "@/lib/authorization";
 import { getClientDetailsPageFineractHeaders } from "@/lib/client-details-page-fineract-auth";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
 import { prisma } from "@/lib/prisma";
+import { SpecificPermission } from "@/shared/types/auth";
 import { ClientDetails } from "./components/client-details";
 import { ClientLoans } from "./components/client-loans";
 import { ClientTransactions } from "./components/client-transactions";
@@ -404,7 +405,7 @@ export default async function ClientDetailPage({ params }: PageProps) {
       getClientData(clientId),
       getClientImage(clientId),
       getDatatables(),
-      hasSuperAdminServer(),
+      hasPermissionServer(SpecificPermission.UPDATE_CLIENT),
       getClientHasLoans(clientId),
     ]);
 

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
-import { hasSuperAdminServer } from "@/lib/authorization";
+import { hasPermissionServer } from "@/lib/authorization";
 import {
   formatMobileForFineract,
   resolveCountryDialCodeForPhone,
 } from "@/lib/phone-utils";
+import { SpecificPermission } from "@/shared/types/auth";
 import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { normalizeUssdPhoneNumber } from "@/lib/ussd-admin-client";
 import {
@@ -91,7 +92,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    if (!(await hasSuperAdminServer())) {
+    if (!(await hasPermissionServer(SpecificPermission.UPDATE_CLIENT))) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/fineract/clients/[id]/route.ts
+++ b/app/api/fineract/clients/[id]/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { fetchFineractAPI } from "@/lib/api";
-import { hasSuperAdminServer } from "@/lib/authorization";
+import { hasPermissionServer, hasSuperAdminServer } from "@/lib/authorization";
 import { getSession } from "@/lib/auth";
+import { SpecificPermission } from "@/shared/types/auth";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
 
@@ -28,18 +29,19 @@ export async function GET(
     }
 
     const session = await getSession();
+    const sessionUser = session?.user;
     const tenantSlug = extractTenantSlugFromRequest(request);
     const data = await fetchFineractAPI(`/clients/${clientId}`, {
       authMode: "service",
     });
     const officeScope = resolveOmamaOfficeScope({
       tenantSlug,
-      roles: ((session?.user as any)?.roles || []) as Array<{
+      roles: (sessionUser?.roles ?? []) as Array<{
         name?: string | null;
         disabled?: boolean | null;
       }>,
-      officeId: ((session?.user as any)?.officeId as number | undefined) ?? null,
-      officeName: ((session?.user as any)?.officeName as string | undefined) ?? null,
+      officeId: sessionUser?.officeId ?? null,
+      officeName: sessionUser?.officeName ?? null,
     });
 
     if (officeScope?.officeId && data?.officeId !== officeScope.officeId) {
@@ -90,7 +92,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    if (!(await hasSuperAdminServer())) {
+    if (!(await hasPermissionServer(SpecificPermission.UPDATE_CLIENT))) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/lib/__tests__/client-edit-permission-gate.test.ts
+++ b/lib/__tests__/client-edit-permission-gate.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("client details and edit pages use UPDATE_CLIENT permission for edit access", () => {
+  const detailsPage = readRepoFile("app/(application)/clients/[id]/page.tsx");
+  const editPage = readRepoFile("app/(application)/clients/[id]/edit/page.tsx");
+
+  assert.match(
+    detailsPage,
+    /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
+  );
+  assert.doesNotMatch(detailsPage, /hasSuperAdminServer/);
+
+  assert.match(
+    editPage,
+    /hasPermissionServer\(\s*SpecificPermission\.UPDATE_CLIENT\s*\)/
+  );
+  assert.doesNotMatch(editPage, /hasSuperAdminServer/);
+});
+
+test("client update APIs require UPDATE_CLIENT permission", () => {
+  const clientApiRoute = readRepoFile("app/api/clients/[id]/route.ts");
+  const fineractClientApiRoute = readRepoFile(
+    "app/api/fineract/clients/[id]/route.ts"
+  );
+  const fineractPutHandler = fineractClientApiRoute.match(
+    /export async function PUT[\s\S]*?export async function DELETE/
+  )?.[0];
+
+  assert.match(
+    clientApiRoute,
+    /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
+  );
+  assert.doesNotMatch(clientApiRoute, /hasSuperAdminServer/);
+
+  assert.ok(fineractPutHandler, "expected to find the Fineract client PUT handler");
+  assert.match(
+    fineractPutHandler,
+    /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
+  );
+  assert.doesNotMatch(fineractPutHandler, /hasSuperAdminServer/);
+});


### PR DESCRIPTION
## What changed
- switched the client details page edit gate to use `UPDATE_CLIENT` instead of the super-admin role check
- switched the client edit page `canEditClient` calculation to the same `UPDATE_CLIENT` permission
- updated the client update API routes to enforce `UPDATE_CLIENT` server-side as well
- added a focused regression test covering the page and API permission gates
- cleaned up the typed session access in the Fineract client route while touching that file

## Why
Client edit access was being tied to `SUPER_ADMIN` instead of the actual client update permission. That hid or disabled edit functionality for users who should be allowed to update clients through `UPDATE_CLIENT`.

## Impact
Users with `UPDATE_CLIENT` can now see and use the client edit flow without needing the `SUPER_ADMIN` role. Users without that permission still cannot submit updates.

## Root cause
The client details page, client edit page, and update routes were all computing edit access with `hasSuperAdminServer()` rather than the existing permission-based authorization helper.

## Validation
- `npx tsx --test lib/__tests__/client-edit-permission-gate.test.ts lib/__tests__/client-consolidated-statement-button.test.ts`
- `npx eslint "app/(application)/clients/[id]/page.tsx" "app/(application)/clients/[id]/edit/page.tsx" "app/api/clients/[id]/route.ts" "app/api/fineract/clients/[id]/route.ts" "lib/__tests__/client-edit-permission-gate.test.ts"`
- `git diff --check`
