### PR TITLE
Add tenant-controlled client edit field restrictions

### DIFF
--- a/app/(application)/clients/[id]/edit/components/client-edit-form.tsx
+++ b/app/(application)/clients/[id]/edit/components/client-edit-form.tsx
@@ -125,6 +125,7 @@ type FormDataState = {
 interface ClientEditFormProps {
   clientId: number;
   canEditClient: boolean;
+  canEditRestrictedClientFields: boolean;
 }
 
 function ClientEditFormSkeleton() {
@@ -298,7 +299,11 @@ function isEmailInvalid(email: string) {
   return !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps) {
+export function ClientEditForm({
+  clientId,
+  canEditClient,
+  canEditRestrictedClientFields,
+}: ClientEditFormProps) {
   const router = useRouter();
   const { success: showSuccessToast } = useToast();
   const [client, setClient] = useState<ClientTemplateData | null>(null);
@@ -601,6 +606,16 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
         </Alert>
       )}
 
+      {!canEditRestrictedClientFields && (
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Some sensitive client fields are locked by tenant settings and can
+            only be updated by a Super Admin.
+          </AlertDescription>
+        </Alert>
+      )}
+
       <form onSubmit={handleSubmit}>
         <Card>
           <CardHeader>
@@ -760,6 +775,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                   <Checkbox
                     id="isStaff"
                     checked={formData.isStaff}
+                    disabled={!canEditRestrictedClientFields}
                     onCheckedChange={(checked) =>
                       handleInputChange("isStaff", checked === true)
                     }
@@ -772,6 +788,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                 <Label htmlFor="staffId">Staff</Label>
                 <Select
                   value={formData.staffId || "__none__"}
+                  disabled={!canEditRestrictedClientFields}
                   onValueChange={(value) =>
                     handleInputChange(
                       "staffId",
@@ -802,6 +819,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                   <SearchableSelect
                     options={countryCodeOptions}
                     value={formData.countryCode}
+                    disabled={!canEditRestrictedClientFields}
                     onValueChange={(value) =>
                       handleInputChange("countryCode", value)
                     }
@@ -812,6 +830,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                     id="mobileNo"
                     type="tel"
                     value={formData.mobileNo}
+                    disabled={!canEditRestrictedClientFields}
                     onChange={(e) => handlePhoneInputChange(e.target.value)}
                     className="flex-1"
                   />
@@ -895,6 +914,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                   id="submittedOnDate"
                   type="date"
                   value={formData.submittedOnDate}
+                  disabled={!canEditRestrictedClientFields}
                   onChange={(e) =>
                     handleInputChange("submittedOnDate", e.target.value)
                   }
@@ -910,6 +930,7 @@ export function ClientEditForm({ clientId, canEditClient }: ClientEditFormProps)
                   id="activationDate"
                   type="date"
                   value={formData.activationDate}
+                  disabled={!canEditRestrictedClientFields}
                   onChange={(e) =>
                     handleInputChange("activationDate", e.target.value)
                   }

--- a/app/(application)/clients/[id]/edit/page.tsx
+++ b/app/(application)/clients/[id]/edit/page.tsx
@@ -2,7 +2,12 @@ import { notFound } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { hasPermissionServer } from "@/lib/authorization";
+import {
+  hasPermissionServer,
+  hasSuperAdminServer,
+} from "@/lib/authorization";
+import { isSensitiveClientEditRestrictionEnabled } from "@/lib/client-edit-restrictions";
+import { getTenantFromHeaders } from "@/lib/tenant-service";
 import { SpecificPermission } from "@/shared/types/auth";
 import { ClientEditForm } from "./components/client-edit-form";
 
@@ -20,9 +25,13 @@ export default async function ClientEditPage({ params }: PageProps) {
     notFound();
   }
 
-  const canEditClient = await hasPermissionServer(
-    SpecificPermission.UPDATE_CLIENT
-  );
+  const [canEditClient, isSuperAdmin, tenant] = await Promise.all([
+    hasPermissionServer(SpecificPermission.UPDATE_CLIENT),
+    hasSuperAdminServer(),
+    getTenantFromHeaders(),
+  ]);
+  const canEditRestrictedClientFields =
+    !isSensitiveClientEditRestrictionEnabled(tenant?.settings) || isSuperAdmin;
 
   return (
     <div className="space-y-6">
@@ -53,7 +62,11 @@ export default async function ClientEditPage({ params }: PageProps) {
       </div>
 
       {/* Client Edit Form */}
-      <ClientEditForm clientId={clientId} canEditClient={canEditClient} />
+      <ClientEditForm
+        clientId={clientId}
+        canEditClient={canEditClient}
+        canEditRestrictedClientFields={canEditRestrictedClientFields}
+      />
     </div>
   );
 } 

--- a/app/(application)/organization/features/page.tsx
+++ b/app/(application)/organization/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Card,
   CardContent,
@@ -120,6 +120,13 @@ const FEATURE_CONFIGS: FeatureConfig[] = [
       "On the loan repayment modal, restrict non-exempt users to cash repayments and auto-fill their teller/cashier from their cashier session, blocking submission if they aren't linked to a cashier. Individual users can be exempted from this restriction on the Users page.",
     tag: "New",
   },
+  {
+    key: "restrictSensitiveClientEditFieldsToSuperAdmin",
+    label: "Restrict Sensitive Client Fields",
+    description:
+      "When enabled, only SUPER_ADMIN users can edit sensitive client fields such as staff assignment, mobile number, submitted date, and activation date.",
+    tag: "New",
+  },
 ];
 
 export default function FeaturesSettingsPage() {
@@ -139,22 +146,32 @@ export default function FeaturesSettingsPage() {
   const [collectionReportsStatus, setCollectionReportsStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [collectionReportsError, setCollectionReportsError] = useState<string | null>(null);
 
-  const fetchFeatures = useCallback(async () => {
-    try {
-      const res = await fetch("/api/tenant/features");
-      if (!res.ok) throw new Error("Failed to load features");
-      const data = await res.json();
-      setFeatures(data.features);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    fetchFeatures();
-  }, [fetchFeatures]);
+    let isActive = true;
+
+    async function loadFeatures() {
+      try {
+        const res = await fetch("/api/tenant/features");
+        if (!res.ok) throw new Error("Failed to load features");
+        const data = await res.json();
+        if (!isActive) return;
+        setFeatures(data.features);
+      } catch (err) {
+        if (!isActive) return;
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadFeatures();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
 
   const handleToggle = async (key: keyof TenantFeatures, value: boolean) => {
     if (!features) return;

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
-import { hasPermissionServer } from "@/lib/authorization";
+import {
+  hasPermissionServer,
+  hasSuperAdminServer,
+} from "@/lib/authorization";
+import {
+  isSensitiveClientEditRestrictionEnabled,
+  stripRestrictedClientEditFields,
+} from "@/lib/client-edit-restrictions";
 import {
   formatMobileForFineract,
   resolveCountryDialCodeForPhone,
@@ -103,9 +110,21 @@ export async function PUT(
       return NextResponse.json({ error: "Invalid client ID" }, { status: 400 });
     }
 
+    const [tenant, isSuperAdmin] = await Promise.all([
+      getTenantFromHeaders(),
+      hasSuperAdminServer(),
+    ]);
+    const restrictSensitiveFields =
+      isSensitiveClientEditRestrictionEnabled(tenant?.settings) &&
+      !isSuperAdmin;
+
     const body = await request.json();
-    const outboundBody =
+    let outboundBody =
       typeof body === "object" && body !== null ? { ...body } : body;
+
+    if (restrictSensitiveFields) {
+      outboundBody = stripRestrictedClientEditFields(outboundBody);
+    }
 
     let ussdPhoneSyncWarning: { status: string; message: string } | null =
       null;
@@ -142,7 +161,6 @@ export async function PUT(
           normalizeUssdPhoneNumber(formattedMobileNo);
 
       if (phoneNumberChanged) {
-        const tenant = await getTenantFromHeaders();
         const ussdServiceTenantId = tenant?.ussdServiceTenantId?.trim();
 
         if (ussdServiceTenantId) {

--- a/app/api/fineract/clients/[id]/route.ts
+++ b/app/api/fineract/clients/[id]/route.ts
@@ -2,9 +2,16 @@ import { NextResponse } from "next/server";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 import { fetchFineractAPI } from "@/lib/api";
 import { hasPermissionServer, hasSuperAdminServer } from "@/lib/authorization";
+import {
+  isSensitiveClientEditRestrictionEnabled,
+  stripRestrictedClientEditFields,
+} from "@/lib/client-edit-restrictions";
 import { getSession } from "@/lib/auth";
 import { SpecificPermission } from "@/shared/types/auth";
-import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
+import {
+  extractTenantSlugFromRequest,
+  getTenantBySlug,
+} from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
 
 /**
@@ -98,7 +105,17 @@ export async function PUT(
 
     const { id } = await params;
     const clientId = Number(id);
+    const tenantSlug = extractTenantSlugFromRequest(request);
+    const [tenant, isSuperAdmin] = await Promise.all([
+      getTenantBySlug(tenantSlug),
+      hasSuperAdminServer(),
+    ]);
     const payload = await request.json();
+    const outboundPayload =
+      isSensitiveClientEditRestrictionEnabled(tenant?.settings) &&
+      !isSuperAdmin
+        ? stripRestrictedClientEditFields(payload)
+        : payload;
 
     if (!Number.isFinite(clientId) || clientId <= 0) {
       return NextResponse.json(
@@ -108,7 +125,7 @@ export async function PUT(
     }
 
     const fineractService = await getFineractServiceWithSession();
-    const data = await fineractService.updateClient(clientId, payload);
+    const data = await fineractService.updateClient(clientId, outboundPayload);
 
     return NextResponse.json(data);
   } catch (error: unknown) {

--- a/lib/__tests__/client-edit-permission-gate.test.ts
+++ b/lib/__tests__/client-edit-permission-gate.test.ts
@@ -9,24 +9,62 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
-test("client details and edit pages use UPDATE_CLIENT permission for edit access", () => {
+test("client details page uses UPDATE_CLIENT permission to show edit access", () => {
   const detailsPage = readRepoFile("app/(application)/clients/[id]/page.tsx");
-  const editPage = readRepoFile("app/(application)/clients/[id]/edit/page.tsx");
 
   assert.match(
     detailsPage,
     /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
   );
   assert.doesNotMatch(detailsPage, /hasSuperAdminServer/);
+});
+
+test("client edit page computes restricted field access from the tenant flag and SUPER_ADMIN role", () => {
+  const editPage = readRepoFile("app/(application)/clients/[id]/edit/page.tsx");
 
   assert.match(
     editPage,
     /hasPermissionServer\(\s*SpecificPermission\.UPDATE_CLIENT\s*\)/
   );
-  assert.doesNotMatch(editPage, /hasSuperAdminServer/);
+  assert.match(editPage, /hasSuperAdminServer\(\)/);
+  assert.match(
+    editPage,
+    /isSensitiveClientEditRestrictionEnabled\(tenant\?\.settings\)/
+  );
+  assert.match(editPage, /canEditRestrictedClientFields/);
 });
 
-test("client update APIs require UPDATE_CLIENT permission", () => {
+test("client edit form disables the tenant-restricted sensitive fields", () => {
+  const formSource = readRepoFile(
+    "app/(application)/clients/[id]/edit/components/client-edit-form.tsx"
+  );
+
+  assert.match(formSource, /canEditRestrictedClientFields: boolean/);
+  assert.match(
+    formSource,
+    /id="isStaff"[\s\S]{0,160}disabled=\{!canEditRestrictedClientFields\}/
+  );
+  assert.match(formSource, /<Label htmlFor="staffId">Staff<\/Label>/);
+  assert.match(formSource, /disabled=\{!canEditRestrictedClientFields\}/);
+  assert.match(
+    formSource,
+    /<SearchableSelect[\s\S]{0,220}disabled=\{!canEditRestrictedClientFields\}/
+  );
+  assert.match(
+    formSource,
+    /id="mobileNo"[\s\S]{0,160}disabled=\{!canEditRestrictedClientFields\}/
+  );
+  assert.match(
+    formSource,
+    /id="submittedOnDate"[\s\S]{0,160}disabled=\{!canEditRestrictedClientFields\}/
+  );
+  assert.match(
+    formSource,
+    /id="activationDate"[\s\S]{0,160}disabled=\{!canEditRestrictedClientFields\}/
+  );
+});
+
+test("client update APIs require UPDATE_CLIENT permission and sanitize tenant-restricted fields", () => {
   const clientApiRoute = readRepoFile("app/api/clients/[id]/route.ts");
   const fineractClientApiRoute = readRepoFile(
     "app/api/fineract/clients/[id]/route.ts"
@@ -39,12 +77,22 @@ test("client update APIs require UPDATE_CLIENT permission", () => {
     clientApiRoute,
     /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
   );
-  assert.doesNotMatch(clientApiRoute, /hasSuperAdminServer/);
+  assert.match(clientApiRoute, /hasSuperAdminServer\(\)/);
+  assert.match(
+    clientApiRoute,
+    /isSensitiveClientEditRestrictionEnabled\(tenant\?\.settings\)/
+  );
+  assert.match(clientApiRoute, /stripRestrictedClientEditFields/);
 
   assert.ok(fineractPutHandler, "expected to find the Fineract client PUT handler");
   assert.match(
     fineractPutHandler,
     /hasPermissionServer\(SpecificPermission\.UPDATE_CLIENT\)/
   );
-  assert.doesNotMatch(fineractPutHandler, /hasSuperAdminServer/);
+  assert.match(fineractPutHandler, /hasSuperAdminServer\(\)/);
+  assert.match(
+    fineractPutHandler,
+    /isSensitiveClientEditRestrictionEnabled\(tenant\?\.settings\)/
+  );
+  assert.match(fineractPutHandler, /stripRestrictedClientEditFields/);
 });

--- a/lib/__tests__/client-edit-restrictions.test.ts
+++ b/lib/__tests__/client-edit-restrictions.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RESTRICTED_CLIENT_EDIT_FIELDS,
+  isSensitiveClientEditRestrictionEnabled,
+  stripRestrictedClientEditFields,
+} from "../client-edit-restrictions";
+
+test("sensitive client edit restriction defaults to false", () => {
+  assert.equal(isSensitiveClientEditRestrictionEnabled(null), false);
+});
+
+test("sensitive client edit restriction reads the tenant feature flag", () => {
+  assert.equal(
+    isSensitiveClientEditRestrictionEnabled({
+      features: { restrictSensitiveClientEditFieldsToSuperAdmin: true },
+    }),
+    true
+  );
+});
+
+test("stripRestrictedClientEditFields removes the sensitive client edit fields only", () => {
+  const payload = {
+    firstname: "ELIAH",
+    lastname: "NYIRENDA",
+    isStaff: true,
+    staffId: 77,
+    mobileNo: "+260967898505",
+    submittedOnDate: "2025-12-17",
+    activationDate: "2025-12-18",
+    emailAddress: "eliah@goodfellow.co.zm",
+  };
+
+  const sanitized = stripRestrictedClientEditFields(payload) as Record<
+    string,
+    unknown
+  >;
+
+  for (const field of RESTRICTED_CLIENT_EDIT_FIELDS) {
+    assert.equal(field in sanitized, false, `expected ${field} to be removed`);
+  }
+
+  assert.equal(sanitized.firstname, payload.firstname);
+  assert.equal(sanitized.lastname, payload.lastname);
+  assert.equal(sanitized.emailAddress, payload.emailAddress);
+});

--- a/lib/client-edit-restrictions.ts
+++ b/lib/client-edit-restrictions.ts
@@ -1,0 +1,32 @@
+import { getTenantFeatures } from "@/lib/tenant-features";
+
+export const RESTRICTED_CLIENT_EDIT_FIELDS = [
+  "isStaff",
+  "staffId",
+  "mobileNo",
+  "submittedOnDate",
+  "activationDate",
+] as const;
+
+export function isSensitiveClientEditRestrictionEnabled(
+  settings: unknown
+): boolean {
+  return (
+    getTenantFeatures(settings).restrictSensitiveClientEditFieldsToSuperAdmin ===
+    true
+  );
+}
+
+export function stripRestrictedClientEditFields(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+
+  const sanitizedPayload = { ...(payload as Record<string, unknown>) };
+
+  for (const field of RESTRICTED_CLIENT_EDIT_FIELDS) {
+    delete sanitizedPayload[field];
+  }
+
+  return sanitizedPayload;
+}

--- a/shared/types/tenant.test.ts
+++ b/shared/types/tenant.test.ts
@@ -39,6 +39,22 @@ function run() {
     false,
     "autoResolveRepaymentCashier defaults to false"
   );
+
+  assert.equal(
+    getTenantFeatures({
+      settings: {
+        features: { restrictSensitiveClientEditFieldsToSuperAdmin: true },
+      },
+    }).restrictSensitiveClientEditFieldsToSuperAdmin,
+    true,
+    "surfaces the new restricted client field flag when set"
+  );
+
+  assert.equal(
+    getTenantFeatures(null).restrictSensitiveClientEditFieldsToSuperAdmin,
+    false,
+    "restrictSensitiveClientEditFieldsToSuperAdmin defaults to false"
+  );
 }
 
 run();

--- a/shared/types/tenant.ts
+++ b/shared/types/tenant.ts
@@ -34,6 +34,8 @@ export interface TenantFeatures {
   topupLoanBalanceExcludeUnrealizedInterests: boolean;
   /** Restrict non-exempt users to cash-only loan repayments, auto-resolving their teller/cashier from their cashier session (blocking submission if unresolvable), unless the user is individually exempted */
   autoResolveRepaymentCashier: boolean;
+  /** When true, only SUPER_ADMIN users may edit sensitive client fields on the client edit form. */
+  restrictSensitiveClientEditFieldsToSuperAdmin: boolean;
   /** When true, MFA is required for tenant logins. Missing or false disables MFA. */
   usesMFA?: boolean;
   /** Enabled MFA delivery channels for the tenant. */
@@ -144,6 +146,7 @@ export const DEFAULT_FEATURES: TenantFeatures = {
   officeScopedAdminLeadsDashboard: false,
   topupLoanBalanceExcludeUnrealizedInterests: false,
   autoResolveRepaymentCashier: false,
+  restrictSensitiveClientEditFieldsToSuperAdmin: false,
 };
 
 /**


### PR DESCRIPTION
## What changed
- added a tenant feature flag: `restrictSensitiveClientEditFieldsToSuperAdmin`
- exposed that flag on the tenant Features page so it can be toggled per tenant
- kept `UPDATE_CLIENT` as the baseline client edit permission
- when the tenant flag is enabled, restricted the following client edit fields to `SUPER_ADMIN` only:
  - `Is staff?`
  - `Staff`
  - `Mobile No`
  - `Submitted On`
  - `Activated On`
- disabled those fields in the client edit form for non-super-admin users when the flag is enabled
- enforced the same restriction in both client update API routes by stripping the restricted fields server-side for non-super-admin users
- added focused tests for tenant defaults, restricted field stripping, UI gating, and API sanitizing

## Why
The client requested a tenant-configurable way to lock sensitive client fields so normal users with `UPDATE_CLIENT` can still edit clients generally, while `SUPER_ADMIN` remains the only role allowed to change those specific fields when the tenant chooses to enforce that restriction.

## Impact
- default behavior is unchanged: if the tenant flag is missing or false, users with `UPDATE_CLIENT` can still edit all client fields
- when the flag is true, only `SUPER_ADMIN` can update the restricted fields
- non-super-admin users can still edit the rest of the client form as long as they have `UPDATE_CLIENT`

## Validation
- `npx tsx shared/types/tenant.test.ts`
- `npx tsx --test lib/__tests__/client-edit-restrictions.test.ts lib/__tests__/client-edit-permission-gate.test.ts lib/__tests__/client-consolidated-statement-button.test.ts`
- `npx eslint "shared/types/tenant.ts" "app/(application)/organization/features/page.tsx" "app/(application)/clients/[id]/edit/page.tsx" "app/(application)/clients/[id]/edit/components/client-edit-form.tsx" "app/api/clients/[id]/route.ts" "app/api/fineract/clients/[id]/route.ts" "lib/client-edit-restrictions.ts" "lib/__tests__/client-edit-restrictions.test.ts" "lib/__tests__/client-edit-permission-gate.test.ts"`
- `git diff --check`
