### PR TITLE
Improve Fineract error messages in client flows

### DIFF
--- a/app/api/fineract/accountingrules/[id]/route.ts
+++ b/app/api/fineract/accountingrules/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function GET(
@@ -10,10 +11,7 @@ export async function GET(
     return NextResponse.json(accountingRule);
   } catch (error: any) {
     console.error('Error fetching accounting rule:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to fetch accounting rule' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -30,10 +28,7 @@ export async function PUT(
     return NextResponse.json(accountingRule);
   } catch (error: any) {
     console.error('Error updating accounting rule:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to update accounting rule' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -48,9 +43,6 @@ export async function DELETE(
     return NextResponse.json(result);
   } catch (error: any) {
     console.error('Error deleting accounting rule:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to delete accounting rule' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 } 

--- a/app/api/fineract/accountingrules/route.ts
+++ b/app/api/fineract/accountingrules/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function GET(request: NextRequest) {
@@ -26,10 +27,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(accountingRules);
   } catch (error: any) {
     console.error('Error fetching accounting rules:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to fetch accounting rules' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -43,9 +41,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(accountingRule, { status: 201 });
   } catch (error: any) {
     console.error('Error creating accounting rule:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to create accounting rule' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 } 

--- a/app/api/fineract/accountingrules/template/route.ts
+++ b/app/api/fineract/accountingrules/template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function GET(request: NextRequest) {
@@ -7,9 +8,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(template);
   } catch (error: any) {
     console.error('Error fetching accounting rules template:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to fetch accounting rules template' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 } 

--- a/app/api/fineract/accounttransfers/route.ts
+++ b/app/api/fineract/accounttransfers/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(request: NextRequest) {
@@ -13,12 +14,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating account transfer:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create account transfer" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/accounttransfers/template/route.ts
+++ b/app/api/fineract/accounttransfers/template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(request: NextRequest) {
@@ -22,12 +23,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching account transfer template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch account transfer template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/chart-of-accounts/route.ts
+++ b/app/api/fineract/chart-of-accounts/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -12,9 +13,6 @@ export async function GET() {
     return NextResponse.json({ chartAccounts: data });
   } catch (error: any) {
     console.error('Error fetching Chart of Accounts:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/client_identifiers/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/client_identifiers/[id]/documents/[documentId]/attachment/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getFineractTenantId } from "@/lib/api";
 import { toInlineContentDisposition } from "@/lib/document-viewing";
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from "@/lib/fineract-route-error";
 
 export async function GET(
   request: NextRequest,
@@ -86,15 +90,29 @@ export async function GET(
     }
 
     if (!response.ok) {
+      const errorResponse = createFineractErrorResponsePayload(
+        {
+          status: response.status,
+          errorData: {
+            defaultUserMessage: "Failed to download document",
+            developerMessage: response.statusText,
+          },
+          response: { statusText: response.statusText },
+        },
+        {
+          action: "download",
+          resource: "document",
+        }
+      );
+
       console.error(
         "Failed to download identifier document:",
         response.status,
         response.statusText
       );
-      return NextResponse.json(
-        { error: "Failed to download document" },
-        { status: response.status }
-      );
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     // Get the file data
@@ -118,9 +136,9 @@ export async function GET(
     });
   } catch (error) {
     console.error("Error downloading identifier document:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "download",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/client_identifiers/[id]/documents/route.ts
+++ b/app/api/fineract/client_identifiers/[id]/documents/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getFineractTenantId } from "@/lib/api";
-import { getFineractErrorMessage, normalizeFineractErrorPayload } from "@/lib/fineract-error";
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from "@/lib/fineract-route-error";
 
 /**
  * GET /api/fineract/client_identifiers/[id]/documents
@@ -89,31 +92,31 @@ export async function GET(
     }
 
     if (!response.ok) {
-      const errorData = normalizeFineractErrorPayload(await response.json().catch(() => ({})), {
-        status: response.status,
-        statusText: response.statusText,
-      });
-
-      return NextResponse.json(
+      const errorResponse = createFineractErrorResponsePayload(
         {
-          error: errorData.defaultUserMessage || "Failed to fetch documents",
-          details: errorData,
+          status: response.status,
+          errorData: await response.json().catch(() => ({})),
+          response: { statusText: response.statusText },
         },
-        { status: response.status }
+        {
+          action: "load",
+          resource: "identifier documents",
+        }
       );
+
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching identifier documents:", error);
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "identifier documents",
+    });
   }
 }
 
@@ -248,37 +251,37 @@ export async function POST(
     }
 
     if (!response.ok) {
-      const errorData = normalizeFineractErrorPayload(await response.json().catch(() => ({})), {
-        status: response.status,
-        statusText: response.statusText,
-      });
+      const errorResponse = createFineractErrorResponsePayload(
+        {
+          status: response.status,
+          errorData: await response.json().catch(() => ({})),
+          response: { statusText: response.statusText },
+        },
+        {
+          action: "upload",
+          resource: "document",
+        }
+      );
 
       console.error(
         "Failed to upload document to identifier:",
         response.status,
         response.statusText,
-        errorData
+        errorResponse.body.details
       );
 
-      return NextResponse.json(
-        {
-          error: errorData.defaultUserMessage || "Failed to upload document",
-          details: errorData,
-        },
-        { status: response.status }
-      );
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error uploading document to identifier:", error);
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "upload",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/client_identifiers/[id]/documents/route.ts
+++ b/app/api/fineract/client_identifiers/[id]/documents/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getFineractTenantId } from "@/lib/api";
+import { getFineractErrorMessage, normalizeFineractErrorPayload } from "@/lib/fineract-error";
 
 /**
  * GET /api/fineract/client_identifiers/[id]/documents
@@ -88,22 +89,14 @@ export async function GET(
     }
 
     if (!response.ok) {
-      let errorData;
-      try {
-        errorData = await response.json();
-      } catch (e) {
-        errorData = {
-          defaultUserMessage: `HTTP ${response.status}: ${response.statusText}`,
-          developerMessage: `HTTP ${response.status}: ${response.statusText}`,
-        };
-      }
+      const errorData = normalizeFineractErrorPayload(await response.json().catch(() => ({})), {
+        status: response.status,
+        statusText: response.statusText,
+      });
 
       return NextResponse.json(
         {
-          error:
-            errorData.defaultUserMessage ||
-            errorData.developerMessage ||
-            "Failed to fetch documents",
+          error: errorData.defaultUserMessage || "Failed to fetch documents",
           details: errorData,
         },
         { status: response.status }
@@ -116,9 +109,10 @@ export async function GET(
     console.error("Error fetching identifier documents:", error);
     return NextResponse.json(
       {
-        error: error?.message || "Internal server error",
+        error: getFineractErrorMessage(error),
+        details: error?.errorData || null,
       },
-      { status: 500 }
+      { status: error?.status || 500 }
     );
   }
 }
@@ -254,15 +248,10 @@ export async function POST(
     }
 
     if (!response.ok) {
-      let errorData;
-      try {
-        errorData = await response.json();
-      } catch (e) {
-        errorData = {
-          defaultUserMessage: `HTTP ${response.status}: ${response.statusText}`,
-          developerMessage: `HTTP ${response.status}: ${response.statusText}`,
-        };
-      }
+      const errorData = normalizeFineractErrorPayload(await response.json().catch(() => ({})), {
+        status: response.status,
+        statusText: response.statusText,
+      });
 
       console.error(
         "Failed to upload document to identifier:",
@@ -273,10 +262,7 @@ export async function POST(
 
       return NextResponse.json(
         {
-          error:
-            errorData.defaultUserMessage ||
-            errorData.developerMessage ||
-            "Failed to upload document",
+          error: errorData.defaultUserMessage || "Failed to upload document",
           details: errorData,
         },
         { status: response.status }
@@ -289,9 +275,10 @@ export async function POST(
     console.error("Error uploading document to identifier:", error);
     return NextResponse.json(
       {
-        error: error?.message || "Internal server error",
+        error: getFineractErrorMessage(error),
+        details: error?.errorData || null,
       },
-      { status: 500 }
+      { status: error?.status || 500 }
     );
   }
 }

--- a/app/api/fineract/clients/[id]/addresses/[addressId]/route.ts
+++ b/app/api/fineract/clients/[id]/addresses/[addressId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * PUT /api/fineract/clients/[id]/addresses/[addressId]
@@ -80,16 +81,10 @@ export async function PUT(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error updating client address:", error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to update client address",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "update",
+      resource: "address",
+    });
   }
 }
 
@@ -115,15 +110,9 @@ export async function DELETE(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error deleting client address:", error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to delete client address",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "delete",
+      resource: "address",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/addresses/route.ts
+++ b/app/api/fineract/clients/[id]/addresses/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * GET /api/fineract/clients/[id]/addresses
@@ -22,16 +23,10 @@ export async function GET(
     if (error?.status === 404) {
       return NextResponse.json([]);
     }
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to fetch client addresses",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "client addresses",
+    });
   }
 }
 
@@ -109,15 +104,9 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating client address:", error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to create client address",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "create",
+      resource: "address",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/clients/[id]/documents/[documentId]/attachment/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getFineractTenantId } from "@/lib/api";
 import { getSearchAuthToken } from "@/lib/fineract-search-auth";
 import { toInlineContentDisposition } from "@/lib/document-viewing";
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from "@/lib/fineract-route-error";
 
 export async function GET(
   request: NextRequest,
@@ -76,15 +80,29 @@ export async function GET(
     }
 
     if (!response.ok) {
+      const errorResponse = createFineractErrorResponsePayload(
+        {
+          status: response.status,
+          errorData: {
+            defaultUserMessage: "Failed to download document",
+            developerMessage: response.statusText,
+          },
+          response: { statusText: response.statusText },
+        },
+        {
+          action: "download",
+          resource: "document",
+        }
+      );
+
       console.error(
         "Failed to download document:",
         response.status,
         response.statusText
       );
-      return NextResponse.json(
-        { error: "Failed to download document" },
-        { status: response.status }
-      );
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     // Get the file data
@@ -108,9 +126,9 @@ export async function GET(
     });
   } catch (error) {
     console.error("Error downloading document:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "download",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/documents/route.ts
+++ b/app/api/fineract/clients/[id]/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
+import { getFineractErrorMessage } from "@/lib/fineract-error";
 import {
   extractTenantSlugFromRequest,
   getTenantBySlug,
@@ -131,6 +132,21 @@ export async function GET(
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     console.error("Error fetching client documents:", error);
+    const fineractError = error as {
+      status?: number;
+      errorData?: unknown;
+    };
+
+    if (fineractError.status && fineractError.errorData) {
+      return NextResponse.json(
+        {
+          error: getFineractErrorMessage(error),
+          details: fineractError.errorData,
+        },
+        { status: fineractError.status }
+      );
+    }
+
     return NextResponse.json(
       { error: message },
       { status: 500 }
@@ -258,10 +274,10 @@ export async function POST(
 
     return NextResponse.json(
       {
-        error:
-          error instanceof Error ? error.message : "Failed to upload document",
+        error: getFineractErrorMessage(error),
+        details: fineractError.errorData || null,
       },
-      { status: 500 }
+      { status: fineractError.status || 500 }
     );
   }
 }

--- a/app/api/fineract/clients/[id]/documents/route.ts
+++ b/app/api/fineract/clients/[id]/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
-import { getFineractErrorMessage } from "@/lib/fineract-error";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import {
   extractTenantSlugFromRequest,
   getTenantBySlug,
@@ -130,27 +130,11 @@ export async function GET(
 
     return NextResponse.json(data);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
     console.error("Error fetching client documents:", error);
-    const fineractError = error as {
-      status?: number;
-      errorData?: unknown;
-    };
-
-    if (fineractError.status && fineractError.errorData) {
-      return NextResponse.json(
-        {
-          error: getFineractErrorMessage(error),
-          details: fineractError.errorData,
-        },
-        { status: fineractError.status }
-      );
-    }
-
-    return NextResponse.json(
-      { error: message },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "client documents",
+    });
   }
 }
 
@@ -259,25 +243,9 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error uploading client document:", error);
-
-    // If it's a Fineract API error with status code, preserve it
-    const fineractError = error as {
-      status?: number;
-      errorData?: unknown;
-    };
-
-    if (fineractError.status && fineractError.errorData) {
-      return NextResponse.json(fineractError.errorData, {
-        status: fineractError.status,
-      });
-    }
-
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: fineractError.errorData || null,
-      },
-      { status: fineractError.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "upload",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/identifiers/[identifierId]/route.ts
+++ b/app/api/fineract/clients/[id]/identifiers/[identifierId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * DELETE /api/fineract/clients/[id]/identifiers/[identifierId]
@@ -20,36 +21,9 @@ export async function DELETE(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error deleting client identifier:", error);
-
-    // Extract specific error message from Fineract response
-    let errorMessage = "Failed to delete identifier";
-
-    if (error?.errorData) {
-      if (
-        error.errorData.errors &&
-        Array.isArray(error.errorData.errors) &&
-        error.errorData.errors.length > 0
-      ) {
-        errorMessage =
-          error.errorData.errors[0].defaultUserMessage ||
-          error.errorData.errors[0].developerMessage ||
-          errorMessage;
-      } else if (error.errorData.defaultUserMessage) {
-        errorMessage = error.errorData.defaultUserMessage;
-      } else if (error.errorData.developerMessage) {
-        errorMessage = error.errorData.developerMessage;
-      }
-    } else if (error?.message) {
-      errorMessage = error.message;
-    }
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "delete",
+      resource: "client identifier",
+    });
   }
 }
-

--- a/app/api/fineract/clients/[id]/identifiers/route.ts
+++ b/app/api/fineract/clients/[id]/identifiers/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -17,16 +18,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching client identifiers:", error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to fetch identifiers",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -51,36 +43,9 @@ export async function POST(
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error("Error creating client identifier:", error);
-
-    // Extract specific error message from Fineract response
-    let errorMessage = "Failed to create identifier";
-
-    if (error?.errorData) {
-      // Check for errors array with specific messages
-      if (
-        error.errorData.errors &&
-        Array.isArray(error.errorData.errors) &&
-        error.errorData.errors.length > 0
-      ) {
-        errorMessage =
-          error.errorData.errors[0].defaultUserMessage ||
-          error.errorData.errors[0].developerMessage ||
-          errorMessage;
-      } else if (error.errorData.defaultUserMessage) {
-        errorMessage = error.errorData.defaultUserMessage;
-      } else if (error.errorData.developerMessage) {
-        errorMessage = error.errorData.developerMessage;
-      }
-    } else if (error?.message) {
-      errorMessage = error.message;
-    }
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "create",
+      resource: "client identifier",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/identifiers/template/route.ts
+++ b/app/api/fineract/clients/[id]/identifiers/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -27,15 +28,6 @@ export async function GET(
       message: error?.message,
       errorData: error?.errorData,
     });
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to fetch identifiers template",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/clients/[id]/images/route.ts
+++ b/app/api/fineract/clients/[id]/images/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { getAccessToken } from "@/lib/api";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
 import { getSearchAuthToken } from "@/lib/fineract-search-auth";
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from "@/lib/fineract-route-error";
 
 const baseUrl = process.env.FINERACT_BASE_URL || "http://10.10.0.143:8443";
 
@@ -57,38 +61,31 @@ export async function POST(
     }
 
     if (!response.ok) {
-      let errorData;
-      try {
-        errorData = await response.json();
-      } catch (e) {
-        errorData = {
-          defaultUserMessage: `HTTP ${response.status}: ${response.statusText}`,
-          developerMessage: `HTTP ${response.status}: ${response.statusText}`,
-        };
-      }
-
-      return NextResponse.json(
+      const errorResponse = createFineractErrorResponsePayload(
         {
-          error:
-            errorData.defaultUserMessage ||
-            errorData.developerMessage ||
-            "Failed to upload image",
-          details: errorData,
+          status: response.status,
+          errorData: await response.json().catch(() => ({})),
+          response: { statusText: response.statusText },
         },
-        { status: response.status }
+        {
+          action: "upload",
+          resource: "image",
+        }
       );
+
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error uploading client image:", error);
-    return NextResponse.json(
-      {
-        error: error?.message || "Failed to upload image",
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "upload",
+      resource: "image",
+    });
   }
 }
 
@@ -148,25 +145,20 @@ export async function GET(
       if (response.status === 404) {
         return NextResponse.json(null);
       }
-      let errorData;
-      try {
-        errorData = await response.json();
-      } catch (e) {
-        errorData = {
-          defaultUserMessage: `HTTP ${response.status}: ${response.statusText}`,
-          developerMessage: `HTTP ${response.status}: ${response.statusText}`,
-        };
-      }
-      return NextResponse.json(
+      const errorResponse = createFineractErrorResponsePayload(
         {
-          error:
-            errorData.defaultUserMessage ||
-            errorData.developerMessage ||
-            "Failed to fetch client images",
-          details: errorData,
+          status: response.status,
+          errorData: await response.json().catch(() => ({})),
+          response: { statusText: response.statusText },
         },
-        { status: response.status }
+        {
+          action: "load",
+          resource: "client images",
+        }
       );
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     // Fineract returns the image as a base64 string or JSON
@@ -184,11 +176,9 @@ export async function GET(
     if (error?.status === 404) {
       return NextResponse.json(null);
     }
-    return NextResponse.json(
-      {
-        error: error?.message || "Failed to fetch client images",
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "client images",
+    });
   }
 }

--- a/app/api/fineract/clients/[id]/loans/route.ts
+++ b/app/api/fineract/clients/[id]/loans/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -54,9 +55,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching client loans:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/clients/[id]/route.ts
+++ b/app/api/fineract/clients/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   getTenantBySlug,
 } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
+import { getFineractErrorMessage } from "@/lib/fineract-error";
 
 /**
  * GET /api/fineract/clients/[id]
@@ -74,10 +75,7 @@ export async function GET(
       errorData?: { defaultUserMessage?: string };
       status?: number;
     };
-    const errorMessage =
-      errorObj?.message ||
-      errorObj?.errorData?.defaultUserMessage ||
-      "Unknown error";
+    const errorMessage = getFineractErrorMessage(errorObj);
     const statusCode = errorObj?.status || 500;
 
     return NextResponse.json(
@@ -137,10 +135,7 @@ export async function PUT(
       errorData?: { defaultUserMessage?: string };
       status?: number;
     };
-    const errorMessage =
-      errorObj?.message ||
-      errorObj?.errorData?.defaultUserMessage ||
-      "Unknown error";
+    const errorMessage = getFineractErrorMessage(errorObj);
     const statusCode = errorObj?.status || 500;
 
     return NextResponse.json(
@@ -189,10 +184,7 @@ export async function DELETE(
       errorData?: { defaultUserMessage?: string };
       status?: number;
     };
-    const errorMessage =
-      errorObj?.message ||
-      errorObj?.errorData?.defaultUserMessage ||
-      "Unknown error";
+    const errorMessage = getFineractErrorMessage(errorObj);
     const statusCode = errorObj?.status || 500;
 
     return NextResponse.json(

--- a/app/api/fineract/clients/[id]/route.ts
+++ b/app/api/fineract/clients/[id]/route.ts
@@ -13,7 +13,7 @@ import {
   getTenantBySlug,
 } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
-import { getFineractErrorMessage } from "@/lib/fineract-error";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * GET /api/fineract/clients/[id]
@@ -68,23 +68,10 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error("Error fetching client details:", error);
-
-    // Better error handling for different error types
-    const errorObj = error as {
-      message?: string;
-      errorData?: { defaultUserMessage?: string };
-      status?: number;
-    };
-    const errorMessage = getFineractErrorMessage(errorObj);
-    const statusCode = errorObj?.status || 500;
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: statusCode }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "client details",
+    });
   }
 }
 
@@ -128,23 +115,10 @@ export async function PUT(
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error("Error updating client:", error);
-
-    // Better error handling for different error types
-    const errorObj = error as {
-      message?: string;
-      errorData?: { defaultUserMessage?: string };
-      status?: number;
-    };
-    const errorMessage = getFineractErrorMessage(errorObj);
-    const statusCode = errorObj?.status || 500;
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: statusCode }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "update",
+      resource: "client",
+    });
   }
 }
 
@@ -177,22 +151,9 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (error: unknown) {
     console.error("Error deleting client:", error);
-
-    // Better error handling for different error types
-    const errorObj = error as {
-      message?: string;
-      errorData?: { defaultUserMessage?: string };
-      status?: number;
-    };
-    const errorMessage = getFineractErrorMessage(errorObj);
-    const statusCode = errorObj?.status || 500;
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: statusCode }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "delete",
+      resource: "client",
+    });
   }
 }

--- a/app/api/fineract/clients/addresses/template/route.ts
+++ b/app/api/fineract/clients/addresses/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -14,15 +15,6 @@ export async function GET(request: Request) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching address template:", error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to fetch address template",
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/clients/external-id/route.ts
+++ b/app/api/fineract/clients/external-id/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -164,9 +165,6 @@ export async function POST(request: Request) {
       );
     }
 
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/clients/route.ts
+++ b/app/api/fineract/clients/route.ts
@@ -5,7 +5,7 @@ import {
 } from "@/lib/fineract-api";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
 import { getSession } from "@/lib/auth";
-import { getFineractErrorMessage } from "@/lib/fineract-error";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
 import {
@@ -255,17 +255,10 @@ export async function GET(request: Request) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching clients:", error);
-
-    const errorMessage = getFineractErrorMessage(error);
-    const statusCode = error?.status || 500;
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: statusCode }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "clients",
+    });
   }
 }
 
@@ -284,16 +277,9 @@ export async function POST(request: Request) {
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error("Error creating client:", error);
-
-    const errorMessage = getFineractErrorMessage(error);
-    const statusCode = error?.status || 500;
-
-    return NextResponse.json(
-      {
-        error: errorMessage,
-        details: error?.errorData || null,
-      },
-      { status: statusCode }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "create",
+      resource: "client",
+    });
   }
 }

--- a/app/api/fineract/clients/route.ts
+++ b/app/api/fineract/clients/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
-import { getFineractService } from "@/lib/fineract-api";
+import {
+  getFineractService,
+  getFineractServiceWithSession,
+} from "@/lib/fineract-api";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
 import { getSession } from "@/lib/auth";
+import { getFineractErrorMessage } from "@/lib/fineract-error";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
 import { resolveOmamaOfficeScope } from "@/lib/omama-office-scope";
 import {
@@ -252,9 +256,7 @@ export async function GET(request: Request) {
   } catch (error: any) {
     console.error("Error fetching clients:", error);
 
-    // Better error handling for different error types
-    const errorMessage =
-      error?.message || error?.errorData?.defaultUserMessage || "Unknown error";
+    const errorMessage = getFineractErrorMessage(error);
     const statusCode = error?.status || 500;
 
     return NextResponse.json(
@@ -283,9 +285,7 @@ export async function POST(request: Request) {
   } catch (error: any) {
     console.error("Error creating client:", error);
 
-    // Better error handling for different error types
-    const errorMessage =
-      error?.message || error?.errorData?.defaultUserMessage || "Unknown error";
+    const errorMessage = getFineractErrorMessage(error);
     const statusCode = error?.status || 500;
 
     return NextResponse.json(

--- a/app/api/fineract/clients/search-v2/route.ts
+++ b/app/api/fineract/clients/search-v2/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractSearch } from '@/lib/fineract-search-auth';
 import { ClientSearchRequest, ClientSearchResponse } from '@/shared/types/client';
 
@@ -46,9 +47,6 @@ export async function POST(request: Request) {
       );
     }
     
-    return NextResponse.json(
-      { error: error.message || 'Unknown error occurred during client search' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/clients/search/route.ts
+++ b/app/api/fineract/clients/search/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractSearch } from '@/lib/fineract-search-auth';
 
 /**
@@ -43,9 +44,6 @@ export async function POST(request: Request) {
       );
     }
     
-    return NextResponse.json(
-      { error: error.message || 'Unknown error occurred during client search' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/codes/[codeName]/codevalues/[valueId]/route.ts
+++ b/app/api/fineract/codes/[codeName]/codevalues/[valueId]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -40,10 +41,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error(`Error fetching code value:`, error);
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch code value" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -82,10 +80,7 @@ export async function PUT(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error(`Error updating code value:`, error);
-    return NextResponse.json(
-      { error: error.message || "Failed to update code value" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -115,10 +110,7 @@ export async function DELETE(
     return NextResponse.json({ success: true, ...data });
   } catch (error: any) {
     console.error(`Error deleting code value:`, error);
-    return NextResponse.json(
-      { error: error.message || "Failed to delete code value" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 

--- a/app/api/fineract/codes/[codeName]/codevalues/route.ts
+++ b/app/api/fineract/codes/[codeName]/codevalues/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -50,10 +51,7 @@ export async function GET(
     return NextResponse.json(filteredValues);
   } catch (error: any) {
     console.error(`Error fetching code values for ${(await params).codeName}:`, error);
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch code values" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -113,18 +111,6 @@ export async function POST(
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error(`Error creating code value for ${codeName}:`, error);
-
-    // Handle specific error cases
-    if (error.status === 400) {
-      return NextResponse.json(
-        { error: error.message || "Invalid request data" },
-        { status: 400 }
-      );
-    }
-
-    return NextResponse.json(
-      { error: error.message || "Failed to create code value" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/currencies/route.ts
+++ b/app/api/fineract/currencies/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * GET /api/fineract/currencies
@@ -11,6 +12,6 @@ export async function GET() {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching currencies:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/dashboard/route.ts
+++ b/app/api/fineract/dashboard/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { getFineractServiceWithSession } from "@/lib/fineract-api";
 
 /**
@@ -137,9 +138,6 @@ export async function GET(request: Request) {
     return NextResponse.json(dashboardData);
   } catch (error: any) {
     console.error("Error fetching dashboard data:", error);
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/datatables/[name]/[id]/route.ts
+++ b/app/api/fineract/datatables/[name]/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { getFineractErrorMessage } from "@/lib/fineract-error";
 
 // GET /api/fineract/datatables/[name]/[id]?genericResultSet=true
 export async function GET(
@@ -22,7 +23,10 @@ export async function GET(
     });
   } catch (error: any) {
     return NextResponse.json(
-      { error: error?.message || "Failed to fetch datatable data" },
+      {
+        error: getFineractErrorMessage(error),
+        details: error?.errorData || null,
+      },
       { status: error?.status || 500 }
     );
   }
@@ -88,10 +92,7 @@ export async function PUT(
     console.error("Error updating datatable:", error);
     return NextResponse.json(
       {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to update datatable entry",
+        error: getFineractErrorMessage(error),
         details: error?.errorData || null,
       },
       { status: error?.status || 500 }
@@ -138,10 +139,7 @@ export async function POST(
     console.error("Error creating datatable entry:", error);
     return NextResponse.json(
       {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          "Failed to create datatable entry",
+        error: getFineractErrorMessage(error),
         details: error?.errorData || null,
       },
       { status: error?.status || 500 }

--- a/app/api/fineract/datatables/[name]/[id]/route.ts
+++ b/app/api/fineract/datatables/[name]/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
-import { getFineractErrorMessage } from "@/lib/fineract-error";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 // GET /api/fineract/datatables/[name]/[id]?genericResultSet=true
 export async function GET(
@@ -22,13 +22,10 @@ export async function GET(
       headers: { "Cache-Control": "no-store" },
     });
   } catch (error: any) {
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "additional details",
+    });
   }
 }
 
@@ -90,13 +87,10 @@ export async function PUT(
     return NextResponse.json(result);
   } catch (error: any) {
     console.error("Error updating datatable:", error);
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "update",
+      resource: "additional details",
+    });
   }
 }
 
@@ -137,12 +131,9 @@ export async function POST(
     return NextResponse.json(result, { status: 201 });
   } catch (error: any) {
     console.error("Error creating datatable entry:", error);
-    return NextResponse.json(
-      {
-        error: getFineractErrorMessage(error),
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "create",
+      resource: "additional details",
+    });
   }
 }

--- a/app/api/fineract/datatables/route.ts
+++ b/app/api/fineract/datatables/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 // GET /api/fineract/datatables?apptable=m_client
@@ -10,10 +11,7 @@ export async function GET(request: Request) {
     const data = await fetchFineractAPI(`/datatables?${query.toString()}`);
     return NextResponse.json(data);
   } catch (error: any) {
-    return NextResponse.json(
-      { error: error?.message || 'Failed to fetch datatables' },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 

--- a/app/api/fineract/external-asset-owners/transfers/loans/[id]/sale/route.ts
+++ b/app/api/fineract/external-asset-owners/transfers/loans/[id]/sale/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -28,18 +29,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error selling loan:", error);
-    
-    // Return the actual error details from Fineract
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        { error: error.errorData },
-        { status: error.status }
-      );
-    }
-
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/fieldconfiguration/[entity]/route.ts
+++ b/app/api/fineract/fieldconfiguration/[entity]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -15,16 +16,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error(`Error fetching field configuration for ${entity}:`, error);
-    return NextResponse.json(
-      {
-        error:
-          error?.message ||
-          error?.errorData?.defaultUserMessage ||
-          `Failed to fetch field configuration for ${entity}`,
-        details: error?.errorData || null,
-      },
-      { status: error?.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 

--- a/app/api/fineract/glaccounts/[id]/balance/route.ts
+++ b/app/api/fineract/glaccounts/[id]/balance/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 import { getOrgDefaultCurrencyCode } from "@/lib/currency-utils";
 
@@ -45,9 +46,6 @@ export async function GET(
     });
   } catch (error: any) {
     console.error("Error fetching GL account balance:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch GL account balance" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/glaccounts/[id]/route.ts
+++ b/app/api/fineract/glaccounts/[id]/route.ts
@@ -2,16 +2,25 @@
 
 import { NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const resolvedParams = await params;
+  try {
+    const resolvedParams = await params;
 
-  // Preserve the ?template=true (or any other) querystring
-  const { search } = new URL(request.url);
-  const path = `/glaccounts/${resolvedParams.id}${search}`;
-  const data = await fetchFineractAPI(path);
-  return NextResponse.json(data);
+    // Preserve the ?template=true (or any other) querystring
+    const { search } = new URL(request.url);
+    const path = `/glaccounts/${resolvedParams.id}${search}`;
+    const data = await fetchFineractAPI(path);
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error('GET /api/fineract/glaccounts/[id] error:', error);
+    return buildFineractErrorResponse(error, {
+      action: 'load',
+      resource: 'GL account',
+    });
+  }
 }
 
 // And keep your PUT here—Fineract 1.11 does support PUT /glaccounts/{id}.
@@ -28,20 +37,10 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('PUT /api/fineract/glaccounts/[id] error:', error);
-    
-    // If it's our custom error with backend data, return it
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    
-    // Fallback error response
-    return NextResponse.json(
-      { 
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message 
-      }, 
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'update',
+      resource: 'GL account',
+    });
   }
 }
 
@@ -54,19 +53,9 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('DELETE /api/fineract/glaccounts/[id] error:', error);
-    
-    // If it's our custom error with backend data, return it
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    
-    // Fallback error response
-    return NextResponse.json(
-      { 
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message 
-      }, 
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'delete',
+      resource: 'GL account',
+    });
   }
 }

--- a/app/api/fineract/glaccounts/detail/route.ts
+++ b/app/api/fineract/glaccounts/detail/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 /**
  * GET /api/fineract/glaccounts/detail
@@ -40,6 +41,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(sortedData);
   } catch (error: any) {
     console.error("Error fetching GL accounts:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/glaccounts/route.ts
+++ b/app/api/fineract/glaccounts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchFineractAPI } from '@/lib/api';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 
 /**
  * GET    /api/fineract/glaccounts         - list all GL accounts (optional)
@@ -16,7 +17,7 @@ export async function POST(request: Request) {
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error('Error creating GL account:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -26,6 +27,6 @@ export async function GET() {
     return NextResponse.json({ chartAccounts: data });
   } catch (error: any) {
     console.error('Error listing GL accounts:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/glclosures/[id]/route.ts
+++ b/app/api/fineract/glclosures/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchFineractAPI } from '@/lib/api';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 
 export async function GET(
   request: NextRequest,
@@ -11,16 +12,10 @@ export async function GET(
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('GET /api/fineract/glclosures/[id] error:', error);
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    return NextResponse.json(
-      {
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'load',
+      resource: 'GL closure',
+    });
   }
 }
 
@@ -39,16 +34,10 @@ export async function PUT(
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('PUT /api/fineract/glclosures/[id] error:', error);
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    return NextResponse.json(
-      {
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'update',
+      resource: 'GL closure',
+    });
   }
 }
 
@@ -64,15 +53,9 @@ export async function DELETE(
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('DELETE /api/fineract/glclosures/[id] error:', error);
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    return NextResponse.json(
-      {
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'delete',
+      resource: 'GL closure',
+    });
   }
-} 
+}

--- a/app/api/fineract/glclosures/route.ts
+++ b/app/api/fineract/glclosures/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchFineractAPI } from '@/lib/api';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,16 +16,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('GET /api/fineract/glclosures error:', error);
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    return NextResponse.json(
-      {
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'load',
+      resource: 'GL closures',
+    });
   }
 }
 
@@ -39,15 +34,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('POST /api/fineract/glclosures error:', error);
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    return NextResponse.json(
-      {
-        defaultUserMessage: 'An unexpected error occurred',
-        developerMessage: error.message
-      },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'create',
+      resource: 'GL closure',
+    });
   }
-} 
+}

--- a/app/api/fineract/journalentries/[transactionId]/reverse/route.ts
+++ b/app/api/fineract/journalentries/[transactionId]/reverse/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function POST(
@@ -21,17 +22,9 @@ export async function POST(
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('Error reverting transaction:', error);
-    
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    
-    return NextResponse.json(
-      { 
-        defaultUserMessage: 'Failed to revert transaction',
-        developerMessage: error.message || 'Unknown error occurred'
-      }, 
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'reverse',
+      resource: 'journal entry',
+    });
   }
-} 
+}

--- a/app/api/fineract/journalentries/[transactionId]/route.ts
+++ b/app/api/fineract/journalentries/[transactionId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function GET(
@@ -13,17 +14,9 @@ export async function GET(
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('Error fetching journal entry details:', error);
-    
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    
-    return NextResponse.json(
-      { 
-        defaultUserMessage: 'Failed to fetch journal entry details',
-        developerMessage: error.message || 'Unknown error occurred'
-      }, 
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'load',
+      resource: 'journal entry details',
+    });
   }
-} 
+}

--- a/app/api/fineract/journalentries/route.ts
+++ b/app/api/fineract/journalentries/route.ts
@@ -1,5 +1,6 @@
 // File: app/api/fineract/journalentries/route.ts
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 export async function GET(request: Request) {
@@ -28,10 +29,7 @@ export async function GET(request: Request) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching journal entries:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -46,9 +44,6 @@ export async function POST(request: Request) {
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error('Error creating journal entry:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to create journal entry' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/action/route.ts
+++ b/app/api/fineract/loans/[id]/action/route.ts
@@ -5,6 +5,7 @@ import { getTenantBySlug, extractTenantSlugFromRequest } from "@/lib/tenant-serv
 import { sendLoanStatusSms } from "@/lib/notification-service";
 import { applyTopupDisbursementCharges } from "@/lib/topup-disbursement-charge-service";
 import { getPipelineStageNameForLoanAction } from "@/lib/fineract-stage-sync";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 // POST /api/fineract/loans/[id]/action - Perform an action on a loan
 export async function POST(
@@ -109,17 +110,16 @@ export async function POST(
       );
     } catch (error: any) {
       console.error("Fineract loan action error:", error);
-      return NextResponse.json(
-        {
-          error:
-            error?.errorData?.defaultUserMessage ||
-            error?.errorData?.error ||
-            error?.message ||
-            `Failed to ${action} loan`,
-          details: error?.errorData || null,
-        },
-        { status: error?.status || 500 }
-      );
+      return buildFineractErrorResponse(error, {
+        action: action === "approve"
+          ? "approve"
+          : action === "reject"
+            ? "reject"
+            : action === "disburse"
+              ? "process"
+              : "update",
+        resource: "loan",
+      });
     }
     console.log("Loan action result:", result);
 
@@ -227,10 +227,10 @@ export async function POST(
     });
   } catch (error: any) {
     console.error("Error performing loan action:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to perform loan action" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "process",
+      resource: "loan action",
+    });
   }
 }
 

--- a/app/api/fineract/loans/[id]/approve/route.ts
+++ b/app/api/fineract/loans/[id]/approve/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
 import { fetchFineractAPI } from '@/lib/api';
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from '@/lib/fineract-route-error';
 
 /**
  * GET /api/fineract/loans/[id]/approve
@@ -25,10 +29,10 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching loan approval template:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'load',
+      resource: 'loan approval template',
+    });
   }
 }
 
@@ -56,11 +60,9 @@ export async function POST(
         return NextResponse.json(
           { 
             error: `Cannot approve loan. Current status: ${loanStatus}. Loan must be in 'Submitted and pending approval' status to be approved.`,
-            errorData: {
-              defaultUserMessage: `Cannot approve loan. Current status: ${loanStatus}. Loan must be in 'Submitted and pending approval' status to be approved.`,
-              developerMessage: `Loan status validation failed. Expected: 'Submitted and pending approval', Actual: '${loanStatus}'`,
+            details: {
               currentStatus: loanStatus
-            }
+            },
           },
           { status: 400 }
         );
@@ -82,29 +84,28 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error approving loan:', error);
-    
-    // Enhanced error handling with better user messages
-    let userMessage = 'Failed to approve loan';
-    let statusCode = 500;
-    
-    if (error.status === 400) {
-      statusCode = 400;
-      if (error.errorData?.defaultUserMessage) {
-        userMessage = error.errorData.defaultUserMessage;
-      } else if (error.errorData?.developerMessage) {
-        userMessage = error.errorData.developerMessage;
-      } else if (error.message?.includes('not in submitted and pending approval state')) {
-        userMessage = 'Cannot approve loan. The loan is not in the correct state for approval. Please ensure the loan is submitted and pending approval.';
-      }
+
+    if (
+      error.message?.includes('not in submitted and pending approval state')
+    ) {
+      const errorResponse = createFineractErrorResponsePayload(error, {
+        action: 'approve',
+        resource: 'loan',
+      });
+
+      return NextResponse.json(
+        {
+          error:
+            'Cannot approve loan. The loan is not in the correct state for approval. Please ensure the loan is submitted and pending approval.',
+          details: errorResponse.body.details,
+        },
+        { status: errorResponse.status || 400 }
+      );
     }
-    
-    return NextResponse.json(
-      { 
-        error: userMessage,
-        errorData: error.errorData || null,
-        details: error.message || 'Unknown error'
-      },
-      { status: statusCode }
-    );
+
+    return buildFineractErrorResponse(error, {
+      action: 'approve',
+      resource: 'loan',
+    });
   }
 }

--- a/app/api/fineract/loans/[id]/charges/[chargeId]/route.ts
+++ b/app/api/fineract/loans/[id]/charges/[chargeId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -25,12 +26,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error processing loan charge action:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to process loan charge action" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/charges/route.ts
+++ b/app/api/fineract/loans/[id]/charges/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -15,13 +16,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan charges:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch loan charges" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -41,12 +36,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating loan charge:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create loan charge" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/charges/template/route.ts
+++ b/app/api/fineract/loans/[id]/charges/template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -16,12 +17,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan charge template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch loan charge template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/collaterals/route.ts
+++ b/app/api/fineract/loans/[id]/collaterals/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -13,19 +14,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan collaterals:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch loan collaterals" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -45,18 +34,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating collateral:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to create collateral" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/collaterals/template/route.ts
+++ b/app/api/fineract/loans/[id]/collaterals/template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -13,18 +14,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching collateral template:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch collateral template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
+++ b/app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildFineractRequest } from "@/lib/api";
 import { toInlineContentDisposition } from "@/lib/document-viewing";
+import {
+  buildFineractErrorResponse,
+  createFineractErrorResponsePayload,
+} from "@/lib/fineract-route-error";
 
 export async function GET(
   request: NextRequest,
@@ -86,28 +90,45 @@ export async function GET(
     console.log("Response status:", response.status);
 
     if (!response.ok) {
-      let errorMessage = "Failed to download document";
+      let errorBody: string | undefined;
       try {
         if (response.arrayBuffer) {
           const errorBuffer = await response.arrayBuffer();
-          const errorText = Buffer.from(errorBuffer).toString();
-          console.error("Error response body:", errorText);
-          errorMessage = errorText || errorMessage;
+          errorBody = Buffer.from(errorBuffer).toString();
+          console.error("Error response body:", errorBody);
         }
       } catch (e) {
         console.error("Could not parse error response");
       }
 
+      const errorResponse = createFineractErrorResponsePayload(
+        {
+          status: response.status,
+          errorData: errorBody
+            ? {
+                defaultUserMessage: errorBody,
+                developerMessage: errorBody,
+              }
+            : {
+                defaultUserMessage: "Failed to download document",
+                developerMessage: response.statusText,
+              },
+          response: { statusText: response.statusText },
+        },
+        {
+          action: "download",
+          resource: "document",
+        }
+      );
+
       console.error(
         "Failed to download document:",
         response.status,
-        response.statusText,
-        errorMessage
+        response.statusText
       );
-      return NextResponse.json(
-        { error: errorMessage },
-        { status: response.status }
-      );
+      return NextResponse.json(errorResponse.body, {
+        status: errorResponse.status,
+      });
     }
 
     // Get the file data
@@ -137,11 +158,9 @@ export async function GET(
     });
   } catch (error) {
     console.error("Error downloading document:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Internal server error";
-    return NextResponse.json(
-      { error: `Failed to download document: ${errorMessage}` },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "download",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/loans/[id]/documents/[documentId]/route.ts
+++ b/app/api/fineract/loans/[id]/documents/[documentId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function DELETE(
@@ -15,18 +16,6 @@ export async function DELETE(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error deleting document:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to delete document" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/documents/route.ts
+++ b/app/api/fineract/loans/[id]/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
+import { getFineractErrorMessage } from "@/lib/fineract-error";
 import {
   extractTenantSlugFromRequest,
   getTenantBySlug,
@@ -104,7 +105,7 @@ export async function GET(
       });
     }
 
-    const message = error instanceof Error ? error.message : "Failed to fetch loan documents";
+    const message = getFineractErrorMessage(error);
     return NextResponse.json(
       { error: message },
       { status: 500 }
@@ -219,7 +220,7 @@ export async function POST(
       });
     }
 
-    const message = error instanceof Error ? error.message : "Failed to upload loan document";
+    const message = getFineractErrorMessage(error);
     return NextResponse.json(
       { error: message },
       { status: 500 }

--- a/app/api/fineract/loans/[id]/documents/route.ts
+++ b/app/api/fineract/loans/[id]/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
-import { getFineractErrorMessage } from "@/lib/fineract-error";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import {
   extractTenantSlugFromRequest,
   getTenantBySlug,
@@ -93,23 +93,10 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error fetching loan documents:", error);
-
-    const fineractError = error as {
-      status?: number;
-      errorData?: unknown;
-    };
-
-    if (fineractError.status && fineractError.errorData) {
-      return NextResponse.json(fineractError.errorData, {
-        status: fineractError.status,
-      });
-    }
-
-    const message = getFineractErrorMessage(error);
-    return NextResponse.json(
-      { error: message },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "loan documents",
+    });
   }
 }
 
@@ -208,22 +195,9 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error uploading loan document:", error);
-
-    const fineractError = error as {
-      status?: number;
-      errorData?: unknown;
-    };
-
-    if (fineractError.status && fineractError.errorData) {
-      return NextResponse.json(fineractError.errorData, {
-        status: fineractError.status,
-      });
-    }
-
-    const message = getFineractErrorMessage(error);
-    return NextResponse.json(
-      { error: message },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "upload",
+      resource: "document",
+    });
   }
 }

--- a/app/api/fineract/loans/[id]/guarantors/route.ts
+++ b/app/api/fineract/loans/[id]/guarantors/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -17,10 +18,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching loan guarantors:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -43,12 +41,6 @@ export async function POST(
     return NextResponse.json(data, { status: 201 });
   } catch (error: any) {
     console.error('Error creating guarantor:', error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/guarantors/template/route.ts
+++ b/app/api/fineract/loans/[id]/guarantors/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -17,9 +18,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching guarantors template:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/interest-pauses/route.ts
+++ b/app/api/fineract/loans/[id]/interest-pauses/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -16,13 +17,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching interest pauses:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch interest pauses" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -42,12 +37,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating interest pause:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create interest pause" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/notes/[noteId]/route.ts
+++ b/app/api/fineract/loans/[id]/notes/[noteId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function PUT(
@@ -24,19 +25,7 @@ export async function PUT(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error updating note:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to update note" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -54,18 +43,6 @@ export async function DELETE(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error deleting note:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to delete note" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/notes/route.ts
+++ b/app/api/fineract/loans/[id]/notes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -13,19 +14,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan notes:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch loan notes" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -52,18 +41,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating note:", error);
-    
-    // If it's a Fineract API error with status code, preserve it
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        error.errorData,
-        { status: error.status }
-      );
-    }
-    
-    return NextResponse.json(
-      { error: error.message || "Failed to create note" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/recover-guarantees/route.ts
+++ b/app/api/fineract/loans/[id]/recover-guarantees/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -21,12 +22,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error recovering from guarantor:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to recover from guarantor" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/route.ts
+++ b/app/api/fineract/loans/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 import { getSession } from "@/lib/auth";
 import { extractTenantSlugFromRequest } from "@/lib/tenant-service";
@@ -52,10 +53,7 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan:", error);
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -78,7 +76,7 @@ export async function PUT(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error updating loan:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -98,6 +96,6 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (error: any) {
     console.error("Error deleting loan:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/[transactionId]/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/[transactionId]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 // POST /api/fineract/loans/:id/transactions/:transactionId?command=chargeback
@@ -23,10 +24,7 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error posting loan transaction command:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 

--- a/app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -13,9 +14,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching charge-off template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to fetch charge-off template" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/charge-off/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/charge-off/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -16,9 +17,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error executing charge-off:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to execute charge-off" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -18,12 +19,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching credit balance refund template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch credit balance refund template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/credit-balance-refund/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/credit-balance-refund/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -20,12 +21,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating credit balance refund:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create credit balance refund" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -13,9 +14,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching goodwill credit template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to fetch goodwill credit template" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/goodwill-credit/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/goodwill-credit/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -16,10 +17,7 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error executing goodwill credit:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to execute goodwill credit" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }
 

--- a/app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -18,12 +19,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching interest payment waiver template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch interest payment waiver template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/interest-payment-waiver/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/interest-payment-waiver/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -20,12 +21,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating interest payment waiver:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create interest payment waiver" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -18,12 +19,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching merchant issued refund template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch merchant issued refund template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/merchant-issued-refund/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/merchant-issued-refund/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -20,12 +21,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating merchant issued refund:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create merchant issued refund" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function GET(
@@ -18,12 +19,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching payout refund template:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch payout refund template" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/payout-refund/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/payout-refund/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -20,12 +21,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating payout refund:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to create payout refund" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/re-age/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/re-age/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -16,9 +17,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error executing re-age:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to execute re-age" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/re-amortize/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/re-amortize/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 export async function POST(
@@ -16,9 +17,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error executing re-amortize:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json({ error: error.message || "Failed to execute re-amortize" }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/transactions/template/route.ts
+++ b/app/api/fineract/loans/[id]/transactions/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -27,9 +28,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching loan transaction template:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/[id]/undodisbursal/route.ts
+++ b/app/api/fineract/loans/[id]/undodisbursal/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 import { getActiveFacilityForClient, getFacilityLoanLink, updateFacility } from "@/lib/fineract-credit-facility";
 
@@ -41,12 +42,6 @@ export async function POST(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error executing undo disbursal:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: error.message || "Failed to execute undo disbursal" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/calculate-schedule/route.ts
+++ b/app/api/fineract/loans/calculate-schedule/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 function sanitizeCalculateSchedulePayload(payload: Record<string, unknown>) {
@@ -46,22 +47,6 @@ export async function POST(request: Request) {
     console.error("Error status:", error.status);
     console.error("Error data:", JSON.stringify(error.errorData, null, 2));
     console.error("Full error:", error);
-
-    // Check if it's an API error with status and errorData
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        {
-          error: error.message || "Failed to calculate loan schedule",
-          status: error.status,
-          details: error.errorData,
-        },
-        { status: error.status }
-      );
-    }
-
-    return NextResponse.json(
-      { error: error.message || "Unknown error calculating loan schedule" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/product/[id]/route.ts
+++ b/app/api/fineract/loans/product/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -17,9 +18,6 @@ export async function GET(
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching loan product:", error);
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/loans/template/route.ts
+++ b/app/api/fineract/loans/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -40,9 +41,6 @@ export async function GET(request: Request) {
   } catch (error: any) {
     console.error('Error fetching loan template:', error);
     
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/notifications/route.ts
+++ b/app/api/fineract/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 
 // GET /api/fineract/notifications - Get all notifications
 export async function GET(request: NextRequest) {
@@ -8,14 +9,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(notifications);
   } catch (error: any) {
     console.error("Error fetching notifications:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to fetch notifications",
-        details: error.message,
-        errorData: error.errorData,
-      },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "load",
+      resource: "notifications",
+    });
   }
 }
 
@@ -32,13 +29,9 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json(result);
   } catch (error: any) {
     console.error("Error updating notifications:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to update notifications",
-        details: error.message,
-        errorData: error.errorData,
-      },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "update",
+      resource: "notifications",
+    });
   }
 }

--- a/app/api/fineract/notifications/stream/route.ts
+++ b/app/api/fineract/notifications/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { getFineractTenantId } from "@/lib/fineract-tenant-service";
+import { createFineractErrorResponsePayload } from "@/lib/fineract-route-error";
 
 const POLLING_INTERVAL = 30000; // 30 seconds
 
@@ -50,7 +51,20 @@ export async function GET(request: NextRequest) {
           });
 
           if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            const errorBody = await response.text().catch(() => "");
+            const errorResponse = createFineractErrorResponsePayload(
+              {
+                status: response.status,
+                errorData: errorBody,
+                response: { statusText: response.statusText },
+              },
+              {
+                action: "load",
+                resource: "notifications",
+              }
+            );
+
+            throw new Error(errorResponse.body.error);
           }
 
           const data = await response.json();

--- a/app/api/fineract/paymenttypes/[id]/route.ts
+++ b/app/api/fineract/paymenttypes/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 type RouteContext = {
@@ -14,10 +15,7 @@ export async function GET(_: Request, context: RouteContext) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching payment type:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to fetch payment type" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -32,10 +30,7 @@ export async function PUT(request: Request, context: RouteContext) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error updating payment type:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to update payment type" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -48,9 +43,6 @@ export async function DELETE(_: Request, context: RouteContext) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error deleting payment type:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to delete payment type" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/paymenttypes/route.ts
+++ b/app/api/fineract/paymenttypes/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { fetchFineractAPI } from "@/lib/api";
 
 /**
@@ -13,7 +14,7 @@ export async function GET() {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error fetching payment types:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return buildFineractErrorResponse(error);
   }
 }
 
@@ -31,9 +32,6 @@ export async function POST(request: Request) {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error("Error creating payment type:", error);
-    return NextResponse.json(
-      { error: error.message || "Failed to create payment type" },
-      { status: error.status || 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/rescheduleloans/template/route.ts
+++ b/app/api/fineract/rescheduleloans/template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 import { fetchFineractAPI } from '@/lib/api';
 
 /**
@@ -13,9 +14,6 @@ export async function GET() {
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error fetching reschedule loan template:', error);
-    return NextResponse.json(
-      { error: error.message || 'Unknown error' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error);
   }
 }

--- a/app/api/fineract/runaccruals/route.ts
+++ b/app/api/fineract/runaccruals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchFineractAPI } from '@/lib/api';
+import { buildFineractErrorResponse } from '@/lib/fineract-route-error';
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,14 +17,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(response);
   } catch (error: any) {
     console.error('Error running accruals:', error);
-    
-    if (error.errorData) {
-      return NextResponse.json(error.errorData, { status: error.status || 500 });
-    }
-    
-    return NextResponse.json(
-      { error: 'Failed to run accruals' },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: 'run',
+      resource: 'accruals',
+    });
   }
-} 
+}

--- a/app/api/leads/[id]/create-loan/route.ts
+++ b/app/api/leads/[id]/create-loan/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { fetchFineractAPI } from "@/lib/api";
+import { buildFineractErrorResponse } from "@/lib/fineract-route-error";
 import { format } from "date-fns";
 import { getSession } from "@/lib/auth";
 import { callCDEAndStore } from "@/lib/cde-utils";
@@ -251,19 +252,9 @@ export async function POST(
     });
   } catch (error: any) {
     console.error("Error creating loan from lead:", error);
-    if (error.status && error.errorData) {
-      return NextResponse.json(
-        {
-          error: error.message,
-          status: error.status,
-          errorData: error.errorData,
-        },
-        { status: error.status }
-      );
-    }
-    return NextResponse.json(
-      { error: error.message || "Unknown error" },
-      { status: 500 }
-    );
+    return buildFineractErrorResponse(error, {
+      action: "create",
+      resource: "loan",
+    });
   }
 }

--- a/lib/__tests__/fineract-error.test.ts
+++ b/lib/__tests__/fineract-error.test.ts
@@ -29,3 +29,48 @@ test("prefers the nested Fineract validation error over the generic domain-rule 
     "error msg cannot transfer client as loan transaction present on or after transfer date"
   );
 });
+
+test("masks technical document storage failures with a safe upload message", async () => {
+  const { parseFineractErrorResponse } = await import("../fineract-error");
+
+  const message = parseFineractErrorResponse({
+    developerMessage: "Request was understood but caused a domain rule violation.",
+    httpStatusCode: "403",
+    defaultUserMessage: "Errors contain reason for domain rule violation.",
+    userMessageGlobalisationCode: "validation.msg.domain.rule.violation",
+    errors: [
+      {
+        developerMessage:
+          "Error while manipulating file payslip.pdf due to a ContentRepository issue Storage backend has reached its minimum free drive threshold.",
+        defaultUserMessage:
+          "Error while manipulating file payslip.pdf due to a ContentRepository issue Storage backend has reached its minimum free drive threshold.",
+        userMessageGlobalisationCode: "error.msg.document.save",
+      },
+    ],
+  });
+
+  assert.equal(
+    message,
+    "Document upload is temporarily unavailable. Please try again later or contact support."
+  );
+});
+
+test("maps datatable not-found responses to a user-friendly empty-data message", async () => {
+  const { parseFineractErrorResponse } = await import("../fineract-error");
+
+  const message = parseFineractErrorResponse({
+    developerMessage: "The requested resource is not available.",
+    httpStatusCode: "404",
+    defaultUserMessage: "The requested resource is not available.",
+    userMessageGlobalisationCode: "error.msg.resource.not.found",
+    errors: [
+      {
+        developerMessage: "Data not found for datatable: ",
+        defaultUserMessage: "Data not found for datatable: ",
+        userMessageGlobalisationCode: "error.msg.datatable.data.not.found",
+      },
+    ],
+  });
+
+  assert.equal(message, "No information is available for this section yet.");
+});

--- a/lib/__tests__/fineract-error.test.ts
+++ b/lib/__tests__/fineract-error.test.ts
@@ -74,3 +74,44 @@ test("maps datatable not-found responses to a user-friendly empty-data message",
 
   assert.equal(message, "No information is available for this section yet.");
 });
+
+test("masks generic internal server errors with a safe default fallback", async () => {
+  const { parseFineractErrorResponse } = await import("../fineract-error");
+
+  const message = parseFineractErrorResponse({
+    timestamp: "2026-08-05T21:17:14.338Z",
+    status: 500,
+    error: "Internal Server Error",
+    httpStatusCode: "500",
+    defaultUserMessage: "Internal Server Error",
+    developerMessage: "Internal Server Error",
+    errors: [],
+  });
+
+  assert.equal(message, "The operation failed. Please try again.");
+});
+
+test("uses action context to make generic server errors user friendly", async () => {
+  const { getFineractErrorMessage } = await import("../fineract-error");
+
+  const message = getFineractErrorMessage(
+    {
+      status: 500,
+      errorData: {
+        timestamp: "2026-08-05T21:17:14.338Z",
+        status: 500,
+        error: "Internal Server Error",
+        httpStatusCode: "500",
+        defaultUserMessage: "Internal Server Error",
+        developerMessage: "Internal Server Error",
+        errors: [],
+      },
+    },
+    {
+      action: "update",
+      resource: "address",
+    }
+  );
+
+  assert.equal(message, "We couldn't update the address. Please try again.");
+});

--- a/lib/__tests__/fineract-route-error-adoption.test.ts
+++ b/lib/__tests__/fineract-route-error-adoption.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(process.cwd());
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("core Fineract client and datatable routes use the shared route error helper", () => {
+  const routes = [
+    "app/api/fineract/clients/[id]/addresses/route.ts",
+    "app/api/fineract/clients/[id]/addresses/[addressId]/route.ts",
+    "app/api/fineract/clients/[id]/route.ts",
+    "app/api/fineract/clients/route.ts",
+    "app/api/fineract/datatables/[name]/[id]/route.ts",
+    "app/api/fineract/client_identifiers/[id]/documents/route.ts",
+    "app/api/fineract/clients/[id]/documents/route.ts",
+    "app/api/fineract/loans/[id]/documents/route.ts",
+  ];
+
+  for (const route of routes) {
+    const source = readRepoFile(route);
+    assert.match(
+      source,
+      /buildFineractErrorResponse/,
+      `${route} should use the shared Fineract route error helper`
+    );
+  }
+});

--- a/lib/__tests__/fineract-route-error-adoption.test.ts
+++ b/lib/__tests__/fineract-route-error-adoption.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
@@ -7,6 +7,21 @@ const repoRoot = path.resolve(process.cwd());
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function getRouteFiles(relativeDir: string): string[] {
+  const absoluteDir = path.join(repoRoot, relativeDir);
+  const entries = readdirSync(absoluteDir, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const relativePath = path.join(relativeDir, entry.name);
+
+    if (entry.isDirectory()) {
+      return getRouteFiles(relativePath);
+    }
+
+    return entry.name === "route.ts" ? [relativePath] : [];
+  });
 }
 
 test("core Fineract client and datatable routes use the shared route error helper", () => {
@@ -28,5 +43,113 @@ test("core Fineract client and datatable routes use the shared route error helpe
       /buildFineractErrorResponse/,
       `${route} should use the shared Fineract route error helper`
     );
+  }
+});
+
+test("remaining Fineract routes with user-facing error fallbacks use the shared route error helper", () => {
+  const routes = [
+    "app/api/fineract/accountingrules/[id]/route.ts",
+    "app/api/fineract/accountingrules/route.ts",
+    "app/api/fineract/accountingrules/template/route.ts",
+    "app/api/fineract/accounttransfers/route.ts",
+    "app/api/fineract/accounttransfers/template/route.ts",
+    "app/api/fineract/chart-of-accounts/route.ts",
+    "app/api/fineract/client_identifiers/[id]/documents/[documentId]/attachment/route.ts",
+    "app/api/fineract/client_identifiers/[id]/documents/route.ts",
+    "app/api/fineract/clients/[id]/documents/[documentId]/attachment/route.ts",
+    "app/api/fineract/clients/[id]/identifiers/route.ts",
+    "app/api/fineract/clients/[id]/identifiers/template/route.ts",
+    "app/api/fineract/clients/[id]/images/route.ts",
+    "app/api/fineract/clients/[id]/loans/route.ts",
+    "app/api/fineract/clients/addresses/template/route.ts",
+    "app/api/fineract/clients/external-id/route.ts",
+    "app/api/fineract/clients/search-v2/route.ts",
+    "app/api/fineract/clients/search/route.ts",
+    "app/api/fineract/codes/[codeName]/codevalues/[valueId]/route.ts",
+    "app/api/fineract/codes/[codeName]/codevalues/route.ts",
+    "app/api/fineract/dashboard/route.ts",
+    "app/api/fineract/datatables/route.ts",
+    "app/api/fineract/external-asset-owners/transfers/loans/[id]/sale/route.ts",
+    "app/api/fineract/fieldconfiguration/[entity]/route.ts",
+    "app/api/fineract/glaccounts/[id]/balance/route.ts",
+    "app/api/fineract/journalentries/[transactionId]/reverse/route.ts",
+    "app/api/fineract/journalentries/[transactionId]/route.ts",
+    "app/api/fineract/journalentries/route.ts",
+    "app/api/fineract/loans/[id]/action/route.ts",
+    "app/api/fineract/loans/[id]/approve/route.ts",
+    "app/api/fineract/loans/[id]/charges/[chargeId]/route.ts",
+    "app/api/fineract/loans/[id]/charges/route.ts",
+    "app/api/fineract/loans/[id]/charges/template/route.ts",
+    "app/api/fineract/loans/[id]/collaterals/route.ts",
+    "app/api/fineract/loans/[id]/collaterals/template/route.ts",
+    "app/api/fineract/loans/[id]/documents/[documentId]/attachment/route.ts",
+    "app/api/fineract/loans/[id]/documents/[documentId]/route.ts",
+    "app/api/fineract/loans/[id]/guarantors/route.ts",
+    "app/api/fineract/loans/[id]/guarantors/template/route.ts",
+    "app/api/fineract/loans/[id]/interest-pauses/route.ts",
+    "app/api/fineract/loans/[id]/notes/[noteId]/route.ts",
+    "app/api/fineract/loans/[id]/notes/route.ts",
+    "app/api/fineract/loans/[id]/recover-guarantees/route.ts",
+    "app/api/fineract/loans/[id]/route.ts",
+    "app/api/fineract/loans/[id]/transactions/[transactionId]/route.ts",
+    "app/api/fineract/loans/[id]/transactions/charge-off-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/charge-off/route.ts",
+    "app/api/fineract/loans/[id]/transactions/credit-balance-refund-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/credit-balance-refund/route.ts",
+    "app/api/fineract/loans/[id]/transactions/goodwill-credit-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/goodwill-credit/route.ts",
+    "app/api/fineract/loans/[id]/transactions/interest-payment-waiver-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/interest-payment-waiver/route.ts",
+    "app/api/fineract/loans/[id]/transactions/merchant-issued-refund-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/merchant-issued-refund/route.ts",
+    "app/api/fineract/loans/[id]/transactions/payout-refund-template/route.ts",
+    "app/api/fineract/loans/[id]/transactions/payout-refund/route.ts",
+    "app/api/fineract/loans/[id]/transactions/re-age/route.ts",
+    "app/api/fineract/loans/[id]/transactions/re-amortize/route.ts",
+    "app/api/fineract/loans/[id]/transactions/template/route.ts",
+    "app/api/fineract/loans/[id]/undodisbursal/route.ts",
+    "app/api/fineract/loans/calculate-schedule/route.ts",
+    "app/api/fineract/loans/product/[id]/route.ts",
+    "app/api/fineract/loans/template/route.ts",
+    "app/api/fineract/notifications/stream/route.ts",
+    "app/api/fineract/paymenttypes/[id]/route.ts",
+    "app/api/fineract/paymenttypes/route.ts",
+    "app/api/fineract/rescheduleloans/template/route.ts",
+  ];
+
+  for (const route of routes) {
+    const source = readRepoFile(route);
+    assert.match(
+      source,
+      /buildFineractErrorResponse|createFineractErrorResponsePayload/,
+      `${route} should use the shared Fineract route error helper`
+    );
+  }
+});
+
+test("Fineract routes do not return raw backend error payloads or developer messages", () => {
+  const disallowedPatterns = [
+    /return\s+NextResponse\.json\(\s*error\.errorData\b/s,
+    /return\s+NextResponse\.json\(\s*\{\s*error:\s*error\.errorData\b/s,
+    /details:\s*error\??\.errorData\b/s,
+    /developerMessage:\s*error\.message\b/s,
+    /errorMessage\s*=\s*error\.errorData(?:\.[A-Za-z0-9_[\].]+)?\.developerMessage\b/s,
+    /errorMessage\s*=\s*error\??\.message\b/s,
+  ];
+
+  const routeFiles = getRouteFiles("app/api").filter((route) =>
+    readRepoFile(route).includes("fetchFineractAPI")
+  );
+
+  for (const route of routeFiles) {
+    const source = readRepoFile(route);
+
+    for (const pattern of disallowedPatterns) {
+      assert.doesNotMatch(
+        source,
+        pattern,
+        `${route} should not return raw Fineract/backend error details to the UI`
+      );
+    }
   }
 });

--- a/lib/__tests__/fineract-route-error.test.ts
+++ b/lib/__tests__/fineract-route-error.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("builds a shared route error payload with contextual fallback messaging", async () => {
+  const { createFineractErrorResponsePayload } = await import(
+    "../fineract-route-error"
+  );
+
+  const result = createFineractErrorResponsePayload(
+    {
+      status: 500,
+      errorData: {
+        timestamp: "2026-08-05T21:17:14.338Z",
+        status: 500,
+        error: "Internal Server Error",
+        httpStatusCode: "500",
+        defaultUserMessage: "Internal Server Error",
+        developerMessage: "Internal Server Error",
+        errors: [],
+      },
+    },
+    {
+      action: "update",
+      resource: "address",
+    }
+  );
+
+  assert.equal(result.status, 500);
+  assert.equal(
+    result.body.error,
+    "We couldn't update the address. Please try again."
+  );
+  assert.equal(
+    result.body.details?.defaultUserMessage,
+    "We couldn't update the address. Please try again."
+  );
+});
+
+test("preserves specific nested Fineract validation messages in shared route payloads", async () => {
+  const { createFineractErrorResponsePayload } = await import(
+    "../fineract-route-error"
+  );
+
+  const result = createFineractErrorResponsePayload(
+    {
+      status: 403,
+      errorData: {
+        developerMessage:
+          "Request was understood but caused a domain rule violation.",
+        httpStatusCode: "403",
+        defaultUserMessage: "Errors contain reason for domain rule violation.",
+        userMessageGlobalisationCode: "validation.msg.domain.rule.violation",
+        errors: [
+          {
+            developerMessage: "Address line 1 must not exceed 100 characters.",
+            defaultUserMessage: "Address line 1 must not exceed 100 characters.",
+            userMessageGlobalisationCode: "validation.msg.address.line1.maxlength",
+          },
+        ],
+      },
+    },
+    {
+      action: "update",
+      resource: "address",
+    }
+  );
+
+  assert.equal(result.status, 403);
+  assert.equal(
+    result.body.error,
+    "Address line 1 must not exceed 100 characters."
+  );
+  assert.equal(
+    result.body.details?.errors?.[0]?.defaultUserMessage,
+    "Address line 1 must not exceed 100 characters."
+  );
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,7 @@
 import https from "https";
 import { getFineractTenantId as getFineractTenantIdFromService } from "./fineract-tenant-service";
 import { getFineractBaseUrl } from "./fineract-base-url";
+import { normalizeFineractErrorPayload } from "./fineract-error";
 
 // Re-export for convenience
 export { getFineractTenantIdFromService as getFineractTenantId };
@@ -132,44 +133,24 @@ async function readFineractResponse(response: Response, url: string) {
       };
     }
 
-    if (!errorData || Object.keys(errorData).length === 0) {
-      errorData = {
-        defaultUserMessage: `HTTP ${response.status}: ${response.statusText}`,
-        developerMessage: `HTTP ${response.status}: ${response.statusText}`,
-      };
-    }
+    const normalizedErrorData = normalizeFineractErrorPayload(errorData, {
+      status: response.status,
+      statusText: response.statusText,
+    });
+    const specificErrorMessage =
+      normalizedErrorData.defaultUserMessage ||
+      `HTTP ${response.status}: ${response.statusText}`;
 
-    let specificErrorMessage =
-      errorData.defaultUserMessage || errorData.developerMessage;
-
-    if (
-      errorData.errors &&
-      Array.isArray(errorData.errors) &&
-      errorData.errors.length > 0
-    ) {
-      const firstError = errorData.errors[0];
-      specificErrorMessage =
-        firstError.defaultUserMessage ||
-        firstError.developerMessage ||
-        specificErrorMessage;
-    }
-
-    const error = new Error(
-      `API error: ${response.status} ${response.statusText}`
-    );
+    const error = new Error(specificErrorMessage);
     const fineractError = error as FineractError;
     fineractError.status = response.status;
-    fineractError.errorData = {
-      ...errorData,
-      defaultUserMessage: specificErrorMessage,
-      developerMessage: specificErrorMessage,
-    };
+    fineractError.errorData = normalizedErrorData;
 
     console.error("API Error Details:", {
       status: response.status,
       statusText: response.statusText,
       url,
-      errorData: JSON.stringify(errorData, null, 2),
+      errorData: JSON.stringify(normalizedErrorData, null, 2),
       specificErrorMessage,
     });
 
@@ -439,34 +420,18 @@ export function createClientFineractAPI(accessToken?: string) {
           };
         }
 
-        // Extract the most specific error message from the errors array
-        let specificErrorMessage =
-          errorData.defaultUserMessage || errorData.developerMessage;
+        const normalizedErrorData = normalizeFineractErrorPayload(errorData, {
+          status: response.status,
+          statusText: response.statusText,
+        });
 
-        if (
-          errorData.errors &&
-          Array.isArray(errorData.errors) &&
-          errorData.errors.length > 0
-        ) {
-          // Use the first error's defaultUserMessage if available, otherwise developerMessage
-          const firstError = errorData.errors[0];
-          specificErrorMessage =
-            firstError.defaultUserMessage ||
-            firstError.developerMessage ||
-            specificErrorMessage;
-        }
-
-        // Create a custom error that includes the backend error data
         const error = new Error(
-          `API error: ${response.status} ${response.statusText}`
+          normalizedErrorData.defaultUserMessage ||
+            `HTTP ${response.status}: ${response.statusText}`
         );
         const fineractError = error as FineractError;
         fineractError.status = response.status;
-        fineractError.errorData = {
-          ...errorData,
-          defaultUserMessage: specificErrorMessage,
-          developerMessage: specificErrorMessage,
-        };
+        fineractError.errorData = normalizedErrorData;
         throw error;
       }
 

--- a/lib/fineract-api.ts
+++ b/lib/fineract-api.ts
@@ -1,13 +1,35 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { error } from "console";
 import { transferClientToOfficeWithServiceAuth } from "./fineract-client-transfer-service";
 import { getFineractBaseUrl } from "./fineract-base-url";
+import { normalizeFineractErrorPayload } from "./fineract-error";
 
 export interface FineractConfig {
   baseUrl: string;
   username: string;
   password: string;
   tenantId: string;
+}
+
+function normalizeAxiosFineractError(error: any) {
+  const status = error?.response?.status;
+  const statusText = error?.response?.statusText;
+  const normalizedErrorData = normalizeFineractErrorPayload(
+    error?.response?.data,
+    { status, statusText }
+  );
+
+  error.status = status;
+  error.errorData = normalizedErrorData;
+
+  if (error?.response) {
+    error.response.data = normalizedErrorData;
+  }
+
+  if (normalizedErrorData.defaultUserMessage) {
+    error.message = normalizedErrorData.defaultUserMessage;
+  }
+
+  return error;
 }
 
 export interface FineractClient {
@@ -460,15 +482,19 @@ export class FineractAPIService {
     });
 
     // Add response interceptor for error handling
-    this.client.interceptors.response.use(
+    const handleAxiosError = (axiosError: any) => {
+      const normalizedError = normalizeAxiosFineractError(axiosError);
+      console.error(
+        "Fineract API Error:",
+        normalizedError.errorData || normalizedError.message
+      );
+      throw normalizedError;
+    };
+
+    this.client.interceptors.response.use((response) => response, handleAxiosError);
+    this.clientV2.interceptors.response.use(
       (response) => response,
-      (error) => {
-        console.error(
-          "Fineract API Error:",
-          error.response?.data || error.message
-        );
-        throw error;
-      }
+      handleAxiosError
     );
   }
 

--- a/lib/fineract-error.ts
+++ b/lib/fineract-error.ts
@@ -1,15 +1,16 @@
-/**
- * Fineract error response structure (from Fineract API)
- */
-interface FineractErrorItem {
+export interface FineractErrorArg {
+  value?: string;
+}
+
+export interface FineractErrorItem {
   developerMessage?: string;
   defaultUserMessage?: string;
   userMessageGlobalisationCode?: string;
   parameterName?: string;
-  args?: Array<{ value?: string }>;
+  args?: FineractErrorArg[];
 }
 
-interface FineractErrorResponse {
+export interface FineractErrorResponse {
   developerMessage?: string;
   httpStatusCode?: string;
   defaultUserMessage?: string;
@@ -17,72 +18,232 @@ interface FineractErrorResponse {
   errors?: FineractErrorItem[];
 }
 
-/**
- * Extracts the user-friendly error message from a Fineract or API error response.
- * Handles: { error }, { defaultUserMessage }, { errors: [{ defaultUserMessage }] },
- * { details: { errors } }, raw Fineract structure.
- *
- * @param body - Response body as string (JSON) or parsed object
- * @returns User-friendly error message
- */
-export function parseFineractErrorResponse(body: string | object): string {
-  let data: FineractErrorResponse & { error?: string; details?: { errors?: FineractErrorItem[] } };
+type ExtendedFineractErrorResponse = FineractErrorResponse & {
+  error?: string | { defaultUserMessage?: string; developerMessage?: string };
+  details?: FineractErrorResponse;
+};
 
+type NormalizeOptions = {
+  status?: number;
+  statusText?: string;
+};
+
+const GENERIC_WRAPPER_CODES = new Set([
+  "validation.msg.domain.rule.violation",
+  "validation.msg.validation.errors.exist",
+  "error.msg.resource.not.found",
+]);
+
+const FRIENDLY_MESSAGE_BY_CODE: Record<string, string> = {
+  "error.msg.document.save":
+    "Document upload is temporarily unavailable. Please try again later or contact support.",
+  "error.msg.document.file.too.big":
+    "This document is too large to upload. Please choose a smaller file and try again.",
+  "error.msg.datatable.data.not.found":
+    "No information is available for this section yet.",
+  "error.msg.datatable.not.found":
+    "This section is not configured in Fineract yet.",
+  "error.msg.resource.not.found": "The requested record could not be found.",
+  "validation.msg.validation.errors.exist":
+    "Please review the entered details and try again.",
+  "validation.msg.domain.rule.violation":
+    "This action could not be completed because it violates a business rule.",
+};
+
+function parseErrorBody(body: string | object): ExtendedFineractErrorResponse | null {
   if (typeof body === "string") {
     try {
-      data = JSON.parse(body) as FineractErrorResponse & {
-        error?: string;
-        details?: { errors?: FineractErrorItem[] };
-      };
+      return JSON.parse(body) as ExtendedFineractErrorResponse;
     } catch {
-      return body.trim() || "An error occurred";
+      return body.trim()
+        ? ({
+            error: body.trim(),
+          } as ExtendedFineractErrorResponse)
+        : null;
     }
-  } else {
-    data = body as FineractErrorResponse & {
-      error?: string;
-      details?: { errors?: FineractErrorItem[] };
+  }
+
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  return body as ExtendedFineractErrorResponse;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function getFallbackStatusMessage(options?: NormalizeOptions): string {
+  const status = options?.status;
+  const statusText = options?.statusText;
+
+  if (status) {
+    return `HTTP ${status}${statusText ? `: ${statusText}` : ""}`;
+  }
+
+  return "An error occurred";
+}
+
+function getPreferredRawMessage(error: FineractErrorItem | ExtendedFineractErrorResponse): string | undefined {
+  if (isNonEmptyString(error.defaultUserMessage)) {
+    return error.defaultUserMessage;
+  }
+
+  if (isNonEmptyString(error.developerMessage)) {
+    return error.developerMessage;
+  }
+
+  return undefined;
+}
+
+function getFriendlyMessageForCode(
+  code: string | undefined,
+  rawMessage: string | undefined,
+  options?: NormalizeOptions
+): string {
+  if (code && FRIENDLY_MESSAGE_BY_CODE[code]) {
+    return FRIENDLY_MESSAGE_BY_CODE[code];
+  }
+
+  if (isNonEmptyString(rawMessage)) {
+    return rawMessage;
+  }
+
+  return getFallbackStatusMessage(options);
+}
+
+function normalizeErrorItems(
+  errors: FineractErrorItem[] | undefined,
+  options?: NormalizeOptions
+): FineractErrorItem[] | undefined {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return undefined;
+  }
+
+  return errors.map((item) => {
+    const friendlyMessage = getFriendlyMessageForCode(
+      item.userMessageGlobalisationCode,
+      getPreferredRawMessage(item),
+      options
+    );
+
+    return {
+      ...item,
+      defaultUserMessage: friendlyMessage,
+      developerMessage: friendlyMessage,
+    };
+  });
+}
+
+function getTopLevelRawMessage(data: ExtendedFineractErrorResponse): string | undefined {
+  if (isNonEmptyString(data.defaultUserMessage)) {
+    return data.defaultUserMessage;
+  }
+
+  if (typeof data.error === "string" && isNonEmptyString(data.error)) {
+    return data.error;
+  }
+
+  if (
+    data.error &&
+    typeof data.error === "object" &&
+    isNonEmptyString(data.error.defaultUserMessage)
+  ) {
+    return data.error.defaultUserMessage;
+  }
+
+  if (
+    data.error &&
+    typeof data.error === "object" &&
+    isNonEmptyString(data.error.developerMessage)
+  ) {
+    return data.error.developerMessage;
+  }
+
+  if (isNonEmptyString(data.developerMessage)) {
+    return data.developerMessage;
+  }
+
+  return undefined;
+}
+
+export function normalizeFineractErrorPayload(
+  body: string | object | undefined,
+  options?: NormalizeOptions
+): FineractErrorResponse {
+  const parsed = parseErrorBody(body);
+  const fallbackMessage = getFallbackStatusMessage(options);
+
+  if (!parsed) {
+    return {
+      httpStatusCode: options?.status ? String(options.status) : undefined,
+      defaultUserMessage: fallbackMessage,
+      developerMessage: fallbackMessage,
+      errors: [],
     };
   }
 
-  if (!data) {
-    return "An error occurred";
+  const nestedErrors = parsed.errors ?? parsed.details?.errors;
+  const normalizedErrors = normalizeErrorItems(nestedErrors, options) ?? [];
+  const firstSpecificMessage = normalizedErrors[0]?.defaultUserMessage;
+  const topLevelCode =
+    parsed.userMessageGlobalisationCode ?? parsed.details?.userMessageGlobalisationCode;
+
+  let topLevelMessage = getFriendlyMessageForCode(
+    topLevelCode,
+    getTopLevelRawMessage(parsed),
+    options
+  );
+
+  if (GENERIC_WRAPPER_CODES.has(topLevelCode ?? "") && firstSpecificMessage) {
+    topLevelMessage = firstSpecificMessage;
   }
 
-  // Check errors array first (Fineract structure)
-  const errors = data.errors ?? data.details?.errors;
-  if (errors && Array.isArray(errors) && errors.length > 0) {
-    const firstError = errors[0];
-    const msg =
-      firstError.defaultUserMessage ??
-      firstError.developerMessage;
-    if (msg) return msg;
-  }
+  return {
+    ...parsed.details,
+    ...parsed,
+    httpStatusCode:
+      parsed.httpStatusCode ??
+      parsed.details?.httpStatusCode ??
+      (options?.status ? String(options.status) : undefined),
+    userMessageGlobalisationCode: topLevelCode,
+    defaultUserMessage: topLevelMessage || fallbackMessage,
+    developerMessage: topLevelMessage || fallbackMessage,
+    errors: normalizedErrors,
+  };
+}
 
-  // Fallback: top-level fields (error can be string or { defaultUserMessage } from some APIs)
-  if (data.defaultUserMessage) return data.defaultUserMessage;
-  if (data.error) {
-    if (typeof data.error === "string") return data.error;
-    const errObj = data.error as { defaultUserMessage?: string };
-    if (errObj?.defaultUserMessage) return errObj.defaultUserMessage;
-  }
-  return data.developerMessage ?? "An error occurred";
+/**
+ * Extracts the user-friendly error message from a Fineract or API error response.
+ */
+export function parseFineractErrorResponse(body: string | object): string {
+  const normalized = normalizeFineractErrorPayload(body);
+  return normalized.defaultUserMessage || "An error occurred";
 }
 
 /**
  * Extracts the user-friendly error message from a caught Fineract API error
- * (thrown by fetchFineractAPI with errorData attached).
- *
- * @param error - Caught error from fetchFineractAPI or similar
- * @returns User-friendly error message
+ * (thrown by fetchFineractAPI or Axios-backed Fineract service calls).
  */
 export function getFineractErrorMessage(error: unknown): string {
   const err = error as {
-    errorData?: { defaultUserMessage?: string };
+    errorData?: FineractErrorResponse;
+    response?: { data?: string | object };
     message?: string;
   };
-  return (
-    err?.errorData?.defaultUserMessage ??
-    err?.message ??
-    "An error occurred"
-  );
+
+  if (err?.errorData) {
+    return (
+      normalizeFineractErrorPayload(err.errorData).defaultUserMessage ||
+      err.message ||
+      "An error occurred"
+    );
+  }
+
+  if (err?.response?.data) {
+    return parseFineractErrorResponse(err.response.data);
+  }
+
+  return err?.message ?? "An error occurred";
 }

--- a/lib/fineract-error.ts
+++ b/lib/fineract-error.ts
@@ -18,12 +18,33 @@ export interface FineractErrorResponse {
   errors?: FineractErrorItem[];
 }
 
+export type FineractErrorAction =
+  | "load"
+  | "create"
+  | "update"
+  | "delete"
+  | "upload"
+  | "download"
+  | "submit"
+  | "approve"
+  | "reject"
+  | "transfer"
+  | "save"
+  | "process";
+
+export interface FineractErrorMessageContext {
+  action?: FineractErrorAction;
+  resource?: string;
+  surface?: string;
+  fallbackMessage?: string;
+}
+
 type ExtendedFineractErrorResponse = FineractErrorResponse & {
   error?: string | { defaultUserMessage?: string; developerMessage?: string };
   details?: FineractErrorResponse;
 };
 
-type NormalizeOptions = {
+type NormalizeOptions = FineractErrorMessageContext & {
   status?: number;
   statusText?: string;
 };
@@ -50,6 +71,37 @@ const FRIENDLY_MESSAGE_BY_CODE: Record<string, string> = {
     "This action could not be completed because it violates a business rule.",
 };
 
+const ACTION_LABEL_BY_TYPE: Record<FineractErrorAction, string> = {
+  load: "load",
+  create: "create",
+  update: "update",
+  delete: "delete",
+  upload: "upload",
+  download: "download",
+  submit: "submit",
+  approve: "approve",
+  reject: "reject",
+  transfer: "transfer",
+  save: "save",
+  process: "process",
+};
+
+const GENERIC_ERROR_MESSAGE_PATTERNS = [
+  /^internal server error$/i,
+  /^bad request$/i,
+  /^not found$/i,
+  /^forbidden$/i,
+  /^unauthorized$/i,
+  /^conflict$/i,
+  /^service unavailable$/i,
+  /^gateway timeout$/i,
+  /^method not allowed$/i,
+  /^unknown error$/i,
+  /^an error occurred$/i,
+  /^request failed$/i,
+  /^http\s+\d{3}(?::|\b)/i,
+];
+
 function parseErrorBody(body: string | object): ExtendedFineractErrorResponse | null {
   if (typeof body === "string") {
     try {
@@ -74,15 +126,39 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function getFallbackStatusMessage(options?: NormalizeOptions): string {
-  const status = options?.status;
-  const statusText = options?.statusText;
-
-  if (status) {
-    return `HTTP ${status}${statusText ? `: ${statusText}` : ""}`;
+function buildErrorTarget(options?: FineractErrorMessageContext): string {
+  if (isNonEmptyString(options?.resource)) {
+    return `the ${options.resource.trim()}`;
   }
 
-  return "An error occurred";
+  if (isNonEmptyString(options?.surface)) {
+    return `this ${options.surface.trim()}`;
+  }
+
+  return "this item";
+}
+
+function getFallbackStatusMessage(options?: NormalizeOptions): string {
+  if (isNonEmptyString(options?.fallbackMessage)) {
+    return options.fallbackMessage.trim();
+  }
+
+  if (options?.action) {
+    return `We couldn't ${ACTION_LABEL_BY_TYPE[options.action]} ${buildErrorTarget(
+      options
+    )}. Please try again.`;
+  }
+
+  return "The operation failed. Please try again.";
+}
+
+function isGenericErrorMessage(value: unknown): boolean {
+  if (!isNonEmptyString(value)) {
+    return true;
+  }
+
+  const message = value.trim();
+  return GENERIC_ERROR_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function getPreferredRawMessage(error: FineractErrorItem | ExtendedFineractErrorResponse): string | undefined {
@@ -106,7 +182,7 @@ function getFriendlyMessageForCode(
     return FRIENDLY_MESSAGE_BY_CODE[code];
   }
 
-  if (isNonEmptyString(rawMessage)) {
+  if (isNonEmptyString(rawMessage) && !isGenericErrorMessage(rawMessage)) {
     return rawMessage;
   }
 
@@ -198,6 +274,12 @@ export function normalizeFineractErrorPayload(
 
   if (GENERIC_WRAPPER_CODES.has(topLevelCode ?? "") && firstSpecificMessage) {
     topLevelMessage = firstSpecificMessage;
+  } else if (
+    isGenericErrorMessage(getTopLevelRawMessage(parsed)) &&
+    firstSpecificMessage &&
+    !isGenericErrorMessage(firstSpecificMessage)
+  ) {
+    topLevelMessage = firstSpecificMessage;
   }
 
   return {
@@ -226,7 +308,10 @@ export function parseFineractErrorResponse(body: string | object): string {
  * Extracts the user-friendly error message from a caught Fineract API error
  * (thrown by fetchFineractAPI or Axios-backed Fineract service calls).
  */
-export function getFineractErrorMessage(error: unknown): string {
+export function getFineractErrorMessage(
+  error: unknown,
+  options?: FineractErrorMessageContext
+): string {
   const err = error as {
     errorData?: FineractErrorResponse;
     response?: { data?: string | object };
@@ -235,15 +320,22 @@ export function getFineractErrorMessage(error: unknown): string {
 
   if (err?.errorData) {
     return (
-      normalizeFineractErrorPayload(err.errorData).defaultUserMessage ||
+      normalizeFineractErrorPayload(err.errorData, options).defaultUserMessage ||
       err.message ||
-      "An error occurred"
+      getFallbackStatusMessage(options)
     );
   }
 
   if (err?.response?.data) {
-    return parseFineractErrorResponse(err.response.data);
+    return (
+      normalizeFineractErrorPayload(err.response.data, options)
+        .defaultUserMessage || getFallbackStatusMessage(options)
+    );
   }
 
-  return err?.message ?? "An error occurred";
+  if (isNonEmptyString(err?.message) && !isGenericErrorMessage(err.message)) {
+    return err.message;
+  }
+
+  return getFallbackStatusMessage(options);
 }

--- a/lib/fineract-route-error.ts
+++ b/lib/fineract-route-error.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import {
+  getFineractErrorMessage,
+  normalizeFineractErrorPayload,
+  type FineractErrorMessageContext,
+  type FineractErrorResponse,
+} from "./fineract-error";
+
+type FineractRouteErrorLike = {
+  status?: number;
+  errorData?: string | object | FineractErrorResponse | null;
+  response?: {
+    data?: string | object;
+    status?: number;
+    statusText?: string;
+  };
+};
+
+export function createFineractErrorResponsePayload(
+  error: unknown,
+  context: FineractErrorMessageContext = {}
+) {
+  const fineractError = error as FineractRouteErrorLike;
+  const status =
+    typeof fineractError?.status === "number"
+      ? fineractError.status
+      : typeof fineractError?.response?.status === "number"
+        ? fineractError.response.status
+        : 500;
+
+  const details = normalizeFineractErrorPayload(
+    fineractError?.errorData ?? fineractError?.response?.data,
+    {
+      ...context,
+      status,
+      statusText: fineractError?.response?.statusText,
+    }
+  );
+
+  return {
+    status,
+    body: {
+      error: details.defaultUserMessage || getFineractErrorMessage(error, context),
+      details,
+    },
+  };
+}
+
+export function buildFineractErrorResponse(
+  error: unknown,
+  context: FineractErrorMessageContext = {}
+) {
+  const responsePayload = createFineractErrorResponsePayload(error, context);
+  return NextResponse.json(responsePayload.body, {
+    status: responsePayload.status,
+  });
+}


### PR DESCRIPTION
## Summary
- centralize Fineract error normalization and map common raw platform responses to user-friendly messages
- return normalized error payloads from the main client, datatable, and document API routes that feed the lead/client UI
- normalize Axios-backed Fineract service failures and add regression tests for validation, datatable, and document upload cases

## Validation
- `npx tsx --test lib/__tests__/fineract-error.test.ts`
- `npm run build`

## Notes
- `npm run build` completed successfully on August 5, 2026
- the build still prints existing Next.js dynamic-render warnings for routes that use `headers`; those warnings predate this change and did not block the build