### PR TITLE
Add accrual activity posting to loan product UI

### DIFF
--- a/app/(application)/products/loan-products/[id]/edit/page.tsx
+++ b/app/(application)/products/loan-products/[id]/edit/page.tsx
@@ -211,6 +211,7 @@ function mapFineractProductToForm(product: Record<string, unknown>): LoanProduct
       : [],
 
     accountingRule: getEnumId(product.accountingRule),
+    enableAccrualActivityPosting: b(product.enableAccrualActivityPosting),
 
     // Fineract nests all GL account objects under accountingMappings
     ...(() => {

--- a/app/(application)/products/loan-products/[id]/page.tsx
+++ b/app/(application)/products/loan-products/[id]/page.tsx
@@ -4,9 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { use } from "react";
 import {
-  ArrowLeft, Pencil, Calendar, Percent, Repeat2, Coins, BookOpen,
-  ShieldAlert, Tag, Settings2, TrendingDown, Info, ChevronDown,
-  Banknote, RefreshCw, Lock,
+  ArrowLeft, Pencil, Percent, Repeat2, Coins, BookOpen,
+  ShieldAlert, Tag, Settings2, TrendingDown, Info,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -99,6 +98,7 @@ interface LoanProduct {
   enableInstallmentLevelDelinquency?: boolean;
   delinquencyBucket?: { id: number; name: string };
   accountingRule?: EnumValue;
+  enableAccrualActivityPosting?: boolean;
   // Fineract nests all GL account objects under accountingMappings
   accountingMappings?: {
     fundSourceAccount?: GLAccount;
@@ -556,6 +556,22 @@ export default function LoanProductViewPage({ params }: { params: Promise<{ id: 
 
             {hasGL && (
               <>
+                {isAccrual && (
+                  <div>
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Accrual Activity Posting
+                    </p>
+                    <InfoGrid
+                      rows={[
+                        {
+                          label: "Enable on Installment Due Date",
+                          value: product.enableAccrualActivityPosting,
+                        },
+                      ]}
+                    />
+                  </div>
+                )}
+
                 {(() => {
                   const am = product.accountingMappings ?? {};
                   return (

--- a/app/(application)/products/loan-products/components/loan-product-stepper.tsx
+++ b/app/(application)/products/loan-products/components/loan-product-stepper.tsx
@@ -80,6 +80,7 @@ function buildTemplateDefaults(template: LoanProductTemplate): Partial<LoanProdu
       defaultLoanScheduleType
     ),
     accountingRule:                first(template.accountingRuleOptions),
+    enableAccrualActivityPosting:  template.enableAccrualActivityPosting ?? false,
     loanScheduleType:              defaultLoanScheduleType,
     currencyCode:                  template.currencyOptions?.[0]?.code ?? "",
     digitsAfterDecimal:            template.currencyOptions?.[0]?.decimalPlaces ?? 2,

--- a/app/(application)/products/loan-products/components/step-accounting.tsx
+++ b/app/(application)/products/loan-products/components/step-accounting.tsx
@@ -491,6 +491,30 @@ export function StepAccounting({ form, template, onChange }: StepAccountingProps
         </div>
       </div>
 
+      {isAccrual && (
+        <div
+          className="flex cursor-pointer select-none items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/40"
+          onClick={() =>
+            onChange({ enableAccrualActivityPosting: !form.enableAccrualActivityPosting })
+          }
+        >
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Accrual Activity Posting
+            </h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Post accrual activity automatically on installment due dates for
+              eligible accrual-based loans.
+            </p>
+          </div>
+          <Switch
+            checked={form.enableAccrualActivityPosting}
+            onCheckedChange={(v) => onChange({ enableAccrualActivityPosting: v })}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+
       {hasAccounting && (
         <>
           <Separator />

--- a/shared/types/loan-product.ts
+++ b/shared/types/loan-product.ts
@@ -109,6 +109,7 @@ export interface LoanProductTemplate {
   repaymentStartDateTypeOptions?: FineractEnumOption[];
   loanScheduleTypeOptions?: FineractEnumOption[];
   loanScheduleProcessingTypeOptions?: FineractEnumOption[];
+  enableAccrualActivityPosting?: boolean;
   advancedPaymentAllocationTransactionTypes?: FineractEnumOption[];
   advancedPaymentAllocationTypes?: FineractEnumOption[];
   advancedPaymentAllocationFutureInstallmentAllocationRules?: FineractEnumOption[];
@@ -300,6 +301,7 @@ export interface LoanProductFormData {
   receivableInterestAccountId: number | "";
   receivableFeeAccountId: number | "";
   receivablePenaltyAccountId: number | "";
+  enableAccrualActivityPosting: boolean;
   enableInterestSuspenseAccounting: boolean;
   interestSuspenseAccountId: number | "";
   advancedAccountingRules: boolean;
@@ -420,6 +422,7 @@ export const defaultLoanProductFormData: LoanProductFormData = {
   receivableInterestAccountId: "",
   receivableFeeAccountId: "",
   receivablePenaltyAccountId: "",
+  enableAccrualActivityPosting: false,
   enableInterestSuspenseAccounting: false,
   interestSuspenseAccountId: "",
   advancedAccountingRules: false,
@@ -750,6 +753,7 @@ export function buildFineractPayload(form: LoanProductFormData): Record<string, 
       if (form.receivableInterestAccountId !== "") payload.receivableInterestAccountId = form.receivableInterestAccountId;
       if (form.receivableFeeAccountId !== "") payload.receivableFeeAccountId = form.receivableFeeAccountId;
       if (form.receivablePenaltyAccountId !== "") payload.receivablePenaltyAccountId = form.receivablePenaltyAccountId;
+      payload.enableAccrualActivityPosting = form.enableAccrualActivityPosting;
       if (form.enableInterestSuspenseAccounting) payload.enableInterestSuspenseAccounting = true;
       if (form.interestSuspenseAccountId !== "") payload.interestSuspenseAccountId = form.interestSuspenseAccountId;
     }


### PR DESCRIPTION
## What changed
- Added `enableAccrualActivityPosting` to the shared loan product form model and Fineract payload builder.
- Added an accrual activity posting toggle to the loan product accounting step for accrual-based products in create and edit flows.
- Added product edit hydration and product detail display for the setting so the value is visible and round-trips correctly.

## Why
Loan Matrix exposed accrual-based accounting rules but omitted the separate Accrual Activity Posting setting that Fineract supports. That made it impossible to enable or verify the setting in Loan Matrix even though upstream Mifos UI supports it.

## Impact
- Users can now enable the setting when creating or editing accrual-based loan products.
- Users can now confirm the setting from the product view page.
- Existing Fineract products with the field already set now load correctly in edit mode.

## Validation
- `npm exec eslint -- app/(application)/products/loan-products/components/step-accounting.tsx app/(application)/products/loan-products/components/loan-product-stepper.tsx app/(application)/products/loan-products/[id]/edit/page.tsx app/(application)/products/loan-products/[id]/page.tsx shared/types/loan-product.ts`
- `npm exec tsc --noEmit` currently fails due to many pre-existing unrelated repo-wide TypeScript errors.
