### PR TITLE
fix: source ussd disbursement callback from env

### DIFF
--- a/app/api/fineract/loans/[id]/disburse/route.ts
+++ b/app/api/fineract/loans/[id]/disburse/route.ts
@@ -8,6 +8,7 @@ import {
   getLeadViewerAccessContext,
 } from '@/lib/lead-policy';
 import { applyTopupDisbursementCharges } from '@/lib/topup-disbursement-charge-service';
+import { getRequiredPaymentServiceCallbackUrl } from '@/lib/payment-service-callback-url';
 import { extractTenantSlugFromRequest, getTenantBySlug } from '@/lib/tenant-service';
 import { resolveYangoUssdDisbursementDetailsForLead } from '@/lib/yango-ussd-disbursement';
 
@@ -117,11 +118,6 @@ export async function POST(
       }
     }
 
-    // Build callback URL to be used by payment gateway
-    //const callbackUrl = `https://webhook.site/45f26e26-5c80-4290-9a1a-87b60be151a4`;
-    // Use specific callback URL for payment gateway
-    const callbackUrl = `http://loan-matrix-dev.loan-matrix-dev.svc.cluster.local:3000/api/ussd-leads/payment-callback`;
-
     const augmentedPayload: Record<string, unknown> = {
       ...payload,
     };
@@ -176,7 +172,7 @@ export async function POST(
           coercePositiveNumber(fineractLoan?.approvedPrincipal) ??
           coercePositiveNumber(fineractLoan?.principal);
       }
-      augmentedPayload.note = payload?.note || callbackUrl;
+      augmentedPayload.note = getRequiredPaymentServiceCallbackUrl();
     }
 
     // Log the payload being sent to Fineract

--- a/env.example
+++ b/env.example
@@ -15,6 +15,8 @@ FINERACT_REPORT_TIMEOUT_MS=300000
 
 # Payment Service Configuration
 PAYMENT_SERVICE_BASE_URL=http://localhost:8080
+# Legacy fallback: CDE_DISBURSEMENT_CALLBACK_URL is also supported.
+PAYMENT_SERVICE_CALLBACK_URL=http://localhost:8090/api/v1/repayment/txn-repaymentcallback
 
 # AMQP Queue Configuration for USSD Leads
 AMQP_HOST=10.10.0.24

--- a/lib/__tests__/payment-service-callback-url.test.ts
+++ b/lib/__tests__/payment-service-callback-url.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getRequiredPaymentServiceCallbackUrl,
+  resolvePaymentServiceCallbackUrl,
+} from "../payment-service-callback-url";
+
+function withCallbackEnv(
+  env: {
+    PAYMENT_SERVICE_CALLBACK_URL?: string | undefined;
+    CDE_DISBURSEMENT_CALLBACK_URL?: string | undefined;
+  },
+  run: () => void
+) {
+  const previousPaymentServiceCallbackUrl =
+    process.env.PAYMENT_SERVICE_CALLBACK_URL;
+  const previousCdeDisbursementCallbackUrl =
+    process.env.CDE_DISBURSEMENT_CALLBACK_URL;
+
+  if (env.PAYMENT_SERVICE_CALLBACK_URL === undefined) {
+    delete process.env.PAYMENT_SERVICE_CALLBACK_URL;
+  } else {
+    process.env.PAYMENT_SERVICE_CALLBACK_URL =
+      env.PAYMENT_SERVICE_CALLBACK_URL;
+  }
+
+  if (env.CDE_DISBURSEMENT_CALLBACK_URL === undefined) {
+    delete process.env.CDE_DISBURSEMENT_CALLBACK_URL;
+  } else {
+    process.env.CDE_DISBURSEMENT_CALLBACK_URL =
+      env.CDE_DISBURSEMENT_CALLBACK_URL;
+  }
+
+  try {
+    run();
+  } finally {
+    if (previousPaymentServiceCallbackUrl === undefined) {
+      delete process.env.PAYMENT_SERVICE_CALLBACK_URL;
+    } else {
+      process.env.PAYMENT_SERVICE_CALLBACK_URL =
+        previousPaymentServiceCallbackUrl;
+    }
+
+    if (previousCdeDisbursementCallbackUrl === undefined) {
+      delete process.env.CDE_DISBURSEMENT_CALLBACK_URL;
+    } else {
+      process.env.CDE_DISBURSEMENT_CALLBACK_URL =
+        previousCdeDisbursementCallbackUrl;
+    }
+  }
+}
+
+test("resolvePaymentServiceCallbackUrl prefers PAYMENT_SERVICE_CALLBACK_URL", () => {
+  withCallbackEnv(
+    {
+      PAYMENT_SERVICE_CALLBACK_URL: "  https://callback.example/primary  ",
+      CDE_DISBURSEMENT_CALLBACK_URL: "https://callback.example/fallback",
+    },
+    () => {
+      assert.equal(
+        resolvePaymentServiceCallbackUrl(),
+        "https://callback.example/primary"
+      );
+    }
+  );
+});
+
+test("resolvePaymentServiceCallbackUrl falls back to CDE_DISBURSEMENT_CALLBACK_URL", () => {
+  withCallbackEnv(
+    {
+      PAYMENT_SERVICE_CALLBACK_URL: undefined,
+      CDE_DISBURSEMENT_CALLBACK_URL: "  https://callback.example/fallback  ",
+    },
+    () => {
+      assert.equal(
+        resolvePaymentServiceCallbackUrl(),
+        "https://callback.example/fallback"
+      );
+    }
+  );
+});
+
+test("getRequiredPaymentServiceCallbackUrl throws when callback env vars are missing", () => {
+  withCallbackEnv(
+    {
+      PAYMENT_SERVICE_CALLBACK_URL: undefined,
+      CDE_DISBURSEMENT_CALLBACK_URL: undefined,
+    },
+    () => {
+      assert.throws(() => getRequiredPaymentServiceCallbackUrl(), {
+        message:
+          "PAYMENT_SERVICE_CALLBACK_URL or CDE_DISBURSEMENT_CALLBACK_URL is required for Yango USSD disbursements",
+      });
+    }
+  );
+});

--- a/lib/__tests__/yango-ussd-disbursement.test.ts
+++ b/lib/__tests__/yango-ussd-disbursement.test.ts
@@ -80,3 +80,28 @@ test("Fineract disbursement paths include Yango external id payload support", ()
   assert.match(disburseRoute, /augmentedPayload\.accountNumber\s*=\s*yangoUssdDetails\.accountNumber/);
   assert.match(disburseRoute, /augmentedPayload\.transactionAmount/);
 });
+
+test(
+  "Yango disbursement route uses env callback URL and auto-progress keeps payout note separate",
+  () => {
+    const stateMachine = readRepoFile("lib/team-state-machine-service.ts");
+    const disburseRoute = readRepoFile(
+      "app/api/fineract/loans/[id]/disburse/route.ts"
+    );
+
+    assert.match(disburseRoute, /getRequiredPaymentServiceCallbackUrl/);
+    assert.doesNotMatch(disburseRoute, /payload\?\.note\s*\|\|/);
+    assert.doesNotMatch(
+      stateMachine,
+      /fineractOverrides:\s*isDisbursementHop\s*\?\s*{\s*\.\.\.paymentResolution\.fineractOverrides,\s*note:\s*`Auto-progressed after CDE \$\{cdeResult\.decision\}`/s
+    );
+    assert.match(
+      stateMachine,
+      /fineractOverrides:\s*isDisbursementHop\s*\?\s*{\s*\.\.\.paymentResolution\.fineractOverrides,\s*payoutNote:\s*`Auto-progressed after CDE \$\{cdeResult\.decision\}`/s
+    );
+    assert.match(
+      stateMachine,
+      /note:\s*yangoUssdDetails\s*\?\s*getRequiredPaymentServiceCallbackUrl\(\)\s*:\s*overrides\?\.note/
+    );
+  }
+);

--- a/lib/payment-service-callback-url.ts
+++ b/lib/payment-service-callback-url.ts
@@ -1,0 +1,21 @@
+const CALLBACK_ENV_ERROR =
+  "PAYMENT_SERVICE_CALLBACK_URL or CDE_DISBURSEMENT_CALLBACK_URL is required for Yango USSD disbursements";
+
+export function resolvePaymentServiceCallbackUrl(): string | null {
+  const callbackUrl =
+    process.env.PAYMENT_SERVICE_CALLBACK_URL?.trim() ||
+    process.env.CDE_DISBURSEMENT_CALLBACK_URL?.trim() ||
+    "";
+
+  return callbackUrl || null;
+}
+
+export function getRequiredPaymentServiceCallbackUrl(): string {
+  const callbackUrl = resolvePaymentServiceCallbackUrl();
+
+  if (!callbackUrl) {
+    throw new Error(CALLBACK_ENV_ERROR);
+  }
+
+  return callbackUrl;
+}

--- a/lib/team-state-machine-service.ts
+++ b/lib/team-state-machine-service.ts
@@ -40,6 +40,7 @@ import {
   isAutoDisbursementDecisionAllowed,
   resolveAutoProgressTriggeredBy,
 } from "./lead-auto-disbursement-policy";
+import { getRequiredPaymentServiceCallbackUrl } from "./payment-service-callback-url";
 import { getTenantAutoDisbursementRules } from "./tenant-auto-disbursement-rules";
 import { resolvePaymentTypeForPreferredMethod } from "./payment-method-resolution";
 import { resolveYangoUssdDisbursementDetailsForLead } from "./yango-ussd-disbursement";
@@ -657,7 +658,6 @@ export class TeamAwareStateMachineService {
         fineractOverrides: isDisbursementHop
           ? {
               ...paymentResolution.fineractOverrides,
-              note: `Auto-progressed after CDE ${cdeResult.decision}`,
               payoutNote: `Auto-progressed after CDE ${cdeResult.decision}`,
             }
           : {
@@ -1738,7 +1738,9 @@ export class TeamAwareStateMachineService {
           bankNumber: overrides?.bankNumber,
           externalId: yangoUssdDetails?.externalId ?? overrides?.externalId,
           transactionAmount: yangoUssdDetails ? transactionAmount : overrides?.transactionAmount,
-          note: overrides?.note,
+          note: yangoUssdDetails
+            ? getRequiredPaymentServiceCallbackUrl()
+            : overrides?.note,
         });
 
         // Non-blocking: disbursement succeeds even when charge application fails.


### PR DESCRIPTION
## Summary
- source the Yango/USSD payment-service callback target from env-backed Loan Matrix config instead of a hardcoded or overwritten note
- preserve the auto-progress audit message in `payoutNote` while forcing the payment callback URL into the disbursement `note` for both route and direct state-machine disbursements
- add focused regression coverage for callback URL resolution and Yango disbursement wiring

## Root Cause
The payment service still reads the callback target from `request.note`, but Loan Matrix was overwriting that field with `Auto-progressed after CDE ...` on the disbursement hop. That caused successful GeePay callbacks to stop at payment service without reaching CDE for the disbursement SMS path.

## Verification
- `node --import tsx lib/__tests__/payment-service-callback-url.test.ts`
- `node --import tsx lib/__tests__/yango-ussd-disbursement.test.ts`
- `git diff --check`