### PR TITLE
fix: make USSD disbursement payment callback tenant-aware

### DIFF
--- a/app/api/fineract/loans/[id]/disburse/route.ts
+++ b/app/api/fineract/loans/[id]/disburse/route.ts
@@ -7,8 +7,11 @@ import {
   getDisbursementBlockReason,
   getLeadViewerAccessContext,
 } from '@/lib/lead-policy';
+import {
+  buildPaymentServiceCallbackUrl,
+  getRequiredPaymentServiceCallbackUrl,
+} from '@/lib/payment-service-callback-url';
 import { applyTopupDisbursementCharges } from '@/lib/topup-disbursement-charge-service';
-import { getRequiredPaymentServiceCallbackUrl } from '@/lib/payment-service-callback-url';
 import { extractTenantSlugFromRequest, getTenantBySlug } from '@/lib/tenant-service';
 import { resolveYangoUssdDisbursementDetailsForLead } from '@/lib/yango-ussd-disbursement';
 
@@ -118,6 +121,10 @@ export async function POST(
       }
     }
 
+    const callbackUrl = buildPaymentServiceCallbackUrl(
+      getRequiredPaymentServiceCallbackUrl(),
+      tenant?.ussdServiceTenantId
+    );
     const augmentedPayload: Record<string, unknown> = {
       ...payload,
     };
@@ -172,7 +179,7 @@ export async function POST(
           coercePositiveNumber(fineractLoan?.approvedPrincipal) ??
           coercePositiveNumber(fineractLoan?.principal);
       }
-      augmentedPayload.note = getRequiredPaymentServiceCallbackUrl();
+      augmentedPayload.note = callbackUrl;
     }
 
     // Log the payload being sent to Fineract

--- a/app/api/fineract/loans/[id]/disburse/route.ts
+++ b/app/api/fineract/loans/[id]/disburse/route.ts
@@ -121,10 +121,6 @@ export async function POST(
       }
     }
 
-    const callbackUrl = buildPaymentServiceCallbackUrl(
-      getRequiredPaymentServiceCallbackUrl(),
-      tenant?.ussdServiceTenantId
-    );
     const augmentedPayload: Record<string, unknown> = {
       ...payload,
     };
@@ -165,6 +161,10 @@ export async function POST(
         : null;
 
     if (yangoUssdDetails) {
+      const callbackUrl = buildPaymentServiceCallbackUrl(
+        getRequiredPaymentServiceCallbackUrl(),
+        tenant?.ussdServiceTenantId
+      );
       augmentedPayload.externalId = yangoUssdDetails.externalId;
       augmentedPayload.accountNumber = yangoUssdDetails.accountNumber;
       if (yangoUssdDetails.paymentTypeId) {

--- a/lib/__tests__/payment-service-callback-url.test.ts
+++ b/lib/__tests__/payment-service-callback-url.test.ts
@@ -136,3 +136,21 @@ test("loan disbursement route uses the tenant-aware payment service callback hel
   assert.match(routeSource, /getRequiredPaymentServiceCallbackUrl/);
   assert.match(routeSource, /tenant\?\.ussdServiceTenantId/);
 });
+
+test("loan disbursement route resolves callback env only inside the Yango USSD branch", () => {
+  const routeSource = readRepoFile(
+    "app/api/fineract/loans/[id]/disburse/route.ts"
+  );
+
+  const yangoBranchIndex = routeSource.indexOf("if (yangoUssdDetails) {");
+  const callbackEnvIndex = routeSource.indexOf(
+    "getRequiredPaymentServiceCallbackUrl()"
+  );
+
+  assert.notEqual(yangoBranchIndex, -1);
+  assert.notEqual(callbackEnvIndex, -1);
+  assert.ok(
+    callbackEnvIndex > yangoBranchIndex,
+    "expected callback env lookup to happen inside the Yango USSD block"
+  );
+});

--- a/lib/__tests__/payment-service-callback-url.test.ts
+++ b/lib/__tests__/payment-service-callback-url.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
+  buildPaymentServiceCallbackUrl,
   getRequiredPaymentServiceCallbackUrl,
   resolvePaymentServiceCallbackUrl,
 } from "../payment-service-callback-url";
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), "utf8");
+}
 
 function withCallbackEnv(
   env: {
@@ -94,4 +101,38 @@ test("getRequiredPaymentServiceCallbackUrl throws when callback env vars are mis
       });
     }
   );
+});
+
+test("buildPaymentServiceCallbackUrl appends tenantCode when tenant is present", () => {
+  const callbackUrl = buildPaymentServiceCallbackUrl(
+    "http://cde-prod.cde-prod.svc.cluster.local:80/api/v1/repayment/txn-repaymentcallback",
+    " goodfellow "
+  );
+
+  assert.equal(
+    new URL(callbackUrl).href,
+    new URL(
+      "http://cde-prod.cde-prod.svc.cluster.local:80/api/v1/repayment/txn-repaymentcallback?tenantCode=goodfellow"
+    ).href
+  );
+});
+
+test("buildPaymentServiceCallbackUrl leaves base URL unchanged when tenant is missing", () => {
+  assert.equal(
+    buildPaymentServiceCallbackUrl(
+      "http://cde-prod.cde-prod.svc.cluster.local:80/api/v1/repayment/txn-repaymentcallback",
+      null
+    ),
+    "http://cde-prod.cde-prod.svc.cluster.local:80/api/v1/repayment/txn-repaymentcallback"
+  );
+});
+
+test("loan disbursement route uses the tenant-aware payment service callback helper", () => {
+  const routeSource = readRepoFile(
+    "app/api/fineract/loans/[id]/disburse/route.ts"
+  );
+
+  assert.match(routeSource, /buildPaymentServiceCallbackUrl/);
+  assert.match(routeSource, /getRequiredPaymentServiceCallbackUrl/);
+  assert.match(routeSource, /tenant\?\.ussdServiceTenantId/);
 });

--- a/lib/payment-service-callback-url.ts
+++ b/lib/payment-service-callback-url.ts
@@ -19,3 +19,23 @@ export function getRequiredPaymentServiceCallbackUrl(): string {
 
   return callbackUrl;
 }
+
+export function buildPaymentServiceCallbackUrl(
+  baseCallbackUrl: string,
+  ussdServiceTenantId?: string | null
+): string {
+  const normalizedBaseUrl = baseCallbackUrl.trim();
+  const tenantCode = ussdServiceTenantId?.trim();
+
+  if (!tenantCode) {
+    return normalizedBaseUrl;
+  }
+
+  try {
+    const callbackUrl = new URL(normalizedBaseUrl);
+    callbackUrl.searchParams.set("tenantCode", tenantCode);
+    return callbackUrl.toString();
+  } catch {
+    return normalizedBaseUrl;
+  }
+}


### PR DESCRIPTION
## Summary
- read the payment callback base URL from `PAYMENT_SERVICE_CALLBACK_URL` with the existing Loan Matrix callback as fallback
- append `tenantCode` from `Tenant.ussdServiceTenantId` when the current tenant has one configured
- add a focused regression test for callback URL composition and route wiring

## Verification
- `node --import tsx lib/__tests__/payment-service-callback-url.test.ts`
- `node --import tsx lib/__tests__/yango-ussd-disbursement.test.ts`
- `'/home/parten/Documents/kenac dev/Loan Matrix/loan-matrix/node_modules/.bin/tsc' --noEmit` *(fails on pre-existing repo-wide TypeScript errors outside this patch)*
